### PR TITLE
log websocket errors to sentry and communicate them to host app;

### DIFF
--- a/src/Tracker/index.js
+++ b/src/Tracker/index.js
@@ -34,5 +34,10 @@ const track = () => {
   RavenTracker.install()
 }
 
+const sendError = (message, extra) => {
+  RavenTracker.captureException(new Error(message), {
+    extra
+  });
+}
 
-export default { setUp, track }
+export default { setUp, track, sendError }

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,6 @@ function bindEvents (options) {
     faceCapture: data => { options.onFaceCapture(stripOneCapture(data)) },
     complete: data => { options.onComplete(strip(data)) },
     onError: () => {
-      console.log("onError")
       Tracker.sendError("socket error");
       options.onError()
     }

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,12 @@ function bindEvents (options) {
     ready: () => { options.onReady() },
     documentCapture: data => { options.onDocumentCapture(stripOneCapture(data)) },
     faceCapture: data => { options.onFaceCapture(stripOneCapture(data)) },
-    complete: data => { options.onComplete(strip(data)) }
+    complete: data => { options.onComplete(strip(data)) },
+    onError: () => {
+      console.log("onError")
+      Tracker.sendError("socket error");
+      options.onError()
+    }
   }
 
   forEach(eventListenersMap, (listener, event) => {
@@ -99,7 +104,8 @@ const defaults = {
   onReady: noOp,
   onDocumentCapture: noOp,
   onFaceCapture: noOp,
-  onComplete: noOp
+  onComplete: noOp,
+  onError: noOp
 }
 
 


### PR DESCRIPTION
### Technical Considerations

`sdk-core` emits a `onError` event when websockets return an error, (this is when the UI changes state to show the error to the user).
This event is now being listened to, when it happens it's sent to sentry and to the `onError` host app callback