### PR TITLE
fixed flickering on confirmation step

### DIFF
--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -55,7 +55,7 @@ class CaptureViewer extends Component {
   }
 
   componentWillReceiveProps({capture:{blob}}) {
-    this.updateBlobPreview(blob)
+    if (this.props.capture.blob !== blob) this.updateBlobPreview(blob)
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Due to the changes that I made on https://github.com/onfido/onfido-sdk-ui/pull/152, a bug was introduced. Steps to reproduce are:

1. Open a browser that supports pdf preview
2. https://152-pr-onfido-sdk-ui-onfido.surge.sh
3. Upload a pdf

Problem:
3. You will see pdf flicker. This is due to the url pointing to file getting recreated at every time the `props` got changed (even if their actually value did not change).

Solution:
Check if the prop has changed in value before deciding to recreate the pdf url.