### PR TITLE
Log error messages on console

### DIFF
--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -80,7 +80,6 @@ class Capture extends Component {
   }
 
   onServerResponse = (response) => {
-    console.log('response', response)
     const { actions } = this.props
     const valid = response.valid
     this.validateCapture(response.id, valid)

--- a/src/components/utils/http.js
+++ b/src/components/utils/http.js
@@ -22,7 +22,8 @@ const errorMessage = (status) => {
   }
 }
 
-const handleError = (status, callback) => {
+const handleError = ({status, response}, callback) => {
+  console.error(status, response)
   const message = errorMessage(status)
   Tracker.sendError(message)
   callback()
@@ -39,11 +40,11 @@ export const postToServer = (payload, serverUrl, token, onSuccess, onError) => {
     if (request.status === 200) {
       onSuccess(JSON.parse(request.response))}
     else {
-      handleError(request.status, onError)
+      handleError(request, onError)
     }
   }
 
-  request.onerror = () => handleError(request.status, onError)
+  request.onerror = () => handleError(request, onError)
 
   request.send(payload)
 }

--- a/src/components/utils/http.js
+++ b/src/components/utils/http.js
@@ -33,6 +33,8 @@ export const postToServer = (payload, serverUrl, token, onSuccess, onError) => {
   const request = new XMLHttpRequest()
   const url = serverUrl ? serverUrl : SDK_SERVER_URL
   request.open('POST', `${url}/validate_document`)
+  // This line doesn't work on IE on Win7, use JSON.parse() instead
+  // request.responseType = 'json'
   request.setRequestHeader('Content-Type', 'application/json')
   request.setRequestHeader('Authorization', token)
 

--- a/src/components/utils/http.js
+++ b/src/components/utils/http.js
@@ -7,25 +7,9 @@ const reduceObj = (object, callback, initialValue) =>
     (accumulator, key) => callback(accumulator, object[key], key, object),
     initialValue)
 
-const objectToFormData = (object) =>
-  reduceObj(object, (formData, value, key) => {
-    formData.append(key, value)
-    return formData;
-  }, new FormData())
-
-const errorMessage = (status) => {
-  if (status === 401 || status === 403) return 'unauthorized'
-  if (status >= 500) {
-    'server error' }
-  else {
-    'request error'
-  }
-}
-
 const handleError = ({status, response}, callback) => {
   console.error(status, response)
-  const message = errorMessage(status)
-  Tracker.sendError(message)
+  Tracker.sendError(`${status} - ${response}`)
   callback()
 }
 


### PR DESCRIPTION
In order to improve the integration experience we print the errors on the console if a requests fails or status code is not 200.