### PR TITLE
Improvement/provide png captures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ Breaking changes result in a different major. UI changes that might break custom
 ### Added
 - Internal: The document capture step now has a strategy to cope with slow responses from the server when requesting to validate documents. If the number of unprocessed documents is 3+, it stops sending more until a response is given.
 - Public: The capture screen UI now includes an upload button fallback, for whenever the user is experiencing problems with the webcam.
+- Internal: `webp` falls back to `jpeg` in case the browser does not support it.
 
 ### Changed
+- Public: Captures are now returned as `png` instead of `webp`, `webp` is still used internally for streaming to the server.
+- Public: the captures returned by `Onfido.getCaptures()` have a simplified signature of just `{id,image,documentType}`.
 - Internal: Updated to `onfido-sdk-core@0.6.0`, selectors are now more general as in they are no longer specific to each capture type, some new selectors are also being used.
 - Internal: `Camera`, `Capture` and `Uploader` have been refactored, the pure part of the components have been separated from the "impure"/state logic part. This adds flexibility and encapsulation.
 - Internal: The `Capture` component now orchestrates all the state logic of the `Uploader` component, this allows to join the camera and uploader state logic together.

--- a/README.md
+++ b/README.md
@@ -229,15 +229,17 @@ You should get something returned back that looks like this:
 ```js
 {
   documentCapture: {
+    //local id of the capture
+    //useful only if you want to track and reference captures which have been taken
     id: "mwxm5loxdu63zlkawcdi",
-    image: "data:image/webp;base64,9frG47Tzp/h/+bzsf/dd…",
-    messageType: "document",
+    //base 64 encoded png image
+    image: "data:image/png;base64,9frG47Tzp/h/+bzsf/dd…",
+    //the result of the document selection step
     documentType: "passport"
   },
   faceCapture: {
     id: "yy5j8hxlxukufjbrzfr",
-    image: "data:image/webp;base64,UklGRrZcAQBXRUJQVlA4…",
-    messageType: "face"
+    image: "data:image/png;base64,UklGRrZcAQBXRUJQVlA4…",
   }
 }
 ```
@@ -301,7 +303,7 @@ The payload keys are case sensitive and should all be lowercase.
 - `uuid {String} required`
 
   A unique ID that identifies your API token in our database. This can be shared publicly and is **not** the same as your API Token. We will provide you with your uuid on request.
