### PR TITLE
Fix Chrome version in tests due to bug in linux's Chrome 62

### DIFF
--- a/test/scripts/install_chromedriver_travis.sh
+++ b/test/scripts/install_chromedriver_travis.sh
@@ -19,7 +19,6 @@ sudo wget --no-verbose -q -O - https://dl-ssl.google.com/linux/linux_signing_key
 echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
 sudo apt-get update -qqy
 sudo apt-get -qqy install ${CHROME_VERSION}
-
 echo "Using `google-chrome --version` from `which google-chrome`"
 
 echo "Installing chromedriver $CHROME_DRIVER_VERSION..."

--- a/test/scripts/install_chromedriver_travis.sh
+++ b/test/scripts/install_chromedriver_travis.sh
@@ -2,9 +2,9 @@
 
 set -ev
 
-# CHROME_VERSION="google-chrome-stable"
-CHROME_DRIVER_TARGET="latest"
-CHROME_DRIVER_VERSION=$(if [ ${CHROME_DRIVER_TARGET:-latest} = "latest" ]; then echo $(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE); else echo $CHROME_DRIVER_TARGET; fi)
+# take the latest chromedriver version from https://chromedriver.storage.googleapis.com/LATEST_RELEASE
+CHROME_DRIVER_VERSION=$(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
+CHROME_VERSION="google-chrome-stable"
 
 echo "Uninstalling current Chromium from `which chromium-browser`..."
 sudo apt-get purge chromium-browser
@@ -14,16 +14,11 @@ echo "Uninstalling current Google Chrome from `which google-chrome`..."
 sudo apt-get purge google-chrome-stable
 rm ~/.config/google-chrome/ -rf
 
-# echo "Installing $CHROME_VERSION..."
-# sudo wget --no-verbose -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-# echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
-# sudo apt-get update -qqy
-# sudo apt-get -qqy install ${CHROME_VERSION}
-
-# install Chrome 61 due to bug in Chrome 62
-apt-get -y update
-wget -q  https://www.slimjet.com/chrome/download-chrome.php?file=lnx%2Fchrome64_61.0.3163.79.deb
-apt install -y --allow-downgrades ./download-chrome.php\?file\=lnx%2Fchrome64_61.0.3163.79.deb
+echo "Installing $CHROME_VERSION..."
+sudo wget --no-verbose -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
+sudo apt-get update -qqy
+sudo apt-get -qqy install ${CHROME_VERSION}
 
 echo "Using `google-chrome --version` from `which google-chrome`"
 

--- a/test/scripts/install_chromedriver_travis.sh
+++ b/test/scripts/install_chromedriver_travis.sh
@@ -2,8 +2,9 @@
 
 set -ev
 
-CHROME_VERSION="google-chrome-stable"
-CHROME_DRIVER_VERSION=2.31
+# CHROME_VERSION="google-chrome-stable"
+CHROME_DRIVER_TARGET="latest"
+CHROME_DRIVER_VERSION=$(if [ ${CHROME_DRIVER_TARGET:-latest} = "latest" ]; then echo $(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE); else echo $CHROME_DRIVER_TARGET; fi)
 
 echo "Uninstalling current Chromium from `which chromium-browser`..."
 sudo apt-get purge chromium-browser
@@ -13,11 +14,17 @@ echo "Uninstalling current Google Chrome from `which google-chrome`..."
 sudo apt-get purge google-chrome-stable
 rm ~/.config/google-chrome/ -rf
 
-echo "Installing $CHROME_VERSION..."
-sudo wget --no-verbose -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
-sudo apt-get update -qqy
-sudo apt-get -qqy install ${CHROME_VERSION}
+# echo "Installing $CHROME_VERSION..."
+# sudo wget --no-verbose -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+# echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
+# sudo apt-get update -qqy
+# sudo apt-get -qqy install ${CHROME_VERSION}
+
+# install Chrome 61 due to bug in Chrome 62
+apt-get -y update
+wget -q  https://www.slimjet.com/chrome/download-chrome.php?file=lnx%2Fchrome64_61.0.3163.79.deb
+apt install -y --allow-downgrades ./download-chrome.php\?file\=lnx%2Fchrome64_61.0.3163.79.deb
+
 echo "Using `google-chrome --version` from `which google-chrome`"
 
 echo "Installing chromedriver $CHROME_DRIVER_VERSION..."


### PR DESCRIPTION
* ~~Fix Chrome version to 61~~ it turned out the issue was solely related to outdated chromedriver version for Chrome 62, not in the browser itself. Reverting these changes then

* Always install latest chromedriver