### PR TITLE
Clear docs and faces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Breaking changes result in a different major. UI changes that might break custom
 
 ### Fixed
 - Internal: Fixed problem on certain versions of Firefox that no longer supported the old version of getUserMedia
+- Internal: Fixed the `tearDown` method to clear the documents and faces currently in the store
 
 ### Changed
 - Internal: replaced the has_webcam checker with a more robust version that periodically checks if the state changed

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { h, render, Component } from 'preact'
 import { Provider } from 'react-redux'
-import { store, events } from 'onfido-sdk-core'
+import { store, events, actions } from 'onfido-sdk-core'
 import Modal from './components/Modal'
 import Router from './components/Router'
 import forEach from 'object-loops/for-each'
@@ -53,7 +53,7 @@ function bindEvents (options) {
 
       const takenCaptures = mapValues(captures, value => !!value)
       Tracker.sendEvent('completed flow', takenCaptures)
-      
+
       options.onComplete(captures)
     }
   }
@@ -116,6 +116,14 @@ Onfido.init = (opts) => {
     },
 
     tearDown() {
+      // TODO should use a actions.resetState() once onfido-sdk-core has been merged
+      // See https://github.com/onfido/onfido-sdk-ui/issues/158
+      [
+        { method: 'document', side: 'front' },
+        { method: 'document', side: 'back' },
+        { method: 'face', side: null }
+      ].forEach(actions.deleteCaptures);
+
       render(null, containerEl, this.element)
     }
   }


### PR DESCRIPTION
This PR sets up some action calls to clear the docs and faces currently captured in the SDK flow, when calling the `tearDown` method

This will mean that tearing down the SDK, and then remounting the SDK later, won't end up in a state where the re-mounted SDK has all of the captures from the last flow still present