-  
+
 - `ref {String} required`
 
   The HTTP referrer of the page where the SDK is initialised. See the API [documentation](https://onfido.com/documentation#json-web-tokens) for allowed formats.

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -8,7 +8,7 @@ import Dropzone from 'react-dropzone'
 
 import { DocumentNotFound, DocumentOverlay, DocumentInstructions } from '../Document'
 import { FaceOverlay, FaceInstructions } from '../Face'
-import { Uploader } from '../Uploader'
+import { Uploader, canvasToBase64Images } from '../Uploader'
 import Countdown from '../Countdown'
 import {functionalSwitch} from '../utils'
 
@@ -98,8 +98,7 @@ export default class Camera extends Component {
 
   screenshot = () => {
     const { onScreenshot } = this.props
-    const image = this.webcam.getScreenshot()
-    onScreenshot(image)
+    canvasToBase64Images(this.webcam.getCanvas(), onScreenshot)
   }
 
   render = ({method, onUserMedia, onUploadFallback}) => (

--- a/src/components/Capture/index.js
+++ b/src/components/Capture/index.js
@@ -79,23 +79,25 @@ export default class Capture extends Component {
     this.validateCapture(message.id, valid)
   }
 
-  handleImage = (base64Image) => {
-    if (!base64Image) {
+  handleImage = (base64ImageLossy, base64ImagePng) => {
+    if (!base64ImageLossy) {
       console.warn('Cannot handle a null image')
       return;
     }
-    const payload = this.createPayload(base64Image)
+    const payload = this.createPayload(base64ImagePng, base64ImageLossy)
     functionalSwitch(this.props.method, {
       document: ()=> this.handleDocument(payload),
       face: ()=> this.handleFace(payload)
     })
   }
 
-  createPayload = (imageDataBase64) => ({
+  createPayload = (image, imageLossy) => ({
     id: randomId(),
     messageType: this.method,
-    image: imageDataBase64
+    image, imageLossy
   })
+
+  createSocketPayload = ({id,messageType,imageLossy,documentType}) => JSON.stringify({id,messageType,image: imageLossy,documentType})
 
   handleDocument(payload) {
     const { socket, method, documentType, unprocessedCaptures } = this.props
@@ -106,7 +108,7 @@ export default class Capture extends Component {
     }
 
     payload = {...payload, documentType}
-    socket.sendMessage(JSON.stringify(payload))
+    socket.sendMessage(this.createSocketPayload(payload))
     this.createCapture(payload)
   }
 

--- a/src/components/Confirm/style.css
+++ b/src/components/Confirm/style.css
@@ -3,7 +3,7 @@
 }
 
 .image {
-  max-width: 80%;
+  max-width: 92%;
   display: block;
   margin: 0 auto;
 }

--- a/src/components/Uploader/index.js
+++ b/src/components/Uploader/index.js
@@ -8,6 +8,23 @@ import theme from '../Theme/style.css'
 import style from './style.css'
 import {functionalSwitch, impurify} from '../utils'
 
+//ref: http://stackoverflow.com/a/27232658/689223
+const isWebP = (base64) => base64.indexOf('data:image/webp') === 0
+
+export const canvasToBase64Images = (canvas, callback) => {
+  let imageLossy = canvas.toDataURL('image/webp')
+  let imagePng
+  //not all browsers support webp
+  if (isWebP(imageLossy)){
+    imagePng = canvas.toDataURL()
+  } else {
+    imagePng = imageLossy//if webp is not supported it defaults to png
+    imageLossy = canvas.toDataURL("image/jpeg")
+  }
+
+  callback(imageLossy, imagePng)
+}
+
 export const fileToBase64 = (file, callback) => {
   const options = {
     maxWidth: 960,
@@ -16,8 +33,7 @@ export const fileToBase64 = (file, callback) => {
   }
 
   loadImage(file.preview, (canvas) => {
-    const image = canvas.toDataURL('image/webp')
-    callback(image)
+    canvasToBase64Images(canvas, callback)
   }, options)
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -62,14 +62,14 @@
               onReady: function() {
                 /*callback for when */ console.log("successfully authorised")
               },
-              onDocumentCapture: function(event) {
-                /*callback for when the*/ console.log("document has been captured successfully")
+              onDocumentCapture: function(data) {
+                /*callback for when the*/ console.log("document has been captured successfully", data)
               },
-              onFaceCapture: function(event) {
-                /*callback for when the*/ console.log("face capture was successful")
+              onFaceCapture: function(data) {
+                /*callback for when the*/ console.log("face capture was successful", data)
               },
-              onComplete: function(event) {
-                /*callback for when */ console.log("everything is complete")
+              onComplete: function(data) {
+                /*callback for when */ console.log("everything is complete", data)
                 console.log(Onfido.getCaptures())
               },
               steps: [

--- a/src/index.js
+++ b/src/index.js
@@ -27,15 +27,31 @@ class Container extends Component {
       </Provider>
     )
   }
-
 }
 
+/**
+ * Renders the Onfido component
+ *
+ * @param {DOMelement} [merge] preact requires the element which was created from the first render to be passed as 3rd argument for a rerender
+ * @returns {DOMelement} Element which was generated from render
+ */
+const onfidoRender = (options, el, merge) => {
+  return render( <Container options={options}/>, el, merge)
+}
+
+const stripOneCapture = ({image,documentType,id}) =>
+  documentType === undefined ? {id,image} : {id,image,documentType}
+
+const stripCapturesHashToNecessaryValues = captures => _.mapValues(captures,
+  capture => capture ? stripOneCapture(capture) : null)
+
 function bindEvents (options) {
+  const strip = stripCapturesHashToNecessaryValues
   const eventListenersMap = {
     ready: () => options.onReady(),
-    documentCapture: data => options.onDocumentCapture(data),
-    faceCapture: data => options.onFaceCapture(data),
-    complete: data => options.onComplete(data)
+    documentCapture: data => options.onDocumentCapture(strip(data)),
+    faceCapture: data => options.onFaceCapture(strip(data)),
+    complete: data => options.onComplete(strip(data))
   }
 
   _.forIn(eventListenersMap, (listener, event) => {
@@ -56,15 +72,9 @@ function rebindEvents(newOptions, previousEventListenersMap){
   return bindEvents(newOptions)
 }
 
-/**
- * Renders the Onfido component
- *
- * @param {DOMelement} [merge] preact requires the element which was created from the first render to be passed as 3rd argument for a rerender
- * @returns {DOMelement} Element which was generated from render
- */
-const onfidoRender = (options, el, merge) => {
-  return render( <Container options={options}/>, el, merge)
-}
+
+Onfido.getCaptures = () => stripCapturesHashToNecessaryValues(events.getCaptures())
+
 
 const defaults = {
   token: 'some token',
@@ -102,7 +112,5 @@ Onfido.init = (opts) => {
     }
   }
 }
-
-Onfido.getCaptures = () => events.getCaptures()
 
 export default Onfido


### PR DESCRIPTION
1. Captures are now returned as png
2. The webp is still used internally for streaming images to server for validation, this is done for performance reasons
3. webp now falls back to jpeg if browser does not support the format;
4. - `Onfido.getCaptures()` has a simplified signature of just `{id,image,documentType}`, the data passed to the events has been simplified in the same manner.