### PR TITLE
new spec for the document overlay

### DIFF
--- a/src/components/Document/style.css
+++ b/src/components/Document/style.css
@@ -15,12 +15,15 @@
   @height-frame: 480;
 
   //Spec of overlay
-  @width-per: 80%;
+  @width-percent: 80%;
   @aspect-ratio: 1.57;
 
-  // @aspect-ratio = (@width-frame * @width-per) / (@height-frame * @height-per)
-  @height-per: (@width-frame * @width-per) / (@height-frame * @aspect-ratio);
+  /*
+    From the equation below one can find out @height-percent
+    aspect-ratio = (width-frame * width-percent) / (height-frame * height-percent)
+   */
+  @height-percent: (@width-frame * @width-percent) / (@height-frame * @aspect-ratio);
 
-  width: @width-per;
-  height: @height-per;
+  width: @width-percent;
+  height: @height-percent;
 }

--- a/src/components/Document/style.css
+++ b/src/components/Document/style.css
@@ -10,6 +10,17 @@
 }
 
 .rectangle {
-  width: 67%;
-  padding-bottom: 47%;//this is relative to the element's width, making the rectangle scale
+  //default value of react-webcam https://github.com/cezary/react-webcam
+  @width-frame: 640;
+  @height-frame: 480;
+
+  //Spec of overlay
+  @width-per: 80%;
+  @aspect-ratio: 1.57;
+
+  // @aspect-ratio = (@width-frame * @width-per) / (@height-frame * @height-per)
+  @height-per: (@width-frame * @width-per) / (@height-frame * @aspect-ratio);
+
+  width: @width-per;
+  height: @height-per;
 }


### PR DESCRIPTION
Fix for CX-184.

The size and shape of the overlay is incorrect.

- Aspect ratio should be 1.57
- Width should be ~80% (to be investigated) of camera image width