### PR TITLE
added support for babel runtime ponyfills

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,7 +10,7 @@
     ["transform-react-jsx", { "pragma": "h" }],
     ["transform-runtime", {
       "helpers": false,
-      "polyfill": false,
+      "polyfill": true,
       "regenerator": true,
       "moduleName": "babel-runtime"
     }]

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "babel-plugin-transform-es2015-modules-umd": "^6.8.0",
     "babel-plugin-transform-react-jsx": "^6.6.5",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
     "cross-env": "^3.0.0",

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -34,22 +34,7 @@ export const preventDefaultOnClick = callback => event => {
 // Copied from https://github.com/muaz-khan/DetectRTC/blob/master/DetectRTC.js
 export const isDesktop = !(/Android|webOS|iPhone|iPad|iPod|BB10|BlackBerry|IEMobile|Opera Mini|Mobile|mobile/i.test(navigator.userAgent || ''))
 
-const hasPromises = (function(){
-  let promiseSupport = false;
-  try {
-      const promise = new Promise(() => {});
-      promiseSupport = true;
-  } catch (e) {}
-  return promiseSupport;
-})()
-
 const enumerateDevicesInternal = (onSuccess, onError) => {
-  //Devices that don't support Promises don't support getUserMedia as well
-  //So it's safe to fail in that case
-  if (!hasPromises){
-    onError({message:"Promise not supported"})
-    return;
-  }
   try {
     enumerateDevices().then(onSuccess).catch(onError);
   }

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -50,7 +50,12 @@ const enumerateDevicesInternal = (onSuccess, onError) => {
     onError({message:"Promise not supported"})
     return;
   }
-  enumerateDevices().then(onSuccess).catch(onError);
+  try {
+    enumerateDevices().then(onSuccess).catch(onError);
+  }
+  catch (exception){
+    onError(exception)
+  }
 }
 
 export const checkIfHasWebcam = onResult => {

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -77,7 +77,7 @@ const basePlugins = [
 
 const baseConfig = {
   context: `${__dirname}/src`,
-  entry: ["babel-polyfill", './index.js'],
+  entry: './index.js',
 
   resolve: {
     extensions: ['.jsx', '.js', '.json', '.less'],


### PR DESCRIPTION
This allows one to use babel polyfills without polluting the global space.
Instance methods will not work, but static methods work fine!

examples:

```javascript
const doesItInclude3 = array => array.includes(3)

doesItInclude3([1,2,3]) //will not work on IE
```

```javascript
const doesItInclude3 = array => Array.includes(array, 3)

doesItInclude3([1,2,3]) //will work on IE
```