### PR TITLE
Bug/cx 824 firefox lower resolution fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Breaking changes result in a different major. UI changes that might break custom
 - Internal: Fixed problem on certain versions of Firefox that no longer supported the old version of getUserMedia
 - Internal: Fixed the `tearDown` method to clear the documents and faces currently in the store
 - Internal: Fixed PDF preview issues on IE Edge, IE11 and mobile browsers.
+- Internal: Fixed lower resolution webcams not working on Firefox
 
 ### Changed
 - Internal: replaced the has_webcam checker with a more robust version that periodically checks if the state changed

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "react-modal-onfido": "1.5.2",
     "react-native-listener": "1.0.1",
     "react-redux": "4.4.6",
-    "react-webcam-onfido": "0.0.18",
+    "react-webcam-onfido": "0.0.19",
     "redux": "3.5.2",
     "supports-webp": "1.0.3",
     "visibilityjs": "1.2.4",

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -19,7 +19,7 @@ const Overlay = ({method, countDownRef}) => (
   functionalSwitch(method, {
     document: () => <DocumentOverlay />,
     face: () => (
-      <div>
+      <div className={style.overlay}>
         <Countdown ref={countDownRef} />
         <FaceOverlay />
       </div>
@@ -46,7 +46,6 @@ const UploadFallback = ({onUploadFallback}) => (
 const CameraPure = ({method, onUploadFallback, onUserMedia, faceCaptureClick, countDownRef, webcamRef, onWebcamError}) => (
   <div>
     <div className={style["video-overlay"]}>
-      <Overlay {...{method, countDownRef}}/>
       <Webcam
         className={style.video}
         audio={false}
@@ -54,6 +53,7 @@ const CameraPure = ({method, onUploadFallback, onUserMedia, faceCaptureClick, co
         height={720}
         {...{onUserMedia, ref: webcamRef, onFailure: onWebcamError}}
       />
+      <Overlay {...{method, countDownRef}}/>
       <UploadFallback {...{onUploadFallback}}/>
     </div>
     <Instructions {...{method, faceCaptureClick}}/>

--- a/src/components/Camera/style.css
+++ b/src/components/Camera/style.css
@@ -3,12 +3,32 @@
   position: relative;
   overflow: hidden;
   margin-top: -10px;
+  width: 100%;
+}
+
+.video-overlay:before {
+  content: "";
+  display: block;
+  padding-top: 76%;
+}
+
+.overlay {
+  width: 100%;
+  height: 100%;
+  top: 0;
+  position: absolute;
 }
 
 .video {
   max-width: 100%;
-  height: auto !important;
   display: block;
+  position: absolute;
+  width: auto;
+  height: 100%;
+  top: 0;
+  margin: auto;
+  object-fit: cover;
+  transform: scale(-1, 1);
 }
 
 .uploadFallback{

--- a/src/components/Camera/style.css
+++ b/src/components/Camera/style.css
@@ -28,7 +28,7 @@
   top: 0;
   margin: auto;
   object-fit: cover;
-  transform: scale(-1, 1);
+  /*Mirroring transform: scale(-1, 1); */
 }
 
 .uploadFallback{

--- a/src/components/Face/style.css
+++ b/src/components/Face/style.css
@@ -1,7 +1,13 @@
 .circle{
   width: 45%;
-  height: 80%;
+  max-height: 80%;
   border-radius: 100%;
+}
+
+.circle:before {
+    content: "";
+    display: block;
+    padding-top: 125%;
 }
 
 .instructions {


### PR DESCRIPTION
Related PR: https://github.com/onfido/react-webcam/pull/8

### Technical Considerations

Since we are using the webcam api `ideal` resolution, what it means is that it does not force the desired aspect ratio on the camera.
For webcam with an aspect ratio which is not 4:3, the layout breaks, since the layout was coded to adapt to the video aspect ratio.

Changes were made to make the video adapt to its container, which was now fixed to 4:3.

Also, the webcam has been mirrored, this was an added to benefit of refactoring the layout, mirroring became trivial.