### PR TITLE
Feature/improve test script

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -19,6 +19,9 @@ if [[ ${CI} != "true" || (${NODE_ENV} = "test" && ${TRAVIS_PULL_REQUEST} != "fal
   server=$([[ ${CI} = "true" ]] && echo "travis" || echo "dev")
   echo "Running local server..."
   exec 3< <(npm run $server)
+  if [[ ${CI} != "true" ]]; then
+    sed '/webpack: Compiled successfully.$/q' <&3 ; cat <&3 &
+  fi
 
   # go to test directory
   cd $TESTS_PATH

--- a/test.sh
+++ b/test.sh
@@ -36,5 +36,5 @@ if [[ ${CI} != "true" || (${NODE_ENV} = "test" && ${TRAVIS_PULL_REQUEST} != "fal
   # run cucumber tests against localhost
   SDK_URL="https://localhost:8080/?async=false"
   echo "Running Cucumber tests on ${SDK_URL}"
-  bundle exec cucumber BROWSER=chrome SDK_URL=${SDK_URL} USE_SECRETS=false SEED_PATH=false DEBUG=false
+  bundle exec cucumber BROWSER=${BROWSER:-chrome} SDK_URL=${SDK_URL} USE_SECRETS=false SEED_PATH=false DEBUG=false
 fi

--- a/test/TESTING_GUIDELINES.md
+++ b/test/TESTING_GUIDELINES.md
@@ -36,7 +36,8 @@ Tests can be run on `test.sh` script runs on two different environments, dependi
 **Express run:**
 
 - Run `test.sh` script
-  - it will start webpack server on development environment, install dependencies and execute all `.feature` tests on Chrome browser.
+  - it will start webpack server on development environment, install dependencies and execute all `.feature` tests on Chrome browser by default
+  - you can run against other browser than Chrome, just specify BROWSER env variable on test.sh execution, i.e: `BROWSER=firefox bash test.sh`
 
 **Custom run:**
 


### PR DESCRIPTION
1. Check if webpack has started before running tests on local (prevents local execution of `test.sh` to randomly fail)
2. Allow to define browser that should be used while executing tests via `test.sh` script, i.e:
* `BROWSER=firefox bash test.sh` runs tests on Firefox
* `bash test.sh` runs tests on Chrome by default