### PR TITLE
Spike/cross device tests

### DIFF
--- a/src/components/crossDevice/CrossDeviceLink/index.js
+++ b/src/components/crossDevice/CrossDeviceLink/index.js
@@ -110,7 +110,7 @@ class CrossDeviceLinkUI extends Component {
 
   copyToClipboard = (e) => {
     e.preventDefault()
-    this.textArea.select()
+    this.linkText.select()
     document.execCommand('copy')
     e.target.focus()
     this.setState({copySuccess: true})
@@ -217,7 +217,9 @@ class CrossDeviceLinkUI extends Component {
           <div className={style.copyLinkSection}>
             <div className={`${style.label}`}>Copy link instead:</div>
               <div className={classNames(style.actionContainer, {[style.copySuccess]: this.state.copySuccess})}>
-                <textarea className={style.linkText} ref={(textarea) => this.textArea = textarea} value={mobileUrl} />
+                <textarea className={style.linkText} ref={(element) => this.linkText = element}>
+                  {mobileUrl}
+                </textarea>
                 { document.queryCommandSupported('copy') &&
                   <a href='' className={style.copyToClipboard} onClick={this.copyToClipboard}>{linkCopy}</a>
                 }

--- a/test/features/page_objects/sdk.rb
+++ b/test/features/page_objects/sdk.rb
@@ -79,6 +79,18 @@ class SDK
   def error_instruction
     @driver.find_element(:css, '.onfido-sdk-ui-Error-instruction')
   end
+
+  def cross_device_button
+    @driver.find_element(:css, '.onfido-sdk-ui-SwitchDevice-container')
+  end
+
+  def cross_device_header
+    @driver.find_element(:css, '.onfido-sdk-ui-SwitchDevice-header')
+  end
+
+  def cross_device_link
+    @driver.find_element(:css, '.onfido-sdk-ui-CrossDeviceLink-linkText')
+  end
 end
 
 Given(/^I navigate to the SDK$/) do

--- a/test/features/sdk_flow.feature
+++ b/test/features/sdk_flow.feature
@@ -1,6 +1,15 @@
 @browser @sdk
 Feature: SDK File Upload Tests
 
+  Scenario: Test multiple tabs/windows
+    Given I verify with passport
+    When I click on cross_device_button ()
+    Then page_title () should contain "Continue verification on your mobile"
+    When I open cross_device_link () in a new tab
+    Then page_title () should contain "Upload front of document"
+    And master flow should show connected
+
+
   Scenario Outline: I should be able to upload a passport and an image of a face correctly.
     Given I verify with passport
     When I try to upload passport <type>

--- a/test/features/step_definitions/sdk_steps.rb
+++ b/test/features/step_definitions/sdk_steps.rb
@@ -5,6 +5,7 @@ Given(/^I verify with (passport|identity_card|drivers_license)$/) do |document_t
     Then I should see 3 document_select_buttons ()
     When I click on #{document_type} ()
     Then page_title () should contain "Upload front of document"
+    And cross_device_header () should contain "Need to use your mobile to take photos?"
   }
 end
 
@@ -15,5 +16,22 @@ When(/^I try to upload (\w+)(?:\s*)(pdf)?( and then retry)?$/) do |document, fil
     Then I should see uploaded_#{file_type}image ()
     And confirmation_text () should contain "Please confirm that you are happy with this photo."
     When I click on #{action_button} ()
+  }
+end
+
+element = '(\w+(?:|\(.*\)) \(\w*\)(?:| index \d+))'
+
+When(/^I open #{element} in a new tab$/) do |element|
+  url = element.text
+  @driver.execute_script("window.open()")
+  @tab1, @tab2 = @driver.window_handles
+  @driver.switch_to.window(@tab2)
+  @driver.get url
+end
+
+Then(/^master flow should show connected$/) do
+  @driver.switch_to.window(@tab1)
+  steps %Q{
+    Then page_title () should contain "Connected to your mobile"
   }
 end


### PR DESCRIPTION
PR to check multi-tab tests work on CI

There are a few moving parts here:

- Browser
- Web driver
- Selenium client

I had to refactor the textarea element area so that selenium could pull the text out of it.

I have got a basic scenario of the cross device flow working between two tabs. This works locally and on CI. 

As far as I can tell there is nothing specific to chrome. However I have been unable to test this approach on firefox because my firefox webdriver crashes (for unrelated reasons).

I will not merge this PR, but use it as the starting point for writing the cross device tests.

