### PR TITLE
Feature/state reset cx 1061

### DIFF
--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -58,11 +58,13 @@ class Capture extends Component {
     const { actions, method, side, nextStep } = this.props
     payload.side = side
     actions.createCapture({method, capture: payload, maxCaptures: this.maxAutomaticCaptures})
-    nextStep()
+    if (payload.valid) nextStep()
   }
 
   onValidationServiceResponse = (payload, {valid}) => {
-    if (valid) this.createCaptureAndProceed({...payload, valid})
+    const { actions, method, nextStep } = this.props
+    actions.validateCapture({id: payload.id, valid, method})
+    if (valid) nextStep()
   }
 
   handleCapture = (blob, base64) => {
@@ -83,7 +85,7 @@ class Capture extends Component {
   createJSONPayload = ({id, base64}) => JSON.stringify({id, image: base64})
 
   handleDocument(payload) {
-    const { token, documentType, unprocessedCaptures} = this.props
+    const { token, documentType, unprocessedCaptures } = this.props
     if (unprocessedCaptures.length === this.maxAutomaticCaptures){
       console.warn('Server response is slow, waiting for responses before uploading more')
       return
@@ -96,8 +98,9 @@ class Capture extends Component {
       )
     }
     else {
-      this.createCaptureAndProceed({...payload, valid: true})
+      payload.valid = true
     }
+    this.createCaptureAndProceed({...payload})
   }
 
   handleFace(payload) {

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -84,22 +84,22 @@ class Capture extends Component {
 
   createJSONPayload = ({id, base64}) => JSON.stringify({id, image: base64})
 
-  handleDocument(payload) {
-    const { token, documentType, unprocessedCaptures } = this.props
+  handleAutocapture(payload){
+    const { token, unprocessedCaptures } = this.props
     if (unprocessedCaptures.length === this.maxAutomaticCaptures){
       console.warn('Server response is slow, waiting for responses before uploading more')
       return
     }
+    postToBackend(this.createJSONPayload(payload), token,
+      (response) => this.onValidationServiceResponse(payload, response),
+      this.onValidationServerError
+    )
+  }
+
+  handleDocument(payload) {
+    const { documentType } = this.props
     payload = {...payload, documentType}
-    if (this.props.useWebcam) {
-      postToBackend(this.createJSONPayload(payload), token,
-        (response) => this.onValidationServiceResponse(payload, response),
-        this.onValidationServerError
-      )
-    }
-    else {
-      payload.valid = true
-    }
+    this.props.useWebcam ? this.handleAutocapture(payload) : payload.valid = true
     this.createCaptureAndProceed({...payload})
   }
 

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -184,7 +184,6 @@ class Confirm extends Component  {
       <Previews
         capture={validCaptures[0]}
         retakeAction={() => {
-          this.deleteCaptures()
           previousStep()
         }}
         confirmAction={this.uploadCaptureToOnfido}

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -10,7 +10,7 @@ import { postToOnfido } from '../utils/onfidoApi'
 import PdfViewer from './PdfPreview'
 import Error from '../Error'
 import Spinner from '../Spinner'
-import { sendError, trackComponentAndMode } from '../../Tracker'
+import { sendError, trackComponentAndMode, appendToTracking } from '../../Tracker'
 
 const CaptureViewerPure = ({capture:{blob, base64, previewUrl}}) =>
   <div className={style.captures}>
@@ -204,11 +204,16 @@ const TrackedConfirmComponent = trackComponentAndMode(Confirm, 'confirmation', '
 
 const MapConfirm = connect(mapStateToProps)(TrackedConfirmComponent)
 
-export const DocumentFrontConfirm = (props) =>
+const DocumentFrontWrapper = (props) =>
   <MapConfirm {...props} method= 'document' side= 'front' />
 
-export const DocumentBackConfrim = (props) =>
+const DocumentBackWrapper = (props) =>
   <MapConfirm {...props} method= 'document' side= 'back' />
 
-export const FaceConfirm = (props) =>
+const FaceConfirm = (props) =>
   <MapConfirm {...props} method= 'face' />
+
+const DocumentFrontConfirm = appendToTracking(DocumentFrontWrapper, 'front')
+const DocumentBackConfrim = appendToTracking(DocumentBackWrapper, 'back')
+
+export { DocumentFrontConfirm, DocumentBackConfrim, FaceConfirm }

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -1,13 +1,16 @@
 import { h, Component } from 'preact'
-import { events } from '../../core'
+import { events, selectors } from '../../core'
+import { connect } from 'react-redux'
 import theme from '../Theme/style.css'
 import style from './style.css'
 import classNames from 'classnames'
 import { isOfFileType } from '../utils/file'
 import {preventDefaultOnClick} from '../utils'
+import { postToOnfido } from '../utils/onfidoApi'
 import PdfViewer from './PdfPreview'
 import Error from '../Error'
-import { trackComponentAndMode } from '../../Tracker'
+import Spinner from '../Spinner'
+import { sendError, trackComponentAndMode } from '../../Tracker'
 
 const CaptureViewerPure = ({capture:{blob, base64, previewUrl}}) =>
   <div className={style.captures}>
@@ -100,15 +103,112 @@ const Previews = ({capture, retakeAction, confirmAction, error} ) =>
     <Actions retakeAction={retakeAction} confirmAction={confirmAction} error={error} />
   </div>
 
-const Confirm = ({method, side, validCaptures:[capture], onConfirm, error, onRetake, actions: {deleteCaptures}}) =>
-  <Previews
-    capture={capture}
-    retakeAction={() => {
-      deleteCaptures({method, side})
-      onRetake()
-    }}
-    confirmAction={onConfirm}
-    error={error}
-  />
+const ProcessingApiRequest = () =>
+  <div className={theme.center}>
+    <Spinner />
+  </div>
 
-export default trackComponentAndMode(Confirm, 'confirmation', 'error')
+class Confirm extends Component  {
+
+  constructor(props){
+    super(props)
+    this.state = { uploadInProgress: false }
+  }
+
+  setError = error => this.setState({error})
+
+  deleteCaptures = () => {
+    const {method, side, actions: {deleteCaptures}} = this.props
+    deleteCaptures({method, side})
+  }
+
+  onfidoErrorFieldMap = ([key, val]) => {
+    if (key === 'document_detection') return 'INVALID_CAPTURE'
+    // on corrupted PDF or other unsupported file types
+    if (key === 'file') return 'INVALID_TYPE'
+    // hit on PDF/invalid file type submission for face detection
+    if (key === 'attachment' || key === 'attachment_content_type') return 'UNSUPPORTED_FILE'
+    if (key === 'face_detection') {
+      return val.indexOf('Multiple faces') === -1 ? 'NO_FACE_ERROR' : 'MULTIPLE_FACES_ERROR'
+    }
+  }
+
+  onfidoErrorReduce = ({fields}) => {
+    const [first] = Object.entries(fields).map(this.onfidoErrorFieldMap)
+    return first
+  }
+
+  onApiError = ({status, response}) => {
+    let errorKey;
+    if (status === 422){
+      errorKey = this.onfidoErrorReduce(response.error)
+    }
+    else {
+      sendError(`${status} - ${response}`)
+      errorKey = 'SERVER_ERROR'
+    }
+
+    this.setState({uploadInProgress: false})
+    this.setError(errorKey)
+  }
+
+  confirmEvent = (method, side) => {
+    if (method === 'document') {
+      if (side === 'front') events.emit('documentCapture')
+      else if (side === 'back') events.emit('documentBackCapture')
+    }
+    else if (method === 'face') events.emit('faceCapture')
+  }
+
+  confirmAndProceed = (apiResponse, id) => {
+    const {method, side, nextStep, actions: {confirmCapture}} = this.props
+    confirmCapture({method, id, onfidoId: apiResponse.id})
+    this.confirmEvent(method, side)
+    nextStep()
+  }
+
+  uploadCaptureToOnfido = () => {
+    this.setState({uploadInProgress: true})
+    const {validCaptures, method, side, token, previousStep} = this.props
+    const capture = validCaptures[0]
+
+    postToOnfido(capture, method, token,
+      (apiResponse) => this.confirmAndProceed(apiResponse, capture.id),
+      this.onApiError
+    )
+  }
+
+  render = ({validCaptures, previousStep}) => (
+    this.state.uploadInProgress ?
+      <ProcessingApiRequest /> :
+      <Previews
+        capture={validCaptures[0]}
+        retakeAction={() => {
+          this.deleteCaptures()
+          previousStep()
+        }}
+        confirmAction={this.uploadCaptureToOnfido}
+        error={this.state.error}
+      />
+  )
+}
+
+const mapStateToProps = (state, props) => {
+  return {
+    validCaptures: selectors.currentValidCaptures(state, props),
+    unprocessedCaptures: selectors.unprocessedCaptures(state, props)
+  }
+}
+
+const TrackedConfirmComponent = trackComponentAndMode(Confirm, 'confirmation', 'error')
+
+const MapConfirm = connect(mapStateToProps)(TrackedConfirmComponent)
+
+export const DocumentFrontConfirm = (props) =>
+  <MapConfirm {...props} method= 'document' side= 'front' />
+
+export const DocumentBackConfrim = (props) =>
+  <MapConfirm {...props} method= 'document' side= 'back' />
+
+export const FaceConfirm = (props) =>
+  <MapConfirm {...props} method= 'face' />

--- a/src/components/Router/StepComponentMap.js
+++ b/src/components/Router/StepComponentMap.js
@@ -2,6 +2,7 @@ import { h, Component } from 'preact'
 import Welcome from '../Welcome'
 import Select from '../Select'
 import {FrontDocumentCapture, BackDocumentCapture, FaceCapture} from '../Capture'
+import {DocumentFrontConfirm, DocumentBackConfrim, FaceConfirm} from '../Confirm'
 import Complete from '../Complete'
 
 export const createComponentList = (steps, documentType) => {
@@ -12,7 +13,7 @@ export const createComponentList = (steps, documentType) => {
 const createComponent = (step, documentType) => {
   const stepMap = {
     welcome: () => [Welcome],
-    face: () => [FaceCapture],
+    face: () => [FaceCapture, FaceConfirm],
     document: () => createDocumentComponents(documentType),
     complete: () => [Complete]
   }
@@ -23,9 +24,9 @@ const createComponent = (step, documentType) => {
 
 const createDocumentComponents = (documentType) => {
   const double_sided_docs = ['driving_licence', 'national_identity_card']
-  const frontDocumentFlow = [Select,FrontDocumentCapture]
+  const frontDocumentFlow = [Select, FrontDocumentCapture, DocumentFrontConfirm]
   if (Array.includes(double_sided_docs, documentType)) {
-    return [...frontDocumentFlow, BackDocumentCapture]
+    return [...frontDocumentFlow, BackDocumentCapture, DocumentBackConfrim]
   }
   return frontDocumentFlow
 }

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -22,20 +22,26 @@ class Router extends Component {
   }
 
   nextStep = () => {
-    const currentStep = this.state.step
-    this.setStepIndex(currentStep + 1)
-  }
-
-  setStepIndex = (newStepIndex) => {
     const components = this.state.componentsList
+    const currentStep = this.state.step
+    const newStepIndex = currentStep + 1
     if (components.length === newStepIndex){
       events.emit('complete')
     }
     else {
-      const state = { step: newStepIndex }
-      const path = `${location.pathname}${location.search}${location.hash}`
-      history.push(path, state)
+      this.setStepIndex(newStepIndex)
     }
+  }
+
+  previousStep = () => {
+    const currentStep = this.state.step
+    this.setStepIndex(currentStep - 1)
+  }
+
+  setStepIndex = (newStepIndex) => {
+    const state = { step: newStepIndex }
+    const path = `${location.pathname}${location.search}${location.hash}`
+    history.push(path, state)
   }
 
   trackScreen = (screenNameHierarchy, properties = {}) => {
@@ -71,6 +77,7 @@ class Router extends Component {
         <CurrentComponent
           {...{...componentBlob.step.options, ...globalUserOptions, ...otherProps}}
           nextStep = {this.nextStep}
+          previousStep = {this.previousStep}
           trackScreen = {this.trackScreen}/>
       </div>
     )

--- a/src/components/utils/onfidoApi.js
+++ b/src/components/utils/onfidoApi.js
@@ -5,7 +5,7 @@ import { humanizeField } from '../utils'
 
 const formatError = ({response, status}) => ({status, response: JSON.parse(response)})
 
-export const postToOnfido = ({blob, documentType, side}, captureType, token, advanced_validation, onSuccess, onError) => {
+export const postToOnfido = ({blob, documentType, side}, captureType, token, onSuccess, onError) => {
   if (captureType === 'face') {
     return sendFile(
       {blob},
@@ -16,7 +16,7 @@ export const postToOnfido = ({blob, documentType, side}, captureType, token, adv
     )
   }
   sendFile(
-    {blob, type: documentType, side, advanced_validation},
+    {blob, type: documentType, side, advanced_validation: true},
     'documents',
     token,
     onSuccess,


### PR DESCRIPTION
In this PR we make the Confirm component part of the face and capture step, this way the router will keep track of the history for each screen of the capture process. On click of the browser back button, the user will be able to move from the face capture to the document confirm screen, to the uploader or webcam screen, to the select document type screen (if they keep clicking the back button). Therefore the Confirm component is not a child of the Capture component anymore.