### PR TITLE
Update expected websockets message signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Breaking changes result in a different major. UI changes that might break custom
 
 ## [next-version]
 
+### Changed
+- Internal: Change the signature expected from the websockets server.
+
 ### Fixed
 - Public: The documentType in the capture object now corresponds to the API document_types.
 

--- a/src/components/Capture/index.js
+++ b/src/components/Capture/index.js
@@ -80,7 +80,7 @@ export default class Capture extends Component {
 
   handleMessages = (message) => {
     const { actions } = this.props
-    const valid = message.is_document;
+    const valid = message.valid;
     this.validateCapture(message.id, valid)
   }
 


### PR DESCRIPTION
The server currently supports both of these signatures. There is not currently a plan or timeline to deprecate the old `is_document` signature.