### PR TITLE
Feature/webcam fallback cx 824

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Breaking changes result in a different major. UI changes that might break custom
 
 ## [next-version]
 
+### Fixed
+- Internal: Fixed problem on certain versions of Firefox that no longer supported the old version of getUserMedia
+
+### Changed
+- Internal: replaced the has_webcam checker with a more robust version that periodically checks if the state changed
+
+
 ## [0.15.0]
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "blueimp-load-image": "2.12.2",
     "classnames": "2.2.5",
     "countup.js": "1.8.1",
-    "detectrtc": "1.3.2",
     "history": "4.5.1",
     "object-loops": "0.8.0",
     "onfido-sdk-core": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "react-modal-onfido": "1.5.2",
     "react-native-listener": "1.0.1",
     "react-redux": "4.4.6",
-    "react-webcam-onfido": "0.0.17",
+    "react-webcam-onfido": "0.0.18",
     "redux": "3.5.2",
     "supports-webp": "1.0.3",
     "visibilityjs": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "blueimp-load-image": "2.12.2",
     "classnames": "2.2.5",
     "countup.js": "1.8.1",
+    "enumerate-devices": "^1.1.0",
     "history": "4.5.1",
     "object-loops": "0.8.0",
     "onfido-sdk-core": "1.1.0",

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -43,7 +43,7 @@ const UploadFallback = ({onUploadFallback}) => (
   </Dropzone>
 )
 
