### PR TITLE
Refactor SMS input to remove redundnant state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.byebug_history
 .DS_Store
 *.log
 build

--- a/src/components/PhoneNumberInput/index.js
+++ b/src/components/PhoneNumberInput/index.js
@@ -8,8 +8,7 @@ import style from './style.css'
 class PhoneNumberInput extends Component {
   constructor(props) {
     super(props)
-    this.state = { value: this.props.mobileNumber, country: 'GB' }
-    this.updateValidNumber()
+    this.state = { country: 'GB' }
     this.getCountry()
   }
 
@@ -24,24 +23,16 @@ class PhoneNumberInput extends Component {
     request.send()
   }
 
-  onChange = (value) => {
-    this.setState({value})
-    this.props.clearPreviousAttempts()
-    this.updateValidNumber()
-  }
-
-  updateValidNumber = () => {
-    const number = this.state.value
-    const validNumber = isValidPhoneNumber(number)
-    if (number && validNumber) {
-      this.props.updateNumber(this.state.value)
-    }
+  onChange = (number) => {
+    this.props.clearErrors()
+    const valid = isValidPhoneNumber(number)
+    this.props.actions.setMobileNumber({number, valid})
   }
 
   render = () =>
     <PhoneNumber placeholder='Enter mobile number'
       onChange={this.onChange}
-      value={this.state.value}
+      value={this.props.sms.number}
       country={this.state.country}
       inputClassName={`${style.mobileInput}`}
       className={`${style.phoneNumberContainer}`}

--- a/src/components/crossDevice/CrossDeviceLink/index.js
+++ b/src/components/crossDevice/CrossDeviceLink/index.js
@@ -99,7 +99,7 @@ class CrossDeviceLinkUI extends Component {
       copySuccess: false,
       sending: false,
       error: {},
-      invalidNumber: false,
+      validNumber: true,
     }
   }
 
@@ -129,7 +129,7 @@ class CrossDeviceLinkUI extends Component {
 
   clearErrors = () => {
     this.setState({error: {}})
-    this.setState({invalidNumber: false})
+    this.setState({validNumber: true})
   }
 
   handleResponse = (response) => {
@@ -159,7 +159,7 @@ class CrossDeviceLinkUI extends Component {
       performHttpReq(options, this.handleResponse , this.handleSMSError)
     }
     else {
-      this.setState({invalidNumber: true})
+      this.setState({validNumber: false})
     }
   }
 
@@ -168,6 +168,7 @@ class CrossDeviceLinkUI extends Component {
     const error = this.state.error
     const linkCopy = this.state.copySuccess ? 'Copied' : 'Copy'
     const buttonCopy = this.state.sending ? 'Sending' : 'Send link'
+    const invalidNumber = !this.state.validNumber
     return (
       <div>
         <div className={style.header}>
@@ -184,7 +185,7 @@ class CrossDeviceLinkUI extends Component {
               <div className={style.sublabel}>(We won’t keep or share your number)</div>
             </div>
             <div className={style.numberInputSection}>
-              <div className={classNames(style.inputContainer, {[style.fieldError]: this.state.invalidNumber})}>
+              <div className={classNames(style.inputContainer, {[style.fieldError]: invalidNumber})}>
                 <PhoneNumberInputLazy { ...this.props} clearErrors={this.clearErrors} />
               </div>
               <button className={classNames(theme.btn, theme["btn-primary"], style.btn, {[style.sending]: this.state.sending})}
@@ -193,7 +194,7 @@ class CrossDeviceLinkUI extends Component {
               </button>
             </div>
           </div>
-          { this.state.invalidNumber && <div className={style.numberError}>Check your mobile number is correct</div> }
+          { invalidNumber && <div className={style.numberError}>Check your mobile number is correct</div> }
           <div className={style.copyLinkSection}>
             <div className={`${style.label}`}>Copy link instead:</div>
               <div className={classNames(style.actionContainer, {[style.copySuccess]: this.state.copySuccess})}>

--- a/src/core/store/reducers/globals.js
+++ b/src/core/store/reducers/globals.js
@@ -4,7 +4,7 @@ const initialState = {
   documentType: null,
   roomId: null,
   socket: null,
-  mobileNumber: null,
+  sms: {number: null, valid: false},
   clientSuccess: false,
 }
 
@@ -18,7 +18,7 @@ export default function globals(state = initialState, action) {
     case constants.SET_SOCKET:
       return {...state, socket: action.payload}
     case constants.SET_MOBILE_NUMBER:
-      return {...state, mobileNumber: action.payload}
+      return {...state, sms: action.payload}
     case constants.SET_CLIENT_SUCCESS:
       return {...state, clientSuccess: action.payload}
     case constants.MOBILE_CONNECTED:


### PR DESCRIPTION
Reduce the places we store the mobile number and related state:

- The input mobile number and whether or not it is valid is saved in the redux store every time the user adds or removes a digit
- The CrossDeviceLink also keeps track of whether or not it should show the invalid number warning

This slightly changes the behaviour of displaying errors. I agreed with Daniel that errors are only triggered when the user clicks `Send SMS`. All errors are dismissed if the user edits the phone number input field.
