### PR TITLE
Bug/memory leak fix some refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,13 +241,13 @@ You should get something returned back that looks like this:
     //useful only if you want to track and reference captures which have been taken
     id: "mwxm5loxdu63zlkawcdi",
     //captures will be returned as File or Blob
-    image: File
+    blob: BlobOrFile
     //the result of the document selection step
     documentType: "passport"
   },
   faceCapture: {
     id: "yy5j8hxlxukufjbrzfr",
-    image: Blob,
+    blob: BlobOrFile,
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -263,17 +263,49 @@ Onfido.init({
   containerId: 'onfido-mount',
   // here we send the data in the complete callback
   onComplete: function() {
-    var data = Onfido.getCaptures()
-    sendToServer(data)
+    var captures = Onfido.getCaptures()
+    sendToServer(captures)
   }
 })
 
-function sendToServer(data) {
-  var request = new XMLHttpRequest()
-  request.open('POST', '/your/server/endpoint', true)
-  request.setRequestHeader('Content-Type', 'application/json')
-  var dataString = JSON.stringify(data)
-  request.send(dataString)
+const reduceObj = (object, callback, initialValue) =>
+  Object.keys(object).reduce(
+    (accumulator, key) => callback(accumulator, object[key], key, object),
+    initialValue)
+
+const objectToFormData = (object) =>
+  reduceObj(object, (formData, value, key) => {
+    formData.append(key, value)
+    return formData;
+  }, new FormData())
+
+const postData = (data, endpoint, callback) => {
+  const request = new XMLHttpRequest()
+  request.open('POST', endpoint, true)
+
+  request.onload = () => {
+    if (request.readyState === request.DONE) {
+      callback(request)
+    }
+  }
+  request.send(objectToFormData(data))
+}
+
+const sendToServer = ({documentCapture, faceCapture}) => {
+  postFormData({
+    file: documentCapture.blob,
+    type: documentCapture.documentType
+  },
+    '/your-document-endpoint/',
+    request => console.log('document uploaded')
+  )
+
+  postFormData({
+    file: faceCapture.blob
+  },
+    '/your-face-endpoint/',
+    request => console.log('face uploaded')
+  )
 }
 ```
 

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -100,6 +100,7 @@ class Capture extends Component {
     }
 
     if (!lossyBase64){
+      //If a lossy file cannot be generated, then a raw base64 should be
       fileToBase64(blob, base64 =>
         handleImageInternal(undefined, blob, base64), this.onFileGeneralError);
     }
@@ -145,18 +146,17 @@ class Capture extends Component {
     this.onImageFileSelected(file)
   }
 
-  handleBase64 = (lossyBase64, base64) => {
-    const blob = base64toBlob(base64)
-    this.handleImage(lossyBase64, blob)
-  }
-
   onScreenshot = canvas => canvasToBase64Images(canvas, (lossyBase64, base64) => {
     const blob = base64toBlob(base64)
     this.handleImage(lossyBase64, blob)
   })
 
   onImageFileSelected = file => {
-    if (!isOfFileType(['jpg','jpeg','png','pdf'], file)){
+    const imageTypes = ['jpg','jpeg','png']
+    const pdfType = ['pdf']
+    const allAcceptedTypes = [...imageTypes, ...pdfType]
+
+    if (!isOfFileType(allAcceptedTypes, file)){
       this.onFileTypeError()
       return
     }
@@ -167,11 +167,11 @@ class Capture extends Component {
       return
     }
 
-    if (isOfFileType(['pdf'], file)){
+    if (isOfFileType(pdfType, file)){
       this.handleImage(undefined, file)
     }
 
-    if (isOfFileType(['jpg','jpeg','png'], file)){
+    if (isOfFileType(imageTypes, file)){
       //avoid rendering pdfs or other formats to image,
       //due to inconsistencies between different browsers and the back end
       fileToLossyBase64Image(undefined, file, (lossyBase64) => {

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -91,24 +91,11 @@ class Capture extends Component {
       return;
     }
 
-    const handleCaptureInternal = (blob, base64) => {
-      const payload = this.createPayload(blob, base64)
-      functionalSwitch(this.props.method, {
-        document: ()=> this.handleDocument(payload),
-        face: ()=> this.handleFace(payload)
-      })
-    }
-
-    if (!base64){
-      //If a base64 (potentially lossy and downsampled) was not provided,
-      //then a raw (not downsampled or compressed) base64 should be created
-      fileToBase64(blob,
-        base64 => handleCaptureInternal(blob, base64),
-        this.onFileGeneralError);
-    }
-    else {
-      handleCaptureInternal(blob, base64)
-    }
+    const payload = this.createPayload(blob, base64)
+    functionalSwitch(this.props.method, {
+      document: ()=> this.handleDocument(payload),
+      face: ()=> this.handleFace(payload)
+    })
   }
 
   createPayload = (blob, base64) => ({
@@ -169,14 +156,18 @@ class Capture extends Component {
       return
     }
 
+    const handleFile = file => fileToBase64(file,
+        base64 => this.handleCapture(file, base64),
+        this.onFileGeneralError);
+
     if (isOfFileType(pdfType, file)){
       //avoid rendering pdfs, due to inconsistencies between different browsers
-      this.handleCapture(file)
+      handleFile(file)
     }
     else if (isOfFileType(imageTypes, file)){
       fileToLossyBase64Image(undefined, file,
         lossyBase64 => this.handleCapture(file, lossyBase64),
-        error => this.handleCapture(file)
+        error => handleFile(file)
       )
     }
   }

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -85,13 +85,13 @@ class Capture extends Component {
     this.validateCapture(message.id, valid)
   }
 
-  handleImage = (base64, blob) => {
+  handleCapture = (blob, base64) => {
     if (!blob) {
       console.warn('Cannot handle a null image')
       return;
     }
 
-    const handleImageInternal = (base64, blob) => {
+    const handleCaptureInternal = (blob, base64) => {
       const payload = this.createPayload(blob, base64)
       functionalSwitch(this.props.method, {
         document: ()=> this.handleDocument(payload),
@@ -103,11 +103,11 @@ class Capture extends Component {
       //If a base64 (potentially lossy and downsampled) was not provided,
       //then a raw (not downsampled or compressed) base64 should be created
       fileToBase64(blob,
-        base64 => handleImageInternal(base64, blob),
+        base64 => handleCaptureInternal(blob, base64),
         this.onFileGeneralError);
     }
     else {
-      handleImageInternal(base64, blob)
+      handleCaptureInternal(blob, base64)
     }
   }
 
@@ -150,7 +150,7 @@ class Capture extends Component {
 
   onScreenshot = canvas => canvasToBase64Images(canvas, (lossyBase64, base64) => {
     const blob = base64toBlob(base64)
-    this.handleImage(lossyBase64, blob)
+    this.handleCapture(blob, lossyBase64)
   })
 
   onImageFileSelected = file => {
@@ -171,12 +171,12 @@ class Capture extends Component {
 
     if (isOfFileType(pdfType, file)){
       //avoid rendering pdfs, due to inconsistencies between different browsers
-      this.handleImage(undefined, file)
+      this.handleCapture(file)
     }
     else if (isOfFileType(imageTypes, file)){
       fileToLossyBase64Image(undefined, file,
-        lossyBase64 => this.handleImage(lossyBase64, file),
-        error => this.handleImage(undefined, file)
+        lossyBase64 => this.handleCapture(file, lossyBase64),
+        error => this.handleCapture(file)
       )
     }
   }

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -22,20 +22,58 @@ const FileViewer = ({file:{preview, type}}) =>
   </object>
 
 
-const Capture = ({capture:{image, base64}}) =>
+const CaptureViewerPure = ({capture:{blob}}) =>
   <div className={style.captures}>
-    {isOfFileType(['pdf'], image) ?
-      <FileViewer file={image}/> :
-      <img src={image.preview || base64} className={style.image} />
+    {isOfFileType(['pdf'], blob) ?
+      <FileViewer file={blob}/> :
+      <img src={blob.preview} className={style.image} />
     }
   </div>
 
+class CaptureViewer extends Component {
+  constructor (props) {
+    super(props)
+    const {capture:{blob}}  = props
+    if (blob){
+      this.state = { previewUrl: URL.createObjectURL(blob) }
+    }
+  }
+
+  updateBlobPreview(blob) {
+    this.revokePreviewURL()
+    if (blob){
+      this.setState({ previewUrl: URL.createObjectURL(blob) })
+    }
+  }
+
+  revokePreviewURL(){
+    URL.revokeObjectURL(this.state.previewUrl)
+  }
+
+  componentWillReceiveProps({capture:{blob}}) {
+    this.updateBlobPreview(blob)
+  }
+
+  componentWillUnmount() {
+    this.revokePreviewURL()
+  }
+
+  render () {
+    const {capture:{blob}} = this.props
+    return <CaptureViewerPure
+      capture={{
+        blob:{
+          type: blob.type, preview: this.state.previewUrl
+        }
+      }}/>
+  }
+}
 
 const Previews = ({capture, retakeAction, confirmAction} ) =>
   <div className={`${theme.previews} ${theme.step}`}>
     <h1 className={theme.title}>Confirm capture</h1>
     <p>Please confirm that you are happy with this photo.</p>
-    <Capture capture={capture}/>
+    <CaptureViewer capture={capture} />
     <div className={`${theme.actions} ${style.actions}`}>
       <button
         onClick={retakeAction}

--- a/src/components/Uploader/index.js
+++ b/src/components/Uploader/index.js
@@ -46,7 +46,12 @@ InvalidFileSize.defaultProps = {
 //some components like Camera will not have componentWillUnmount called
 export const Uploader = impurify(({method, onImageSelected, uploading, error}) => (
   <Dropzone
-    onDrop={([ file ])=> onImageSelected(file)}
+    onDrop={([ file ])=> {
+      //removes a memory leak created by react-dropzone
+      URL.revokeObjectURL(file.preview)
+      file.preview = undefined
+      onImageSelected(file)
+    }}
     multiple={false}
     className={style.dropzone}
   >

--- a/src/components/Uploader/index.js
+++ b/src/components/Uploader/index.js
@@ -49,7 +49,7 @@ export const Uploader = impurify(({method, onImageSelected, uploading, error}) =
     onDrop={([ file ])=> {
       //removes a memory leak created by react-dropzone
       URL.revokeObjectURL(file.preview)
-      file.preview = undefined
+      delete file.preview
       onImageSelected(file)
     }}
     multiple={false}

--- a/src/components/utils/file.js
+++ b/src/components/utils/file.js
@@ -33,8 +33,10 @@ export const isOfFileType = (fileTypeList, file) =>
     acceptableFileType === fileType(file));
 
 const fileToCanvas = (options = { maxWidth: 960, maxHeight: 960, canvas: true},
-                      file, callback, errorCallback) =>
-  loadImage(file.preview, canvasOrEventError => {
+                      file, callback, errorCallback) => {
+  const preview = URL.createObjectURL(file)
+  loadImage(preview, canvasOrEventError => {
+    URL.revokeObjectURL(preview)
     if (canvasOrEventError.type === "error"){
       errorCallback(canvasOrEventError)
     }
@@ -42,6 +44,7 @@ const fileToCanvas = (options = { maxWidth: 960, maxHeight: 960, canvas: true},
       callback(canvasOrEventError)
     }
   }, options)
+}
 
 export const fileToLossyBase64Image = (options, file, callback, errorCallback) =>
   fileToCanvas(options, file,

--- a/src/index.js
+++ b/src/index.js
@@ -50,9 +50,8 @@ const onfidoRender = (options, el, merge) => {
   return render( <Container options={options}/>, el, merge)
 }
 
-const stripOneCapture = ({image, documentType, id, side}) => {
-  delete image.base64
-  const capture = {id, image}
+const stripOneCapture = ({blob, documentType, id, side}) => {
+  const capture = {id, blob}
   if (documentType) capture.documentType = documentType
   if (side) capture.side = side
   return capture

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -42,6 +42,7 @@ const basePlugins = [
 if (ENV === 'production') {
   basePlugins.push(
     new webpack.optimize.UglifyJsPlugin({
+      sourceMap: true,
       compressor: {
         pure_getters: true,
         unsafe: true,
@@ -133,7 +134,7 @@ const configDist = {
     setImmediate: false
   },
 
-  devtool: ENV==='production' ? 'source-map' : 'cheap-module-eval-source-map',
+  devtool: ENV==='production' ? 'source-map' : 'eval-source-map',
 
   devServer: {
     port: process.env.PORT || 8080,


### PR DESCRIPTION
## The problem

`react-dropzone` was creating `ObjectURL`s but it did not manage them. This created a memory leak since we were not revoking them.

## Technical Implementation

The `ObjectURL` is automatically revoked and removed from the `File` object, whenever `react-dropzone` creates it.

The `ObjectURL` is still used to create lossy `Base64` and to display Blob or Files in the confirmation step. However these `ObjectURL` are created only when needed and are removed (revoked) when no longer necessary.

It's a good practice not to return these `ObjectURL` to the user, since he might not be aware that he needs to revoke them too.

https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL

Internally `image` was renamed `Blob` since it can always be considered a `Blob` even when it's a `File` (since it's inherited).

`imageLossy` was renamed to `lossyBase64` since it's more descriptive.

## Api changes

the returned capture had it's `image` renamed to `blob`. Open to discussion though.

## Documentation Change

Added an example taken from IDV demo app on how to upload captures to webserver