### PR TITLE
reverted E6 syntax on sample app code

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -54,7 +54,7 @@
         }
       }
 
-      const steps = [
+      var steps = [
         {
           type:'welcome',
           options:{
@@ -83,7 +83,7 @@
           onComplete: function() {
             /*callback for when */ console.log("everything is complete")
           },
-          steps,
+          steps: steps
         })
       }
 


### PR DESCRIPTION
@stefaniacardenas and @seewah 

# Problem

We were using E6 syntax on our demo apa. This code doesn't go to the transpiler, so it doesn't produce IE compatible code.