### PR TITLE
Improvement: refactor modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Breaking changes result in a different major. UI changes that might break custom
 ### Changed
 - Public: Captures are now returned as `png` instead of `webp`, `webp` is still used internally for streaming to the server.
 - Public: the captures returned by `Onfido.getCaptures()` have a simplified signature of just `{id,image,documentType}`.
+- Public: It's now possible to open and close the modal by calling `.setOptions({isModalOpen:boolean})`
+- Internal: The modal has been refactored to be fully reactive, `vanilla-modal` has been replaced with a fork of `react-modal`.
 - Internal: Updated to `onfido-sdk-core@0.6.0`, selectors are now more general as in they are no longer specific to each capture type, some new selectors are also being used.
 - Internal: `Camera`, `Capture` and `Uploader` have been refactored, the pure part of the components have been separated from the "impure"/state logic part. This adds flexibility and encapsulation.
 - Internal: The `Capture` component now orchestrates all the state logic of the `Uploader` component, this allows to join the camera and uploader state logic together.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Onfido.init({
   token: 'your-jwt-token',
   // id of the button that will trigger the modal opening
   buttonId: 'onfido-button',
+  // Modal open state
+  isModalOpen: false
   // id of the element you want to mount the component on
   containerId: 'onfido-mount',
   // here are various callbacks that fire during the capture process
@@ -150,9 +152,10 @@ onfidoOut.setOptions({
 });
 ...
 //replace the jwt token
-onfidoOut.setOptions({
-  token:"new token"
-});
+onfidoOut.setOptions({ token:"new token" });
+...
+//Open the modal
+onfidoOut.setOptions({ isModalOpen:true });
 ```
 
 The new options will be shallowly merged with the previous one. So one can pass only the differences to a get a new flow.
@@ -168,6 +171,11 @@ A breakdown of the options and methods available to the SDK.
 - **`buttonId {String} optional`**
 
   A string of the ID of the button that when clicked, will open the verification modal. This defaults to `onfido-button`. We recommend adding a `disabled` attribute to this element so that the modal cannot be activated until `onReady` has fired.
+
+- **`isModalOpen {Boolean} optional`**
+
+  It's possible to set the state of modal in code too, without using the button defined in `buttonId`.
+  To change the state of the modal after calling `init()` you need to later use `setOptions()`.
 
 - **`containerId {String} optional`**
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "babel-preset-es2015-minimal": "^2.1.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.7.2",
-    "babel-runtime": "^6.6.1",
+    "babel-runtime": "^6.11.6",
     "chai": "^3.5.0",
     "core-js": "^2.2.1",
     "cross-env": "^3.0.0",
@@ -80,7 +80,6 @@
     "postcss-custom-media": "^5.0.1",
     "postcss-loader": "^0.13.0",
     "postcss-url": "^5.1.2",
-    "preact-compat": "^3.4.2",
     "raw-loader": "^0.5.1",
     "rimraf": "^2.5.4",
     "sinon": "^1.17.3",
@@ -101,16 +100,17 @@
     "lodash": "^4.13.1",
     "object-assign": "^4.1.0",
     "onfido-sdk-core": "^0.6.0",
+    "parse-unit": "^1.0.1",
     "preact": "^6.0.2",
     "preact-compat": "^3.4.2",
     "preact-router": "^2.0.0",
     "react": "^15.0.2",
     "react-dom": "^15.1.0",
     "react-dropzone": "^3.4.0",
+    "react-modal-onfido": "^1.5.2",
     "react-native-listener": "^1.0.1",
     "react-redux": "^4.4.5",
     "react-webcam": "0.0.14",
-    "redux": "^3.5.2",
-    "vanilla-modal": "^1.3.0"
+    "redux": "^3.5.2"
   }
 }

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -7,38 +7,22 @@ import {
   unboundActions,
   store,
   events,
-  selectors,
-  connect as ws
+  selectors
 } from 'onfido-sdk-core'
 import {stepsToComponents} from './StepComponentMap'
 import Error from '../Error'
 
-class App extends Component {
-
-  componentWillMount () {
-    const { token } = this.props.options
-    this.socket = ws(token)
-  }
-
-  componentWillReceiveProps (nextProps) {
-    const nextToken = nextProps.options.token
-    if (this.props.options.token !== nextToken){
-      this.socket = ws(nextToken)
-    }
-  }
-
-  render () {
-    const { websocketErrorEncountered, options } = this.props
-    const stepIndex = this.props.step || 0;
+const App = ({ websocketErrorEncountered, step, options, socket, ...otherProps }) => {
+    const stepIndex = step || 0;
 
     const stepDefaultOptions = {
       prevLink: `/step/${(parseInt(stepIndex, 10) - 1 || 1)}/`,
       nextLink: `/step/${(parseInt(stepIndex, 10) + 1 || 1)}/`,
-      socket: this.socket,
-      ...this.props
+      socket,
+      step,
+      ...otherProps
     }
     const stepsToComponentsWithDefaultOptions = steps => stepsToComponents(stepDefaultOptions, steps)
-
     const defaultSteps = ['welcome','document','face','complete']
     const stepComponents = stepsToComponentsWithDefaultOptions(options.steps || defaultSteps)
 
@@ -48,8 +32,6 @@ class App extends Component {
         {stepComponents[stepIndex] || <div>Error: Step Missing</div>}
       </div>
     )
-  }
-
 }
 
 const {

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -4,41 +4,37 @@ import theme from '../Theme/style.css'
 import style from './style.css'
 import {functionalSwitch, impurify} from '../utils'
 
-const Capture = ({ image }) => (
+const Capture = ({ image }) =>
   <div className={style.captures}>
     <img src={image} className={style.image} />
   </div>
-)
 
-const Previews = ({capture, step, retakeAction, confirmAction} ) =>  {
-  const nextLink = `/step/${(parseInt(step, 10) + 1 || 1)}/`
 
-  return (
-    <div className={`${theme.previews} ${theme.step}`}>
-      <h1 className={theme.title}>Confirm capture</h1>
-      <p>Please confirm that you are happy with this photo.</p>
-      <Capture image={capture.image} />
-      <div className={`${theme.actions} ${style.actions}`}>
-        <button
-          onClick={retakeAction}
-          className={`${theme.btn} ${style["btn-outline"]}`}
-        >
-          Take again
-        </button>
-        <a
-          href={nextLink}
-          className={`${theme.btn} ${theme["btn-primary"]}`}
-          onClick={confirmAction}
-        >
-          Confirm
-        </a>
-      </div>
+const Previews = ({capture, nextLink, retakeAction, confirmAction} ) =>
+  <div className={`${theme.previews} ${theme.step}`}>
+    <h1 className={theme.title}>Confirm capture</h1>
+    <p>Please confirm that you are happy with this photo.</p>
+    <Capture image={capture.image} />
+    <div className={`${theme.actions} ${style.actions}`}>
+      <button
+        onClick={retakeAction}
+        className={`${theme.btn} ${style["btn-outline"]}`}
+      >
+        Take again
+      </button>
+      <a
+        href={nextLink}
+        className={`${theme.btn} ${theme["btn-primary"]}`}
+        onClick={confirmAction}
+      >
+        Confirm
+      </a>
     </div>
-  )
-}
+  </div>
+
 
 const Confirm = ({
-      step,
+      nextLink,
       method,
       validCaptures,
       actions: {
@@ -53,7 +49,7 @@ const Confirm = ({
     capture={capture}
     retakeAction={() => deleteCaptures({method})}
     confirmAction={() => confirmCapture({method, id: capture.id})}
-    step={step}
+    nextLink={nextLink}
   />
 }
 

--- a/src/components/Error/index.js
+++ b/src/components/Error/index.js
@@ -5,7 +5,7 @@ import style from './style.css'
 const Error = ({visible}) => {
   return (
     <div
-      className={style.base + (visible ? '' : ' '+style.hidden)}
+      className={style.base + ' ' + (visible ? '' : style.hidden)}
     >
       <div>
         <p>There was an error connecting to the server</p>

--- a/src/components/Modal/style.css
+++ b/src/components/Modal/style.css
@@ -1,37 +1,33 @@
 @import (less) "../Theme/constants.css";
 
-.inline {
-  font-size: .875rem;
-  font-family: "Gotham SSm A", "Gotham SSm B", sans-serif;
-  line-height: 1.5;
-  font-weight: 300;
-
-  @media (--small-viewport) {
-    height: 100%;
-  }
+.portal > * {
+  // When the modal is closed, overlay div has no css class
+  // This selector should be overridden by the `&--after-open` class below
+  opacity: 0;
 }
 
-.modal {
+.modalBody {
+  /*! Just a placeholder no namespace this element using css modules*/
+}
+
+@value modal_animation_duration: 200ms;
+
+.overlay {
   display: flex;
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
+
   background: rgba(0, 0, 0, 0.6);
-  z-index: -1;
-  opacity: 0;
-  transition: opacity 0.2s, z-index 0s 0.2s;
+  transition: opacity modal_animation_duration, z-index 0s modal_animation_duration;
 
-  @media (--small-viewport) {
-    padding-top: 3vw;
-    padding-bottom: 3vw;
-  }
-
-  .vanillaModal.modalVisible & {
-    z-index: 99;
+  &--after-open {
     opacity: 1;
-    transition: opacity 0.2s;
+  }
+  &--before-close {
+    opacity: 0;
   }
 }
 
@@ -49,6 +45,11 @@
   background: #f3f3f3 url('./assets/powered-by-onfido.svg') 50% ~"calc(100% - 20px)" no-repeat;
   border-radius: 3px;
 
+  font-size: .875rem;
+  font-family: "Gotham SSm A", "Gotham SSm B", sans-serif;
+  line-height: 1.5;
+  font-weight: 300;
+
   @media (--small-viewport) {
     width: 100%;
     height: 100%;
@@ -58,19 +59,19 @@
     box-sizing: border-box;
   }
 
-  .modal & {
+  .portal & {
     margin: auto;
     z-index: -1;
     opacity: 0;
     transform: scale(0);
-    transition: opacity 0.2s, transform 0.2s, z-index 0s 0.2s;
+    transition: opacity modal_animation_duration, transform modal_animation_duration, z-index 0s modal_animation_duration;
   }
 
-  .modalVisible .modal & {
+  .overlay--after-open & {
     z-index: 100;
     opacity: 1;
     transform: scale(1);
-    transition: opacity 0.2s, transform 0.2s;
+    transition: opacity modal_animation_duration, transform modal_animation_duration;
   }
 }
 

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -1,6 +1,21 @@
+import parseUnit from 'parse-unit'
 import { h, Component } from 'preact'
 
 export const functionalSwitch = (key, hash) => (hash[key] || (_=>null))()
+
+
+export const getCSSValue = (expectedUnit, cssUnit) => {
+  const [value, resUnit] = parseUnit(cssUnit)
+  if (resUnit !== expectedUnit) {
+    console.warn(`The css @value: ${cssUnit} unit is ${resUnit} but it should be ${expectedUnit}`)
+  }
+  return value
+}
+export const getCSSMilisecsValue = cssUnit => getCSSValue("ms", cssUnit)
+
+
+export const wrapWithClass = (className, children) =>
+  <div className={className}>{children}</div>
 
 export const impurify = pureComponent => {
   const impureComponent = class extends Component {

--- a/src/index.html
+++ b/src/index.html
@@ -32,7 +32,7 @@
     </style>
   </head>
   <body>
-    <div id='onfido-mount' style='display: none'></div>
+    <div id='onfido-mount'></div>
     <button id='onfido-button' disabled>Verify identity</button>
     <script type="text/javascript">
       var options = window.location.search.slice(1)

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -77,7 +77,8 @@ const configDist = {
       components: `${__dirname}/src/components`,    // used for tests
       style: `${__dirname}/src/style`,
       'react': 'preact-compat',
-      'react-dom': 'preact-compat'
+      'react-dom': 'preact-compat',
+      'react-modal': 'react-modal-onfido'
     }
   },
 


### PR DESCRIPTION
1. The `vanilla-modal` has been replaced with `react-modal-onfido`, https://github.com/rfreitas/react-modal
2. Modal is now fully reactive (see issue #50)
4. Modal can now be opened programatically by calling `returnedOnfidoInitValue.setOptions({isModalOpen: boolean})`

For comparison here is a PR that uses the vanilla modal: https://github.com/onfido/onfido-sdk-ui/pull/68