### PR TITLE
Fix/component lifecycle issue

### DIFF
--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -74,19 +74,26 @@ export default class Camera extends Component {
     }
   }
 
-  //Necessary since componentDidMount is sometimes not called
   webcamMounted () {
     const { autoCapture } = this.props
     if (autoCapture) this.capture.start()
     events.on('onBeforeClose', () => {
+      //TODO remove this once the react modal is implemented
       this.capture.stop()
       route('/', true)
     })
   }
 
-  //Necessary since componentWillUnmount is sometimes not called
   webcamUnmounted () {
     this.capture.stop()
+  }
+
+  componentDidMount () {
+    this.webcamMounted()
+  }
+
+  componentWillUnmount () {
+    this.webcamUnmounted()
   }
 
   screenshot = () => {
@@ -100,12 +107,7 @@ export default class Camera extends Component {
       method, onUserMedia, onUploadFallback,
       faceCaptureClick: this.capture.once,
       countDownRef: (c) => { this.countdown = c },
-      webcamRef: (c) => {
-        const previous = this.webcam;
-        this.webcam = c
-        if (c===null && previous!==null) this.webcamUnmounted()
-        else if (c!==null && previous===null) this.webcamMounted()
-      }}}
+      webcamRef: (c) => { this.webcam = c }}}
     />
   )
 }

--- a/src/components/Capture/index.js
+++ b/src/components/Capture/index.js
@@ -10,7 +10,7 @@ import { DocumentTitle } from '../Document'
 import isDesktop from '../utils/isDesktop'
 import DetectRTC from 'detectrtc'
 import style from './style.css'
-import {functionalSwitch} from '../utils'
+import {functionalSwitch, impurify} from '../utils'
 
 export default class Capture extends Component {
   constructor (props) {
@@ -24,13 +24,8 @@ export default class Capture extends Component {
   }
 
   componentDidMount () {
-    console.log("componentDidMount")
     events.on('onMessage', (message) => this.handleMessages(message))
     this.checkWebcamSupport()
-  }
-
-  componentWillUnmount () {
-    console.log("componentWillUnmount")
   }
 
   checkWebcamSupport () {

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -2,6 +2,7 @@ import { h, Component } from 'preact'
 import { Link } from 'preact-router'
 import theme from '../Theme/style.css'
 import style from './style.css'
+import {functionalSwitch, impurify} from '../utils'
 
 const Capture = ({ image }) => (
   <div className={style.captures}>
@@ -56,4 +57,7 @@ const Confirm = ({
   />
 }
 
-export default Confirm
+//TODO move to react instead of preact, since preact has issues handling pure components
+//IF this component is exported as pure,
+//some components like Camera will not have componentWillUnmount called
+export default impurify(Confirm)

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -3,14 +3,14 @@ import classNames from 'classnames'
 import theme from '../Theme/style.css'
 import style from './style.css'
 import DocumentSelector from '../DocumentSelector'
+import { impurify } from '../utils'
 
-const Home = (props) => {
+const Home = props => {
   const {
     nextPage,
     actions: { setDocumentType },
     data: { renderDropdown, title, hint }
   } = props;
-
   return (
     <div className={style.wrapper}>
       <div className={`${style.methods} ${theme.step}`}>
@@ -24,7 +24,6 @@ const Home = (props) => {
   )
 }
 
-
 Home.defaultProps = {
   data: {
     hint: 'Select the type of document you would like to upload',
@@ -33,4 +32,7 @@ Home.defaultProps = {
   }
 };
 
-export default Home;
+//TODO move to react instead of preact, since preact has issues handling pure components
+//IF this component is exported as pure,
+//some components like Capture will not have componentWillUnmount called
+export default impurify(Home)

--- a/src/components/Uploader/index.js
+++ b/src/components/Uploader/index.js
@@ -6,6 +6,7 @@ import Spinner from '../Spinner'
 import Confirm from '../Confirm'
 import theme from '../Theme/style.css'
 import style from './style.css'
+import {functionalSwitch, impurify} from '../utils'
 
 export const fileToBase64 = (file, callback) => {
   const options = {
@@ -38,7 +39,10 @@ export const UploadError = ({errorMessage}) => (
   <div className={`${style.text} ${style.error}`}>{errorMessage}</div>
 )
 
-export const Uploader = ({method, onImageSelected, uploading, noDocument}) => (
+//TODO move to react instead of preact, since preact has issues handling pure components
+//IF this component is exported as pure,
+//some components like Camera will not have componentWillUnmount called
+export const Uploader = impurify(({method, onImageSelected, uploading, noDocument}) => (
   <Dropzone
     onDrop={([ file ])=> onImageSelected(file)}
     multiple={false}
@@ -49,4 +53,4 @@ export const Uploader = ({method, onImageSelected, uploading, noDocument}) => (
       <DocumentNotFound /> : null
     }
   </Dropzone>
-)
+))

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -1,1 +1,11 @@
+import { h, Component } from 'preact'
+
 export const functionalSwitch = (key, hash) => (hash[key] || (_=>null))()
+
+export const impurify = pureComponent => {
+  const impureComponent = class extends Component {
+    render = () => pureComponent(this.props)
+  }
+  impureComponent.defaultProps = pureComponent.defaultProps
+  return impureComponent;
+}


### PR DESCRIPTION
This a fix for the bug #54.

It only solves the lifecycle issues for `Camera` and `Capture`.

The issue is due to `preact` not handling nested pure components well. Sibling and stateful parents often don't get lifecycle method calls if they have pure components associated with them.

The fix found was _impurify_ some components.

This is a hack/workaround and more general fix should be found.