### PR TITLE
Raise file size limit to 10 MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Breaking changes result in a different major. UI changes that might break custom
 
 ### Changed
 - Internal: replaced the has_webcam checker with a more robust version that periodically checks if the state changed
+- Internal: Increased the file size upper limit to 10 MB.
 
 
 ## [0.15.0]

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -136,8 +136,8 @@ class Capture extends Component {
       return
     }
 
-    // The Onfido API only accepts files below 4MB
-    if (file.size > 4000000) {
+    // The Onfido API only accepts files below 10 MB
+    if (file.size > 10000000) {
       this.onFileSizeError()
       return
     }

--- a/src/components/Uploader/index.js
+++ b/src/components/Uploader/index.js
@@ -41,7 +41,7 @@ const ServerError = ({message}) =>
   <UploadError>{message}</UploadError>
 
 InvalidFileSize.defaultProps = {
-  message: 'The file size limit of 4MB has been exceeded. Please try again.'
+  message: 'The file size limit of 10 MB has been exceeded. Please try again.'
 }
 
 ServerError.defaultProps = {


### PR DESCRIPTION
Given we now resize images on platform we can raise the file size limit to match the limit on the API.