### PR TITLE
Captures to fit within viewport

### DIFF
--- a/src/components/Confirm/style.css
+++ b/src/components/Confirm/style.css
@@ -12,7 +12,7 @@
   max-height: 35vh;
   padding: 0 10px;
   @media (max-width: 30em) {
-    max-height: 48vh;
+    max-height: 40vh;
   }
 }
 

--- a/src/components/Confirm/style.css
+++ b/src/components/Confirm/style.css
@@ -1,3 +1,6 @@
+.title {
+  padding-bottom: 0px;
+}
 .captures {
   margin-bottom: 1.5rem;
 }
@@ -6,6 +9,11 @@
   max-width: 92%;
   display: block;
   margin: 0 auto;
+  max-height: 35vh;
+  padding: 0 10px;
+  @media (max-width: 30em) {
+    max-height: 48vh;
+  }
 }
 
 .btn-outline {


### PR DESCRIPTION
Captures should fit within viewport and should allow enough space for the actions to be visible. 