### PR TITLE
Update monster gem dependency in cucumber tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -37,5 +37,5 @@ if [[ ${CI} != "true" || (${NODE_ENV} = "production" && ${TRAVIS_PULL_REQUEST} !
   # run cucumber tests against localhost
   SDK_URL="https://localhost:8080/?async=false"
   echo "Running Cucumber tests on ${SDK_URL}"
-  bundle exec cucumber BROWSER=chrome SDK_URL=${SDK_URL} USE_SECRETS=false DEBUG=false --retry 2
+  bundle exec cucumber BROWSER=chrome SDK_URL=${SDK_URL} USE_SECRETS=false SEED_PATH=false DEBUG=false --retry 2
 fi

--- a/test/Gemfile
+++ b/test/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-gem 'monster', :git => 'git@bitbucket.org:onfido/monster.git', :tag => '0.2.0'
+gem 'monster', :git => 'git@bitbucket.org:onfido/monster.git', :tag => '0.3.1'
 gem 'cucumber', :git => 'https://github.com/cucumber/cucumber-ruby.git', :ref => '085be64'
 gem 'cucumber-api', :git => 'https://github.com/cristian-m-vasile/cucumber-api.git'
 gem 'rake'

--- a/test/Gemfile
+++ b/test/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-gem 'monster', :git => 'git@bitbucket.org:onfido/monster.git'
+gem 'monster', :git => 'git@bitbucket.org:onfido/monster.git', :tag => '0.2.0'
 gem 'cucumber', :git => 'https://github.com/cucumber/cucumber-ruby.git', :ref => '085be64'
 gem 'cucumber-api', :git => 'https://github.com/cristian-m-vasile/cucumber-api.git'
 gem 'rake'

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: git@bitbucket.org:onfido/monster.git
   revision: f833b834f4e658f4bc1820e88882ecc64b2f6c8f
+  tag: 0.2.0
   specs:
     monster (0.2.0)
       browserstack-local

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: git@bitbucket.org:onfido/monster.git
-  revision: f833b834f4e658f4bc1820e88882ecc64b2f6c8f
-  tag: 0.2.0
+  revision: 972ed40a581a3e44877afa7e8659ef127751e47e
+  tag: 0.3.1
   specs:
-    monster (0.2.0)
+    monster (0.3.1)
       browserstack-local
       chronic
       faker
@@ -83,10 +83,11 @@ GEM
       addressable (>= 2.4)
     jsonpath (0.7.2)
       multi_json
-    mail (2.6.6)
-      mime-types (>= 1.16, < 4)
+    mail (2.7.0)
+      mini_mime (>= 0.1.1)
     method_source (0.9.0)
     mime-types (2.99.3)
+    mini_mime (0.1.4)
     mini_portile2 (2.3.0)
     multi_json (1.12.2)
     multi_test (0.1.2)

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: git@bitbucket.org:onfido/monster.git
-  revision: 37712832fadcb89a8b0aa111b8388d82b37f7cf6
+  revision: f833b834f4e658f4bc1820e88882ecc64b2f6c8f
   specs:
-    monster (0.1.14)
+    monster (0.2.0)
       browserstack-local
       chronic
       faker
@@ -14,17 +14,17 @@ GIT
       parallel_tests
       pry-byebug
       rake
-      report_builder
+      report_builder (= 0.1.4)
+      require_all
       retries
       rspec-expectations
       selenium-webdriver (= 3.4.3)
 
 GIT
   remote: https://github.com/cristian-m-vasile/cucumber-api.git
-  revision: 9634a58af9d7e5e112f195d1b29c9fa41783a28c
+  revision: a7cdef1c1271148b48ca97bf8402cd33d538c159
   specs:
-    cucumber-api (0.6.1)
-      cucumber
+    cucumber-api (0.6.2)
       json-schema (~> 2.5)
       jsonpath (~> 0.5)
       rest-client (~> 1.8)
@@ -48,14 +48,15 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    backports (3.8.0)
+    backports (3.10.3)
     browserstack-local (1.3.0)
     builder (3.2.3)
     byebug (9.1.0)
-    childprocess (0.7.1)
+    childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
     coderay (1.1.2)
+    concurrent-ruby (1.0.5)
     cucumber-core (2.0.0)
       backports (~> 3.6)
       gherkin (~> 4.0)
@@ -74,7 +75,8 @@ GEM
       oauth (>= 0.3.6)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (0.8.6)
+    i18n (0.9.0)
+      concurrent-ruby (~> 1.0)
     json (2.1.0)
     json-schema (2.8.0)
       addressable (>= 2.4)
@@ -82,45 +84,44 @@ GEM
       multi_json
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
-    method_source (0.8.2)
+    method_source (0.9.0)
     mime-types (2.99.3)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     multi_json (1.12.2)
     multi_test (0.1.2)
     net-ssh (4.2.0)
     netrc (0.11.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     oauth (0.5.3)
     parallel (1.12.0)
-    parallel_tests (2.15.0)
+    parallel_tests (2.17.0)
       parallel
-    pry (0.10.4)
+    pry (0.11.2)
       coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
+      method_source (~> 0.9.0)
     pry-byebug (3.5.0)
       byebug (~> 9.1)
       pry (~> 0.10)
     public_suffix (3.0.0)
-    rake (12.0.0)
+    rake (12.2.1)
     report_builder (0.1.4)
       builder (~> 3.2, >= 3.2.2)
       json (>= 1.8.1)
+    require_all (1.4.0)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     retries (0.0.5)
-    rspec-expectations (3.6.0)
+    rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-support (3.6.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.0)
     rubyzip (1.2.1)
     selenium-webdriver (3.4.3)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
-    slop (3.6.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
@@ -135,4 +136,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.15.1
+   1.15.4

--- a/test/features/support/env.rb
+++ b/test/features/support/env.rb
@@ -1,4 +1,3 @@
-require 'monster/cucumber_steps'
-require 'monster/support'
+require 'monster'
 
 SDK_URL = ENV['SDK_URL'] or raise "Missing SDK_URL environment variable"


### PR DESCRIPTION
This is required due the most recent breaking changes introduced on master in `monster` gem, one of cucumber test dependencies.