### PR TITLE
fixed issue with wrong canvas size if video element had not be initia…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The standard for the caret can [be found here](https://docs.npmjs.com/misc/semve
 Breaking changes result in a different major. UI changes that might break customizations on top of the sdk, will be treated as breaking changes too.
 
 
+## [new-version]
+
+### Fixed
+- Updated `react-webcam` to the onfido fork, this fixes the issue where the webcam canvas (used to obtain screenshots) has 0 height under certain circumstances (namely on windows machines running Chrome). This bug, when it happened, caused the document capture step not to work.
+
+
 ## [0.8.3]
 
 ### Added
@@ -88,6 +94,7 @@ Breaking changes result in a different major. UI changes that might break custom
 
 The standard for this change log can be found [here](http://keepachangelog.com/).
 
+[new-version]: https://github.com/onfido/onfido-sdk-ui/compare/0.8.3...master
 [0.8.3]: https://github.com/onfido/onfido-sdk-ui/compare/0.8.2...0.8.3
 [0.8.2]: https://github.com/onfido/onfido-sdk-ui/compare/0.8.1...0.8.2
 [0.8.1]: https://github.com/onfido/onfido-sdk-ui/compare/0.8.0...0.8.1

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "react-modal-onfido": "^1.5.2",
     "react-native-listener": "^1.0.1",
     "react-redux": "^4.4.5",
-    "react-webcam": "0.0.14",
+    "react-webcam-onfido": "0.0.16",
     "redux": "^3.5.2",
     "wpt": "https://github.com/onfido/js-client-tracker/tarball/master"
   }

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact'
 import { Link, route } from 'preact-router'
-import Webcam from 'react-webcam'
+import Webcam from 'react-webcam-onfido'
 import CountUp from 'countup.js'
 import classNames from 'classnames'
 import { connect, events } from 'onfido-sdk-core'


### PR DESCRIPTION
fixed issue with getting a canvas size with no height, in case the webcam video element had not be initialised properly at the time `getCanvas()` gets called.

Symptoms:
The webcam does not work, because the canvas has `height` 0.
This always happens running Chrome on Windows.

Complementary `react-webcam-onfido` fix: https://github.com/onfido/react-webcam/compare/5320a15...master