### PR TITLE
Travis deployment: fixed the sorting to find the latest git release

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -15,7 +15,14 @@ then
   DEPLOY_SUBDOMAIN_UNFORMATTED_LIST+=(${TRAVIS_PULL_REQUEST}-pr)
 elif [ -n "${TRAVIS_TAG// }" ] #TAG is not empty
 then
-  LATEST_TAG=`git tag | sort -r | sed -n 1p`
+  #sorts the tags and picks the latest
+  #sort -V does not work on the travis machine
+  #sort -V              ref: http://stackoverflow.com/a/14273595/689223
+  #sort -t ...          ref: http://stackoverflow.com/a/4495368/689223
+  #reverse with sed     ref: http://stackoverflow.com/a/744093/689223
+  #git tags | sort versions | reverse | pick first line
+  LATEST_TAG=`git tag | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | sed '1!G;h;$!d' | sed -n 1p`
+  echo $LATEST_TAG
 
   if [ "$TRAVIS_TAG" == "$LATEST_TAG" ]
   then


### PR DESCRIPTION
Fix for deploying to latest when the release reaches a decimal (eg. 0.10.0)