### PR TITLE
Pass woopra cookie between devices

### DIFF
--- a/src/Tracker/index.js
+++ b/src/Tracker/index.js
@@ -105,4 +105,20 @@ const sendError = (message, extra) => {
   });
 }
 
-export default { setUp, track, sendError, sendEvent, sendScreen, trackComponent, trackComponentAndMode, appendToTracking }
+const setWoopraCookie = (cookie) => {
+  const cookie_name = woopra.config('cookie_name')
+  const cookie_expire = woopra.config('cookie_expire')
+  const cookie_path = woopra.config('cookie_path')
+  const cookie_domain = woopra.config('cookie_domain')
+  woopra.docCookies.setItem(
+    cookie_name, cookie, cookie_expire, cookie_path, cookie_domain
+  )
+  woopra.cookie = cookie
+}
+
+const getWoopraCookie = () =>
+  woopra.cookie
+
+export default { setUp, track, sendError, sendEvent, sendScreen, trackComponent,
+                 trackComponentAndMode, appendToTracking, setWoopraCookie,
+                 getWoopraCookie }

--- a/src/Tracker/index.js
+++ b/src/Tracker/index.js
@@ -29,10 +29,12 @@ const setUp = () => {
    referer: location.href
   });
 
-  woopra.identify({
-    sdk_version: process.env.SDK_VERSION,
-    client: window.location.hostname
-  });
+  const client = window.location.hostname
+  const sdk_version = process.env.SDK_VERSION
+  // Do not overwrite the woopra client if we are in the cross device client.
+  // This is so we can track the original page where the user opened the SDK.
+  woopra.identify(client.match(/^(id|id-dev)\.onfido\.com$/) ?
+    {sdk_version} : {sdk_version, client})
 
   Raven.TraceKit.collectWindowErrors = true//TODO scope exceptions to sdk code only
 }

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -9,6 +9,7 @@ import StepsRouter from './StepsRouter'
 import Spinner from '../Spinner'
 import { unboundActions } from '../../core'
 import { isDesktop } from '../utils'
+import { getWoopraCookie, setWoopraCookie } from '../../Tracker'
 
 const history = createHistory()
 
@@ -39,20 +40,9 @@ class CrossDeviceMobileRouter extends Component {
 
   setConfig = (actions) => (data) => {
     const {token, steps, documentType, step, woopraCookie} = data
-    this.setWoopraCookie(woopraCookie)
+    setWoopraCookie(woopraCookie)
     this.setState({token, steps, step})
     actions.setDocumentType(documentType)
-  }
-
-  setWoopraCookie = (cookie) => {
-    const cookie_name = window.onfidojssdkwoopra.config('cookie_name')
-    const cookie_expire = window.onfidojssdkwoopra.config('cookie_expire')
-    const cookie_path = window.onfidojssdkwoopra.config('cookie_path')
-    const cookie_domain = window.onfidojssdkwoopra.config('cookie_domain')
-    window.onfidojssdkwoopra.docCookies.setItem(
-      cookie_name, cookie, cookie_expire, cookie_path, cookie_domain
-    )
-    window.onfidojssdkwoopra.cookie = cookie
   }
 
   onStepChange = ({step}) => {
@@ -85,7 +75,7 @@ class MainRouter extends Component {
   mobileConfig = () => {
     const {documentType, options} = this.props
     const {steps, token} = options
-    const woopraCookie = window.onfidojssdkwoopra.cookie
+    const woopraCookie = getWoopraCookie()
     return {steps, token, documentType, step: this.state.mobileInitialStep, woopraCookie}
   }
 

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -38,9 +38,21 @@ class CrossDeviceMobileRouter extends Component {
   }
 
   setConfig = (actions) => (data) => {
-    const {token, steps, documentType, step} = data
+    const {token, steps, documentType, step, woopraCookie} = data
+    this.setWoopraCookie(woopraCookie)
     this.setState({token, steps, step})
     actions.setDocumentType(documentType)
+  }
+
+  setWoopraCookie = (cookie) => {
+    const cookie_name = window.onfidojssdkwoopra.config('cookie_name')
+    const cookie_expire = window.onfidojssdkwoopra.config('cookie_expire')
+    const cookie_path = window.onfidojssdkwoopra.config('cookie_path')
+    const cookie_domain = window.onfidojssdkwoopra.config('cookie_domain')
+    window.onfidojssdkwoopra.docCookies.setItem(
+      cookie_name, cookie, cookie_expire, cookie_path, cookie_domain
+    )
+    window.onfidojssdkwoopra.cookie = cookie
   }
 
   onStepChange = ({step}) => {
@@ -73,7 +85,8 @@ class MainRouter extends Component {
   mobileConfig = () => {
     const {documentType, options} = this.props
     const {steps, token} = options
-    return {steps, token, documentType, step: this.state.mobileInitialStep}
+    const woopraCookie = window.onfidojssdkwoopra.cookie
+    return {steps, token, documentType, step: this.state.mobileInitialStep, woopraCookie}
   }
 
   onFlowChange = (newFlow, newStep, previousFlow, previousStep) => {


### PR DESCRIPTION
This PR allows us to track users between devices on the cross device flow.

We use the woopra cookie as a unique identifier see: https://docs.woopra.com/v2.4/docs/profile-id-system#section-identifiers-in-woopra

When you open the mobile link we send the cookie from the desktop session and set it in your mobile session.

The JS docs advise using an email address as a unique identifer, but give we don't have one then using that field with a random ID would be a hack.

Setting the cookie is usually handled under the covers by the JS SDK, but it's OK to override that behaviour e.g. they do it in their Rails SDK https://www.woopra.com/docs/setup/ruby-on-rails-sdk/