-const CameraPure = ({method, onUploadFallback, onUserMedia, faceCaptureClick, countDownRef, webcamRef}) => (
+const CameraPure = ({method, onUploadFallback, onUserMedia, faceCaptureClick, countDownRef, webcamRef, onWebcamError}) => (
   <div>
     <div className={style["video-overlay"]}>
       <Overlay {...{method, countDownRef}}/>
@@ -52,7 +52,7 @@ const CameraPure = ({method, onUploadFallback, onUserMedia, faceCaptureClick, co
         audio={false}
         width={960}
         height={720}
-        {...{onUserMedia, ref:webcamRef}}
+        {...{onUserMedia, ref: webcamRef, onFailure: onWebcamError}}
       />
       <UploadFallback {...{onUploadFallback}}/>
     </div>
@@ -104,9 +104,9 @@ export default class Camera extends Component {
     asyncFunc(cloneCanvas, [canvas], onScreenshot)
   }
 
-  render = ({method, onUserMedia, onUploadFallback}) => (
+  render = ({method, onUserMedia, onUploadFallback, onWebcamError}) => (
     <CameraPure {...{
-      method, onUserMedia, onUploadFallback,
+      method, onUserMedia, onUploadFallback, onWebcamError,
       faceCaptureClick: this.capture.once,
       countDownRef: (c) => { this.countdown = c },
       webcamRef: (c) => { this.webcam = c }}}

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -9,7 +9,8 @@ import Confirm from '../Confirm'
 import { FaceTitle } from '../Face'
 import { DocumentTitle } from '../Document'
 import style from './style.css'
-import { functionalSwitch, impurify, isDesktop, getUserMediaSupported } from '../utils'
+import { functionalSwitch, impurify, isDesktop } from '../utils'
+import { hasGetUserMedia } from 'react-webcam-onfido'
 import { canvasToBase64Images } from '../utils/canvas.js'
 import { base64toBlob, fileToBase64, isOfFileType, fileToLossyBase64Image } from '../utils/file.js'
 import { postToServer } from '../utils/http.js'
@@ -164,7 +165,7 @@ class Capture extends Component {
   }
 
   render ({method, side, validCaptures, useWebcam, unprocessedCaptures, ...other}) {
-    const useCapture = (!this.state.uploadFallback && useWebcam && isDesktop && getUserMediaSupported)
+    const useCapture = (!this.state.uploadFallback && useWebcam && isDesktop && hasGetUserMedia)
     const hasUnprocessedCaptures = unprocessedCaptures.length > 0
     return (
       <CaptureScreen {...{method, side, validCaptures, useCapture,

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -9,7 +9,6 @@ import Confirm from '../Confirm'
 import { FaceTitle } from '../Face'
 import { DocumentTitle } from '../Document'
 import isDesktop from '../utils/isDesktop'
-import DetectRTC from 'detectrtc'
 import style from './style.css'
 import { functionalSwitch, impurify } from '../utils'
 import { canvasToBase64Images } from '../utils/canvas.js'
@@ -20,16 +19,9 @@ class Capture extends Component {
   constructor (props) {
     super(props)
     this.state = {
-      hasWebcamPermission: false,
-      hasWebcam: DetectRTC.hasWebcam,
-      DetectRTCLoading: true,
       uploadFallback: false,
       error: false
     }
-  }
-
-  componentDidMount () {
-    this.checkWebcamSupport()
   }
 
   componentWillUnmount () {
@@ -41,29 +33,6 @@ class Capture extends Component {
     if (validCaptures.length > 0) this.setState({uploadFallback: false})
     if (unprocessedCaptures.length > 0) this.setState({error: false})
     if (allInvalid) this.onFileGeneralError()
-  }
-
-  checkWebcamSupport () {
-    DetectRTC.load( _ => {
-      this.setState({
-        DetectRTCLoading: false,
-        hasWebcam: DetectRTC.hasWebcam
-      })
-    })
-  }
-
-  supportsWebcam (){
-    const supportNotYetUnknown = DetectRTC.isGetUserMediaSupported && this.state.DetectRTCLoading;
-    return supportNotYetUnknown || this.state.hasWebcam;
-  }
-
-  //Fired when there is an active webcam feed
-  onUserMedia = () => {
-    this.setState({
-      hasWebcam: true,
-      hasWebcamPermission: true,
-      DetectRTCLoading: false
-    })
   }
 
   validateCapture = (id, valid) => {
@@ -196,11 +165,10 @@ class Capture extends Component {
   }
 
   render ({method, side, validCaptures, useWebcam, unprocessedCaptures, ...other}) {
-    const useCapture = (!this.state.uploadFallback && useWebcam && this.supportsWebcam() && isDesktop)
+    const useCapture = (!this.state.uploadFallback && useWebcam && isDesktop)
     const hasUnprocessedCaptures = unprocessedCaptures.length > 0
     return (
       <CaptureScreen {...{method, side, validCaptures, useCapture,
-        onUserMedia: this.onUserMedia,
         onScreenshot: this.onScreenshot,
         onUploadFallback: this.onUploadFallback,
         onImageSelected: this.onImageFileSelected,

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -131,6 +131,11 @@ class Capture extends Component {
     this.onImageFileSelected(file)
   }
 
+  onWebcamError = () => {
+    this.setState({uploadFallback: true})
+    this.deleteCaptures()
+  }
+
   onScreenshot = canvas => canvasToBase64Images(canvas, (lossyBase64, base64) => {
     const blob = base64toBlob(base64)
     this.handleCapture(blob, lossyBase64)
@@ -199,6 +204,7 @@ class Capture extends Component {
         onScreenshot: this.onScreenshot,
         onUploadFallback: this.onUploadFallback,
         onImageSelected: this.onImageFileSelected,
+        onWebcamError: this.onWebcamError,
         uploading: hasUnprocessedCaptures,
         error: this.state.error,
         ...other}}/>

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -10,7 +10,6 @@ import { FaceTitle } from '../Face'
 import { DocumentTitle } from '../Document'
 import style from './style.css'
 import { functionalSwitch, impurify, isDesktop } from '../utils'
-import { hasGetUserMedia } from 'react-webcam-onfido'
 import { canvasToBase64Images } from '../utils/canvas.js'
 import { base64toBlob, fileToBase64, isOfFileType, fileToLossyBase64Image } from '../utils/file.js'
 import { postToServer } from '../utils/http.js'
@@ -165,7 +164,7 @@ class Capture extends Component {
   }
 
   render ({method, side, validCaptures, useWebcam, unprocessedCaptures, ...other}) {
-    const useCapture = (!this.state.uploadFallback && useWebcam && isDesktop && hasGetUserMedia)
+    const useCapture = (!this.state.uploadFallback && useWebcam && isDesktop)
     const hasUnprocessedCaptures = unprocessedCaptures.length > 0
     return (
       <CaptureScreen {...{method, side, validCaptures, useCapture,

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -8,9 +8,8 @@ import Camera from '../Camera'
 import Confirm from '../Confirm'
 import { FaceTitle } from '../Face'
 import { DocumentTitle } from '../Document'
-import isDesktop from '../utils/isDesktop'
 import style from './style.css'
-import { functionalSwitch, impurify } from '../utils'
+import { functionalSwitch, impurify, isDesktop, getUserMediaSupported } from '../utils'
 import { canvasToBase64Images } from '../utils/canvas.js'
 import { base64toBlob, fileToBase64, isOfFileType, fileToLossyBase64Image } from '../utils/file.js'
 import { postToServer } from '../utils/http.js'
@@ -165,7 +164,7 @@ class Capture extends Component {
   }
 
   render ({method, side, validCaptures, useWebcam, unprocessedCaptures, ...other}) {
-    const useCapture = (!this.state.uploadFallback && useWebcam && isDesktop)
+    const useCapture = (!this.state.uploadFallback && useWebcam && isDesktop && getUserMediaSupported)
     const hasUnprocessedCaptures = unprocessedCaptures.length > 0
     return (
       <CaptureScreen {...{method, side, validCaptures, useCapture,

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -43,13 +43,19 @@ const hasPromises = (function(){
   return promiseSupport;
 })()
 
-export const checkIfHasWebcam = onResult => {
-  //enumerateDevices needs Promise support to work
+const enumerateDevicesInternal = (onSuccess, onError) => {
+  //Devices that don't support Promises don't support getUserMedia as well
+  //So it's safe to fail in that case
   if (!hasPromises){
-    onResult(false)
+    onError({message:"Promise not supported"})
     return;
   }
-  enumerateDevices().then(devices => {
-      onResult( devices.some(device => device.kind === "videoinput") )
-    }).catch(() => onResult(false));
+  enumerateDevices().then(onSuccess).catch(onError);
+}
+
+export const checkIfHasWebcam = onResult => {
+  enumerateDevicesInternal(
+    devices => onResult( devices.some(device => device.kind === "videoinput") ),
+    error => onResult(false)
+  )
 }

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -32,6 +32,3 @@ export const preventDefaultOnClick = callback => event => {
 
 // Copied from https://github.com/muaz-khan/DetectRTC/blob/master/DetectRTC.js
 export const isDesktop = !(/Android|webOS|iPhone|iPad|iPod|BB10|BlackBerry|IEMobile|Opera Mini|Mobile|mobile/i.test(navigator.userAgent || ''))
-
-// Adapted from https://github.com/muaz-khan/DetectRTC/blob/master/DetectRTC.js
-export const getUserMediaSupported = (navigator.getUserMedia || (navigator.mediaDevices && navigator.mediaDevices.getUserMedia))

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -29,3 +29,9 @@ export const preventDefaultOnClick = callback => event => {
   event.preventDefault()
   callback()
 }
+
+// Copied from https://github.com/muaz-khan/DetectRTC/blob/master/DetectRTC.js
+export const isDesktop = !(/Android|webOS|iPhone|iPad|iPod|BB10|BlackBerry|IEMobile|Opera Mini|Mobile|mobile/i.test(navigator.userAgent || ''))
+
+// Adapted from https://github.com/muaz-khan/DetectRTC/blob/master/DetectRTC.js
+export const getUserMediaSupported = (navigator.getUserMedia || (navigator.mediaDevices && navigator.mediaDevices.getUserMedia))

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -1,5 +1,6 @@
 import parseUnit from 'parse-unit'
 import { h, Component } from 'preact'
+import enumerateDevices from 'enumerate-devices'
 
 export const functionalSwitch = (key, hash) => (hash[key] || (_=>null))()
 
@@ -32,3 +33,23 @@ export const preventDefaultOnClick = callback => event => {
 
 // Copied from https://github.com/muaz-khan/DetectRTC/blob/master/DetectRTC.js
 export const isDesktop = !(/Android|webOS|iPhone|iPad|iPod|BB10|BlackBerry|IEMobile|Opera Mini|Mobile|mobile/i.test(navigator.userAgent || ''))
+
+const hasPromises = (function(){
+  let promiseSupport = false;
+  try {
+      const promise = new Promise(function (x, y) {});
+      promiseSupport = true;
+  } catch (e) {}
+  return promiseSupport;
+})()
+
+export const checkIfHasWebcam = onResult => {
+  //enumerateDevices needs Promise support to work
+  if (!hasPromises){
+    onResult(false)
+    return;
+  }
+  enumerateDevices().then(devices => {
+      onResult( devices.some(device => device.kind === "videoinput") )
+    }).catch(() => onResult(false));
+}

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -37,7 +37,7 @@ export const isDesktop = !(/Android|webOS|iPhone|iPad|iPod|BB10|BlackBerry|IEMob
 const hasPromises = (function(){
   let promiseSupport = false;
   try {
-      const promise = new Promise(function (x, y) {});
+      const promise = new Promise(() => {});
       promiseSupport = true;
   } catch (e) {}
   return promiseSupport;

--- a/src/components/utils/isDesktop.js
+++ b/src/components/utils/isDesktop.js
@@ -1,3 +1,2 @@
-import DetectRTC from 'detectrtc'
-
-export default !DetectRTC.isMobileDevice
+// Copied from https://github.com/muaz-khan/DetectRTC/blob/master/DetectRTC.js
+export default !(/Android|webOS|iPhone|iPad|iPod|BB10|BlackBerry|IEMobile|Opera Mini|Mobile|mobile/i.test(navigator.userAgent || ''))

--- a/src/components/utils/isDesktop.js
+++ b/src/components/utils/isDesktop.js
@@ -1,2 +1,0 @@
-// Copied from https://github.com/muaz-khan/DetectRTC/blob/master/DetectRTC.js
-export default !(/Android|webOS|iPhone|iPad|iPod|BB10|BlackBerry|IEMobile|Opera Mini|Mobile|mobile/i.test(navigator.userAgent || ''))


### PR DESCRIPTION
(written by Ricardo)
### Scope

Investigate which dependencies could be replaced or improved to generate a better webcam user experience.
One of the bugs was with Firefox that no longer supported the old version of getUserMedia (which we were using)

### Technical Considerations

webcam.js was tried but it was found to be not well maintained.
A choice was made to improve onfido/react-webcam based on code and knowledge extracted from webcam.js. This fixed the firefox bug and other potential bugs, since an `errorCallback` is now called if `react-webcam` finds any problem.

DetectRTC was replaced with other more focused and robust solutions. Namely the `has_webcam` check. This was replaced by a dependency that normalizes this api, but only works with Promises. Therefore browsers that don't support `Promise` (iE11) get a `hasWebcam = false` and are sent to upload file.

Also a 2 second checker is run which determines dynamically if a webcam has been disconnected or connected.