### PR TITLE
tracking sdk version

### DIFF
--- a/src/Tracker/index.js
+++ b/src/Tracker/index.js
@@ -23,7 +23,7 @@ const setUp = () => {
 
   // configure tracker
   woopra.config({
-   domain: 'onfido-js-sdk.com',
+   domain: process.env.WOOPRA_DOMAIN,
    cookie_name: 'onfido-js-sdk-woopra',
    cookie_domain: location.hostname,
    referer: location.href

--- a/src/Tracker/index.js
+++ b/src/Tracker/index.js
@@ -2,6 +2,7 @@ import { h, Component } from 'preact'
 import Raven from 'raven-js'
 import {cleanFalsy, wrapArray} from '../components/utils/array'
 require('script-loader!../../node_modules/wpt/wpt.js')
+import mapObject from 'object-loops/map'
 
 const RavenTracker = Raven.config('https://6e3dc0335efc49889187ec90288a84fd@sentry.io/109946')
 
@@ -36,8 +37,15 @@ const track = () => {
   RavenTracker.install()
 }
 
+const formatProperties = properties => mapObject(properties,
+  value => typeof value === 'object' ? JSON.stringify(value) : value
+)
+
 const sendEvent = (eventName, properties) =>
-  woopra.track(eventName, {...properties, sdk_version: process.env.SDK_VERSION })
+  woopra.track(
+    eventName,
+    {...formatProperties(properties), sdk_version: process.env.SDK_VERSION }
+  )
 
 const screeNameHierarchyFormat = (screeNameHierarchy) =>
   `screen_${cleanFalsy(screeNameHierarchy).join('_')}`

--- a/src/Tracker/index.js
+++ b/src/Tracker/index.js
@@ -36,9 +36,8 @@ const track = () => {
   RavenTracker.install()
 }
 
-const sendEvent = (eventName, properties) => {
-  woopra.track(eventName, properties)
-}
+const sendEvent = (eventName, properties) =>
+  woopra.track(eventName, {...properties, sdk_version: process.env.SDK_VERSION })
 
 const screeNameHierarchyFormat = (screeNameHierarchy) =>
   `screen_${cleanFalsy(screeNameHierarchy).join('_')}`

--- a/src/Tracker/index.js
+++ b/src/Tracker/index.js
@@ -29,6 +29,11 @@ const setUp = () => {
    referer: location.href
   });
 
+  woopra.identify({
+    sdk_version: process.env.SDK_VERSION,
+    client: window.location.hostname
+  });
+
   Raven.TraceKit.collectWindowErrors = true//TODO scope exceptions to sdk code only
 }
 
@@ -42,10 +47,7 @@ const formatProperties = properties => mapObject(properties,
 )
 
 const sendEvent = (eventName, properties) =>
-  woopra.track(
-    eventName,
-    {...formatProperties(properties), sdk_version: process.env.SDK_VERSION }
-  )
+  woopra.track(eventName, formatProperties(properties))
 
 const screeNameHierarchyFormat = (screeNameHierarchy) =>
   `screen_${cleanFalsy(screeNameHierarchy).join('_')}`

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -76,7 +76,11 @@
             {
               type:'welcome',
               options:{
-                title:'Open your new bank account'
+                title:'Open your new bank account',
+                descriptions: [
+                  'To open a bank account, we will need to verify your identity.',
+                  'It will only take a couple of minutes.'
+                ]
               }
             },
             {

--- a/src/index.js
+++ b/src/index.js
@@ -101,6 +101,7 @@ const formatOptions = ({steps, ...otherOptions}) => ({
 
 
 Onfido.init = (opts) => {
+  console.log("onfido_sdk_version", process.env.SDK_VERSION)
   Tracker.track()
   const options = formatOptions({ ...defaults, ...opts })
   const eventListenersMap = bindEvents(options)

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -92,7 +92,7 @@ const basePlugins = [
     'ONFIDO_API_URL': CONFIG.ONFIDO_API_URL,
     'ONFIDO_SDK_URL': CONFIG.ONFIDO_SDK_URL,
     'SDK_VERSION': packageJson.version,
-    'WOOPRA_DOMAIN': `${DEV_OR_STAGING? 'dev-':''}onfido-js-sdk.com`
+    'WOOPRA_DOMAIN': `${DEV_OR_STAGING ? 'dev-':''}onfido-js-sdk.com`
   }))
 ]
 

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -5,6 +5,8 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 import autoprefixer from 'autoprefixer';
 import customMedia from 'postcss-custom-media';
 import url from 'postcss-url';
+import mapObject from 'object-loops/map'
+import mapKeys from 'object-loops/map-keys'
 
 // ENV can be one of: development | staging | production
 const ENV = process.env.NODE_ENV || 'production'
@@ -15,6 +17,7 @@ const WEBPACK_ENV = PRODUCTION_BUILD ? 'production' : 'development'
 // For production we should use the production API, for staging and development
 // we should use the staging API
 const PRODUCTION_API = ENV === 'production'
+const DEV_OR_STAGING = ENV !== 'production'
 
 const baseRules = [{
   test: /\.jsx?$/,
@@ -76,14 +79,21 @@ const STAGING_CONFIG = {
 
 const CONFIG = PRODUCTION_API ? PROD_CONFIG : STAGING_CONFIG
 
+const formatDefineHash = defineHash =>
+  mapObject(
+    mapKeys(defineHash, key => `process.env.${key}`),
+    value => JSON.stringify(value)
+  )
+
 const basePlugins = [
   new webpack.NoEmitOnErrorsPlugin(),
-  new webpack.DefinePlugin({
-    'process.env.NODE_ENV': JSON.stringify(WEBPACK_ENV),
-    'process.env.ONFIDO_API_URL': JSON.stringify(CONFIG.ONFIDO_API_URL),
-    'process.env.ONFIDO_SDK_URL': JSON.stringify(CONFIG.ONFIDO_SDK_URL),
-    'process.env.SDK_VERSION': JSON.stringify(packageJson.version)
-  })
+  new webpack.DefinePlugin(formatDefineHash({
+    'NODE_ENV': WEBPACK_ENV,
+    'ONFIDO_API_URL': CONFIG.ONFIDO_API_URL,
+    'ONFIDO_SDK_URL': CONFIG.ONFIDO_SDK_URL,
+    'SDK_VERSION': packageJson.version,
+    'WOOPRA_DOMAIN': `${DEV_OR_STAGING? 'dev-':''}onfido-js-sdk.com`
+  }))
 ]
 
 const baseConfig = {


### PR DESCRIPTION
### Problem

We were not able to determine which sdk was being used by a client.


### Technical considerations

All events now have an `sdk_version` to its properties.

#### Freebies

Nested options can now be tracked.