### PR TITLE
Fixed JsFiddle demo and release guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ And the CSS styles:
 
 #### Example app
 
-[JsFiddle example here.](https://jsfiddle.net/4xqtt6fL/35/)
+[JsFiddle example here.](https://jsfiddle.net/4xqtt6fL/47/)
 Simple example using script tags.
 
 #### 4.2 NPM style import

--- a/release_guidelines.md
+++ b/release_guidelines.md
@@ -16,7 +16,7 @@ An example `<version>` could be `2.0.0-rc.1`
 * Build the dist files with `npm run build`
 * Commit the above using the version as the commit message
 * Create a pull request from the release branch into master
-* Update the JSFiddle demo
+* [Update JSFiddle demo](#update-jsfiddle-demo)
 * On the release branch run `npm publish --tag next`
   * Get the credentials from One Login
   * Read about npm and release candidates [here](https://medium.com/@mbostock/prereleases-and-npm-e778fc5e2420)
@@ -35,7 +35,7 @@ An example `<version>` could be `2.0.0`
 * Create a release candidate
 * On the release branch update the version in `package.json`
 * Update the change log entry of the release candidate you are using
-* Update the JSFiddle demo
+* [Update JSFiddle demo](#update-jsfiddle-demo)
 * Perform the release: on the release branch run `npm publish`
 * Check you can install your release with `npm install onfido-sdk-ui`
 * Create a new release on GitHub

--- a/release_guidelines.md
+++ b/release_guidelines.md
@@ -16,6 +16,7 @@ An example `<version>` could be `2.0.0-rc.1`
 * Build the dist files with `npm run build`
 * Commit the above using the version as the commit message
 * Create a pull request from the release branch into master
+* Update the JSFiddle demo
 * On the release branch run `npm publish --tag next`
   * Get the credentials from One Login
   * Read about npm and release candidates [here](https://medium.com/@mbostock/prereleases-and-npm-e778fc5e2420)
@@ -34,7 +35,18 @@ An example `<version>` could be `2.0.0`
 * Create a release candidate
 * On the release branch update the version in `package.json`
 * Update the change log entry of the release candidate you are using
+* Update the JSFiddle demo
 * Perform the release: on the release branch run `npm publish`
 * Check you can install your release with `npm install onfido-sdk-ui`
 * Create a new release on GitHub
 * Commit and merge the release branch into master
+
+
+## Update JSFiddle Demo
+* Make sure the dist folder is updated and commited
+* Make sure a TAG is created for this version you want to update to
+* Open the JSFiddle and udpate its resources to the following, (replace `NEW_TAG`):
+  * `https://cdn.rawgit.com/onfido/onfido-sdk-ui/NEW_TAG/dist/style.css`
+  * `https://cdn.rawgit.com/onfido/onfido-sdk-ui/NEW_TAG/dist/onfido.min.js`
+* Follow the migration notes and update the code if necessary
+* Test the happy path


### PR DESCRIPTION
## Problem

JSFiddle was pointing to the latest master, which meant it could potentially break on every new major releases. In fact it was broken, because the sdk now needs a new type of jwt token.

## Solution

1. Make the JSFiddle point to a specific version
2. Update the release guidelines to take this into account