### PR TITLE
made pdf validation consistent across different browsers

### DIFF
--- a/src/components/utils/canvas.js
+++ b/src/components/utils/canvas.js
@@ -33,8 +33,9 @@ const cloneLowResCanvas = (canvas, maxHeight) => {
 const toDataUrl = type => (canvas, callback) =>
   tick( _=> callback(canvas.toDataURL(type)))
 
+const browserSupportedLossyFormat = `image/${supportsWebP ? 'webp':'jpeg'}`
 
-export const toLossyImageDataUrl = toDataUrl(`image/${supportsWebP ? 'webp':'jpeg'}`)
+export const toLossyImageDataUrl = toDataUrl(browserSupportedLossyFormat)
 const toPngImageDataUrl = toDataUrl("image/png")
 
 export const canvasToBase64Images = (canvas, callback/*(imageLossy, imagePng)*/) => {

--- a/src/components/utils/file.js
+++ b/src/components/utils/file.js
@@ -30,25 +30,8 @@ const fileToCanvas = (options = { maxWidth: 960, maxHeight: 960, canvas: true},
     }
   }, options)
 
-
-export const fileToBase64AndLossyBase64Image = (options, file, callback, errorCallback) => {
-  errorCallback = errorCallback || callback
-
-  const onFileBase64 = fileBase64 =>
-    fileToCanvas(options, file,
-      canvas => { onCanvasFromFile(canvas, fileBase64) },
-      error  => { callback(fileBase64, file, null) }
-    )
-
-  const onCanvasFromFile = (canvas, fileBase64) =>
-    toLossyImageDataUrl(canvas,
-      imageLossyDataUrl => onLossyImageDataUrl(imageLossyDataUrl, fileBase64))
-
-  const onLossyImageDataUrl = (imageLossyDataUrl, fileBase64) =>
-    callback(fileBase64, file, imageLossyDataUrl)
-
-  fileToBase64(file,
-    onFileBase64,
+export const fileToLossyBase64Image = (options, file, callback, errorCallback) =>
+  fileToCanvas(options, file,
+    canvas => toLossyImageDataUrl(canvas, callback),
     errorCallback
   )
-}


### PR DESCRIPTION
Browsers that render pdfs are no longer allowed to do so. The pdf is sent raw to the server, this is to reduce inconsistencies, since the server rendered version might have a different result from the browser rendered version.