### PR TITLE
Added id to captures and fixed file size error string

### DIFF
--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -60,9 +60,9 @@ class Capture extends Component {
     checkIfHasWebcam( hasWebcam => this.setState({hasWebcam}) )
   }
 
-  validateCapture = (id, valid) => {
+  validateCapture = (valid) => {
     const { actions, method } = this.props
-    actions.validateCapture({ id, valid, method})
+    actions.validateCapture({valid, method})
   }
 
   maxAutomaticCaptures = 3
@@ -76,7 +76,7 @@ class Capture extends Component {
   onServerResponse = (response) => {
     const { actions } = this.props
     const valid = response.valid
-    this.validateCapture(response.id, valid)
+    this.validateCapture(valid)
   }
 
   handleCapture = (blob, base64) => {
@@ -92,12 +92,9 @@ class Capture extends Component {
     })
   }
 
-  createPayload = (blob, base64) => ({
-    id: randomId(), blob, base64
-  })
+  createPayload = (blob, base64) => ({blob, base64})
 
-  createJSONPayload = ({id, base64}) =>
-    JSON.stringify({id, image: base64})
+  createJSONPayload = ({base64}) => JSON.stringify({image: base64})
 
   handleDocument(payload) {
     const { token, documentType, unprocessedCaptures } = this.props
@@ -228,7 +225,7 @@ const Title = ({method, side, useCapture}) => functionalSwitch(method, {
 //TODO move to react instead of preact, since preact has issues handling pure components
 //IF this component is pure some components, like Camera,
 //will not have the componentWillUnmount method called
-const CaptureMode = impurify(({method, side, useCapture, ...other}) => (
+const CaptureMode = impurify(({method, side, useCapture, uploadInProgress, ...other}) => (
   <div>
     <Title {...{method, side, useCapture}}/>
     {useCapture ?
@@ -246,7 +243,7 @@ const CaptureScreen = ({method, side, validCaptures, useCapture, advancedValidat
   })}>
     {hasCapture ?
       uploadInProgress ? <ProcessingApiRequest /> : <Confirm {...{ method, side, validCaptures, token, advancedValidation, onApiUpload, onApiError, ...other}} /> :
-      <CaptureMode {...{method, side, useCapture, ...other}} />
+      <CaptureMode {...{method, side, useCapture, uploadInProgress, ...other}} />
     }
   </div>)
 }

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -223,7 +223,7 @@ class Capture extends Component {
         onUploadFallback: this.onUploadFallback,
         onImageSelected: this.onImageFileSelected,
         onWebcamError: this.onWebcamError,
-        onApiUpload: this.uploadCaptureToOnfido,
+        onConfirm: this.uploadCaptureToOnfido,
         advancedValidation: this.state.advancedValidation,
         error: this.state.error,
         uploadInProgress,
@@ -250,17 +250,22 @@ const CaptureMode = impurify(({method, side, useCapture, ...other}) => (
   </div>
 ))
 
-const CaptureScreen = ({method, side, validCaptures, useCapture, uploadInProgress, onApiUpload, ...other}) => {
+const CaptureScreen = ({validCaptures, useCapture, uploadInProgress, ...other}) => {
   const hasCapture = validCaptures.length > 0
-  return (<div className={classNames({
-    [style.camera]: useCapture && !hasCapture,
-    [style.uploader]: !useCapture && !hasCapture
-  })}>
-    { uploadInProgress ? <ProcessingApiRequest /> :
-        hasCapture ? <Confirm {...{ method, side, validCaptures, onApiUpload, ...other}} /> :
-        <CaptureMode {...{method, side, useCapture, ...other}} />
+  return (
+    <div
+      className={classNames({
+        [style.camera]: useCapture && !hasCapture,
+        [style.uploader]: !useCapture && !hasCapture})}
+    >
+    { uploadInProgress ?
+        <ProcessingApiRequest /> :
+        hasCapture ?
+          <Confirm {...{validCaptures,...other}} /> :
+          <CaptureMode {...{useCapture, ...other}} />
     }
-  </div>)
+    </div>
+  )
 }
 
 const mapStateToProps = (state, props) => {

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -75,7 +75,7 @@ class Capture extends Component {
         this.confirmEvent(method, side)
         nextStep()
       },
-      (error) => this.onApiError(error)
+      this.onApiError
     )
   }
 

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -209,7 +209,6 @@ class Capture extends Component {
         onApiError: this.onApiError,
         onApiUpload: this.onApiUpload,
         advancedValidation: this.state.advancedValidation,
-        uploading: hasUnprocessedCaptures,
         error: this.state.error,
         uploadInProgress,
         ...other}}/>

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -245,7 +245,7 @@ const CaptureMode = impurify(({method, side, useCapture, uploadInProgress, ...ot
     <Title {...{method, side, useCapture}}/>
     {useCapture ?
       <Camera {...{method, ...other}}/> :
-      <Uploader {...{method,...other}}/>
+      <Uploader {...{method, ...other}}/>
     }
   </div>
 ))
@@ -256,9 +256,9 @@ const CaptureScreen = ({method, side, validCaptures, useCapture, uploadInProgres
     [style.camera]: useCapture && !hasCapture,
     [style.uploader]: !useCapture && !hasCapture
   })}>
-    {hasCapture ?
-      uploadInProgress ? <ProcessingApiRequest /> : <Confirm {...{ method, side, validCaptures, onApiUpload, ...other}} /> :
-      <CaptureMode {...{method, side, useCapture, uploadInProgress, ...other}} />
+    { uploadInProgress ? <ProcessingApiRequest /> :
+        hasCapture ? <Confirm {...{ method, side, validCaptures, onApiUpload, ...other}} /> :
+        <CaptureMode {...{method, side, useCapture, ...other}} />
     }
   </div>)
 }

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -240,7 +240,7 @@ const Title = ({method, side, useCapture}) => functionalSwitch(method, {
 //TODO move to react instead of preact, since preact has issues handling pure components
 //IF this component is pure some components, like Camera,
 //will not have the componentWillUnmount method called
-const CaptureMode = impurify(({method, side, useCapture, uploadInProgress, ...other}) => (
+const CaptureMode = impurify(({method, side, useCapture, ...other}) => (
   <div>
     <Title {...{method, side, useCapture}}/>
     {useCapture ?

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -95,8 +95,7 @@ class Capture extends Component {
     actions.createCapture({method, capture: payload, maxCaptures: this.maxAutomaticCaptures})
   }
 
-  onValidationServiceResponse = (response) => {
-    const {id, valid} = response
+  onValidationServiceResponse = (id, {valid}) => {
     const { actions, method } = this.props
     actions.validateCapture({id, valid, method})
   }
@@ -126,7 +125,7 @@ class Capture extends Component {
     }
     payload = {...payload, documentType}
     if (this.props.useWebcam) {
-      postToBackend(this.createJSONPayload(payload), token, this.onValidationServiceResponse, this.onServerError)
+      postToBackend(this.createJSONPayload(payload), token, (response) => this.onValidationServiceResponse(payload.id, response), this.onServerError)
       this.setState({advancedValidation: false})
     }
     else {

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -125,7 +125,10 @@ class Capture extends Component {
     }
     payload = {...payload, documentType}
     if (this.props.useWebcam) {
-      postToBackend(this.createJSONPayload(payload), token, (response) => this.onValidationServiceResponse(payload.id, response), this.onServerError)
+      postToBackend(this.createJSONPayload(payload), token,
+        (response) => this.onValidationServiceResponse(payload.id, response),
+        this.onServerError
+      )
       this.setState({advancedValidation: false})
     }
     else {

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -2,10 +2,8 @@ import { h, Component } from 'preact'
 import { events } from '../../core'
 import theme from '../Theme/style.css'
 import style from './style.css'
-import {impurify} from '../utils'
 import { isOfFileType } from '../utils/file'
 import {preventDefaultOnClick} from '../utils'
-import { postToOnfido } from '../utils/onfidoApi'
 import PdfViewer from './PdfPreview'
 
 const CaptureViewerPure = ({capture:{blob, base64, previewUrl}}) =>
@@ -84,37 +82,14 @@ const Previews = ({capture, retakeAction, confirmAction} ) =>
 
 
 export default class Confirm extends Component {
-  completeCapture(onfidoId, method, side, capture, confirmCapture, nextStep) {
-    confirmCapture({method, id: capture.id, onfidoId})
-    confirmEvent(method, side)
-    nextStep()
-  }
-
-  startApiUpload(method, side, capture, token, confirmCapture, nextStep, advancedValidation, onApiUpload, onApiError) {
-    onApiUpload()
-    postToOnfido(capture, method, token, advancedValidation,
-      (apiResponse) => this.completeCapture(apiResponse.id, method, side, capture, confirmCapture, nextStep),
-      onApiError
-    )
-  }
-
-  render({nextStep, method, side, validCaptures, token, onApiUpload, onApiError,
-    advancedValidation, actions: {deleteCaptures, confirmCapture}}) {
+  render({method, side, validCaptures, onApiUpload, actions: {deleteCaptures}}) {
       const capture = validCaptures[0]
       return (
         <Previews
           capture={capture}
           retakeAction={() => deleteCaptures({method, side})}
-          confirmAction={() => this.startApiUpload(method, side, capture, token, confirmCapture, nextStep, advancedValidation, onApiUpload, onApiError) }
+          confirmAction={() => onApiUpload()}
         />
       )
     }
-}
-
-const confirmEvent = (method, side) => {
-  if (method === 'document') {
-    if (side === 'front') events.emit('documentCapture')
-    else if (side === 'back') events.emit('documentBackCapture')
-  }
-  else if (method === 'face') events.emit('faceCapture')
 }

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -84,7 +84,8 @@ const Previews = ({capture, retakeAction, confirmAction} ) =>
 
 
 export default class Confirm extends Component {
-  completeCapture(method, side, capture, confirmCapture, nextStep) {
+  completeCapture(id, method, side, capture, confirmCapture, nextStep) {
+    capture.id = id
     confirmCapture({method, id: capture.id})
     confirmEvent(method, side)
     nextStep()
@@ -92,7 +93,7 @@ export default class Confirm extends Component {
 
   startApiUpload(method, side, capture, token, confirmCapture, nextStep, advancedValidation, onApiUpload, onApiError) {
     onApiUpload()
-    postToOnfido(capture, method, token, advancedValidation, () => this.completeCapture(method, side, capture, confirmCapture, nextStep), onApiError)
+    postToOnfido(capture, method, token, advancedValidation, ({id}) => this.completeCapture(id, method, side, capture, confirmCapture, nextStep), onApiError)
   }
 
   render({nextStep, method, side, validCaptures, token, onApiUpload, onApiError,

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -81,15 +81,11 @@ const Previews = ({capture, retakeAction, confirmAction} ) =>
   </div>
 
 
-export default class Confirm extends Component {
-  render({method, side, validCaptures, onApiUpload, actions: {deleteCaptures}}) {
-      const capture = validCaptures[0]
-      return (
-        <Previews
-          capture={capture}
-          retakeAction={() => deleteCaptures({method, side})}
-          confirmAction={() => onApiUpload()}
-        />
-      )
-    }
-}
+const Confirm = ({method, side, validCaptures:[capture], onConfirm, actions: {deleteCaptures}}) =>
+  <Previews
+    capture={capture}
+    retakeAction={() => deleteCaptures({method, side})}
+    confirmAction={onConfirm}
+  />
+
+export default Confirm

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -85,8 +85,7 @@ const Previews = ({capture, retakeAction, confirmAction} ) =>
 
 export default class Confirm extends Component {
   completeCapture(id, method, side, capture, confirmCapture, nextStep) {
-    capture.id = id
-    confirmCapture({method, id: capture.id})
+    confirmCapture({method, id: capture.id, onfidoId: id})
     confirmEvent(method, side)
     nextStep()
   }

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -84,15 +84,18 @@ const Previews = ({capture, retakeAction, confirmAction} ) =>
 
 
 export default class Confirm extends Component {
-  completeCapture(id, method, side, capture, confirmCapture, nextStep) {
-    confirmCapture({method, id: capture.id, onfidoId: id})
+  completeCapture(onfidoId, method, side, capture, confirmCapture, nextStep) {
+    confirmCapture({method, id: capture.id, onfidoId})
     confirmEvent(method, side)
     nextStep()
   }
 
   startApiUpload(method, side, capture, token, confirmCapture, nextStep, advancedValidation, onApiUpload, onApiError) {
     onApiUpload()
-    postToOnfido(capture, method, token, advancedValidation, ({id}) => this.completeCapture(id, method, side, capture, confirmCapture, nextStep), onApiError)
+    postToOnfido(capture, method, token, advancedValidation,
+      (apiResponse) => this.completeCapture(apiResponse.id, method, side, capture, confirmCapture, nextStep),
+      onApiError
+    )
   }
 
   render({nextStep, method, side, validCaptures, token, onApiUpload, onApiError,

--- a/src/components/Theme/style.css
+++ b/src/components/Theme/style.css
@@ -84,7 +84,6 @@
 
 .overlay {
   display: flex;
-  position: absolute;
   width: 100%;
   height: 100%;
 }

--- a/src/components/Uploader/index.js
+++ b/src/components/Uploader/index.js
@@ -26,7 +26,7 @@ const UploadError = ({error}) => {
 //TODO move to react instead of preact, since preact has issues handling pure components
 //IF this component is exported as pure,
 //some components like Camera will not have componentWillUnmount called
-export const Uploader = impurify(({method, onImageSelected, uploadInProgress, error}) => (
+export const Uploader = impurify(({method, onImageSelected, error}) => (
   <Dropzone
     onDrop={([ file ])=> {
       //removes a memory leak created by react-dropzone
@@ -37,6 +37,6 @@ export const Uploader = impurify(({method, onImageSelected, uploadInProgress, er
     multiple={false}
     className={style.dropzone}
   >
-    {uploadInProgress ? <UploadProcessing /> : <UploadInstructions error={error}/> }
+    {<UploadInstructions error={error}/> }
   </Dropzone>
 ))

--- a/src/components/Uploader/index.js
+++ b/src/components/Uploader/index.js
@@ -26,7 +26,7 @@ const UploadError = ({error}) => {
 //TODO move to react instead of preact, since preact has issues handling pure components
 //IF this component is exported as pure,
 //some components like Camera will not have componentWillUnmount called
-export const Uploader = impurify(({method, onImageSelected, uploading, error}) => (
+export const Uploader = impurify(({method, onImageSelected, uploadInProgress, error}) => (
   <Dropzone
     onDrop={([ file ])=> {
       //removes a memory leak created by react-dropzone
@@ -37,6 +37,6 @@ export const Uploader = impurify(({method, onImageSelected, uploading, error}) =
     multiple={false}
     className={style.dropzone}
   >
-    {uploading ? <UploadProcessing /> : <UploadInstructions error={error}/> }
+    {uploadInProgress ? <UploadProcessing /> : <UploadInstructions error={error}/> }
   </Dropzone>
 ))

--- a/src/components/strings/errors.js
+++ b/src/components/strings/errors.js
@@ -1,7 +1,7 @@
 export const errors = {
   'INVALID_CAPTURE': 'We are unable to detect an identity document in this image. Please try again.',
   'INVALID_TYPE': 'The file uploaded has an unsupported file type.',
-  'INVALID_SIZE': 'The file size limit of 4MB has been exceeded. Please try again.',
+  'INVALID_SIZE': 'The file size limit of 10MB has been exceeded. Please try again.',
   'NO_FACE_ERROR': 'No face detected in the picture',
   'MULTIPLE_FACES_ERROR': 'Multiple faces detected in the picture',
   'SERVER_ERROR': 'There was an error connecting to the server. Please wait and try again later.'

--- a/src/core/store/reducers/captures.js
+++ b/src/core/store/reducers/captures.js
@@ -1,5 +1,4 @@
 import * as constants from '../../constants'
-import objectAssign from 'object-assign'
 
 const initialState = {
   document: [],

--- a/src/core/store/reducers/captures.js
+++ b/src/core/store/reducers/captures.js
@@ -7,7 +7,7 @@ const initialState = {
 }
 
 const changeCapturesThatMatchValidator = (captures, validator, newCaptureDiffState) => captures.map( capture =>
-  validator(capture) ? objectAssign({}, capture, newCaptureDiffState) : capture
+  validator(capture) ? {...capture, ...newCaptureDiffState} : capture
 )
 
 export function captures(state = initialState, action) {
@@ -31,7 +31,7 @@ export function captures(state = initialState, action) {
       return changeStateWithNewCaptures(validatedCaptures)
     }
     case constants.CAPTURE_CONFIRM: {
-      const confirmedCaptures = changeCapturesThatMatchPayloadId({ confirmed: true })
+      const confirmedCaptures = changeCapturesThatMatchPayloadId({ confirmed: true, onfidoId: payload.onfidoId })
       return changeStateWithNewCaptures(confirmedCaptures)
     }
     case constants.CAPTURE_DELETE: {

--- a/src/index.js
+++ b/src/index.js
@@ -30,8 +30,8 @@ const onfidoRender = (options, el, merge) => {
   return render( <Container options={options}/>, el, merge)
 }
 
-const stripOneCapture = ({blob, documentType, id, side}) => {
-  const capture = {id, blob}
+const stripOneCapture = ({blob, documentType, onfidoId, side}) => {
+  const capture = {id: onfidoId, blob}
   if (documentType) capture.documentType = documentType
   if (side) capture.side = side
   return capture


### PR DESCRIPTION
In this PR for all captures we are including the id returned by the API on successful upload.

Fixed issue with webcam overlay for document autocapture

Re `validateCapture` action refactoring:
As discussed, we are using an action called `validateCapture` to mark the capture that can be confirmed by the user as processed and suitable for upload. The name `validateCapture` is no longer meaningful and can be misleading given that we are performing the validation after the capture has been confirmed (on API upload). The refactoring is not trivial as the value added by this action is used across multiple selectors, therefore I will handle this as part of another story.