### PR TITLE
Feature/cross device tests cx 1504

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ os:
 env:
   - NODE_ENV=staging
   - NODE_ENV=test
+  - NODE_ENV=production
 cache:
   directories:
     - "node_modules"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ node_js:
 os:
   - linux
 env:
-  - NODE_ENV=staging
   - NODE_ENV=test
+  - NODE_ENV=staging
   - NODE_ENV=production
 cache:
   directories:

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,6 +9,12 @@ DEPLOY_PATH=./dist
 
 DEPLOY_SUBDOMAIN_UNFORMATTED_LIST=()
 
+if [ "$NODE_ENV" == "test" ]
+then
+  echo 'No need to deploy build for UI tests, exiting'
+  exit 0
+fi
+
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]
 then
   DEPLOY_SUBDOMAIN_UNFORMATTED_LIST+=(${TRAVIS_PULL_REQUEST}-pr)

--- a/deploy.sh
+++ b/deploy.sh
@@ -50,6 +50,7 @@ do
   then
     DEPLOY_DOMAIN=https://${DEPLOY_SUBDOMAIN}-${REPO_NAME}-${REPO_OWNER}.surge.sh
   elif [ "$NODE_ENV" == "staging" ]
+  then
     DEPLOY_DOMAIN=https://staging-${DEPLOY_SUBDOMAIN}-${REPO_NAME}-${REPO_OWNER}.surge.sh
   fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -46,10 +46,10 @@ do
   DEPLOY_SUBDOMAIN=`echo "$DEPLOY_SUBDOMAIN_UNFORMATTED" | sed -r 's/[^A-Za-z0-9]+/\-/g'`
   echo $DEPLOY_SUBDOMAIN
 
-  if [ "$NODE_ENV" == "test" ]
+  if [ "$NODE_ENV" == "production" ]
   then
     DEPLOY_DOMAIN=https://${DEPLOY_SUBDOMAIN}-${REPO_NAME}-${REPO_OWNER}.surge.sh
-  else
+  elif [ "$NODE_ENV" == "staging" ]
     DEPLOY_DOMAIN=https://staging-${DEPLOY_SUBDOMAIN}-${REPO_NAME}-${REPO_OWNER}.surge.sh
   fi
 

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -24,10 +24,11 @@ const Router = (props) =>{
 class CrossDeviceMobileRouter extends Component {
   constructor(props) {
     super(props)
+    // Some environments put the link ID in the query string so they can serve
+    // the cross device flow without running nginx
     const url = new URL(document.location)
     const roomId = window.location.pathname.substring(3) ||
       url.searchParams.get('link_id').substring(2)
-    console.log(roomId)
     this.state = {
       token: null,
       steps: null,

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -24,12 +24,16 @@ const Router = (props) =>{
 class CrossDeviceMobileRouter extends Component {
   constructor(props) {
     super(props)
+    const url = new URL(document.location)
+    const roomId = window.location.pathname.substring(3) ||
+      url.searchParams.get('link_id').substring(2)
+    console.log(roomId)
     this.state = {
       token: null,
       steps: null,
       step: null,
       socket: io(process.env.DESKTOP_SYNC_URL, {autoConnect: false}),
-      roomId: window.location.pathname.substring(3),
+      roomId,
       crossDeviceError: false,
       loading: true,
     }

--- a/src/components/crossDevice/CrossDeviceLink/index.js
+++ b/src/components/crossDevice/CrossDeviceLink/index.js
@@ -109,7 +109,7 @@ class CrossDeviceLinkUI extends Component {
 
   copyToClipboard = (e) => {
     e.preventDefault()
-    this.textArea.select()
+    this.linkText.select()
     document.execCommand('copy')
     e.target.focus()
     this.setState({copySuccess: true})
@@ -198,7 +198,9 @@ class CrossDeviceLinkUI extends Component {
           <div className={style.copyLinkSection}>
             <div className={`${style.label}`}>Copy link instead:</div>
               <div className={classNames(style.actionContainer, {[style.copySuccess]: this.state.copySuccess})}>
-                <textarea className={style.linkText} ref={(textarea) => this.textArea = textarea} value={mobileUrl} />
+                <textarea className={style.linkText} ref={(element) => this.linkText = element}>
+                  {mobileUrl}
+                </textarea>
                 { document.queryCommandSupported('copy') &&
                   <a href='' className={style.copyToClipboard} onClick={this.copyToClipboard}>{linkCopy}</a>
                 }

--- a/src/components/crossDevice/CrossDeviceLink/index.js
+++ b/src/components/crossDevice/CrossDeviceLink/index.js
@@ -164,7 +164,9 @@ class CrossDeviceLinkUI extends Component {
   }
 
   mobileUrl = () =>
-    process.env.MOBILE_URL === "localhost" ?
+    // This lets us test the cross device flow locally and on surge.
+    // We use the same location to test the same bundle as the desktop flow.
+    process.env.MOBILE_URL === "/" ?
       `${window.location.origin}?link_id=${this.linkId}` :
       `${process.env.MOBILE_URL}/${this.linkId}`
 

--- a/src/components/crossDevice/CrossDeviceLink/index.js
+++ b/src/components/crossDevice/CrossDeviceLink/index.js
@@ -198,9 +198,7 @@ class CrossDeviceLinkUI extends Component {
           <div className={style.copyLinkSection}>
             <div className={`${style.label}`}>Copy link instead:</div>
               <div className={classNames(style.actionContainer, {[style.copySuccess]: this.state.copySuccess})}>
-                <textarea className={style.linkText} ref={(element) => this.linkText = element}>
-                  {mobileUrl}
-                </textarea>
+                <textarea className={style.linkText} value={mobileUrl} ref={(element) => this.linkText = element}/>
                 { document.queryCommandSupported('copy') &&
                   <a href='' className={style.copyToClipboard} onClick={this.copyToClipboard}>{linkCopy}</a>
                 }

--- a/src/components/crossDevice/CrossDeviceLink/index.js
+++ b/src/components/crossDevice/CrossDeviceLink/index.js
@@ -163,8 +163,13 @@ class CrossDeviceLinkUI extends Component {
     }
   }
 
+  mobileUrl = () =>
+    process.env.MOBILE_URL === "localhost" ?
+      `${window.location.origin}?link_id=${this.linkId}` :
+      `${process.env.MOBILE_URL}/${this.linkId}`
+
   render() {
-    const mobileUrl = `${process.env.MOBILE_URL}/${this.linkId}`
+    const mobileUrl = this.mobileUrl()
     const error = this.state.error
     const linkCopy = this.state.copySuccess ? 'Copied' : 'Copy'
     const buttonCopy = this.state.sending ? 'Sending' : 'Send link'

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -48,6 +48,8 @@
         if (options.async === "false") {
           getToken(createSDK)
         }
+        if (options.link_id)
+          window.onfidoOut = Onfido.init({mobileFlow: true})
         else {
           createSDK(null)
           getToken(injectToken)

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -48,7 +48,7 @@
         if (options.async === "false") {
           getToken(createSDK)
         }
-        if (options.link_id)
+        else if (options.link_id)
           window.onfidoOut = Onfido.init({mobileFlow: true})
         else {
           createSDK(null)

--- a/test/Gemfile
+++ b/test/Gemfile
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-gem 'monster', :git => 'git@bitbucket.org:onfido/monster.git', :tag => '0.3.3'
+# TODO point to the monster tag once merged and tagged.
+# gem 'monster', :git => 'git@bitbucket.org:onfido/monster.git', :tag => '0.4.5'
+gem 'monster', :git => 'git@bitbucket.org:onfido/monster.git', :branch => 'feature/add-multiple-tabs-CX-1504'
 gem 'cucumber', :git => 'https://github.com/cucumber/cucumber-ruby.git', :ref => '085be64'
 gem 'cucumber-api', :git => 'https://github.com/cristian-m-vasile/cucumber-api.git'
 gem 'rake'

--- a/test/Gemfile
+++ b/test/Gemfile
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-# TODO point to the monster tag once merged and tagged.
-# gem 'monster', :git => 'git@bitbucket.org:onfido/monster.git', :tag => '0.4.5'
-gem 'monster', :git => 'git@bitbucket.org:onfido/monster.git', :branch => 'feature/add-multiple-tabs-CX-1504'
+gem 'monster', :git => 'git@bitbucket.org:onfido/monster.git', :tag => '0.4.5'
 gem 'cucumber', :git => 'https://github.com/cucumber/cucumber-ruby.git', :ref => '085be64'
 gem 'cucumber-api', :git => 'https://github.com/cristian-m-vasile/cucumber-api.git'
 gem 'rake'

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git@bitbucket.org:onfido/monster.git
-  revision: 6b3065fcb36a9bed9331810616baddb33dc23bc4
-  branch: feature/add-multiple-tabs-CX-1504
+  revision: be637ebc2bf7863b7e422322b0567fa3ad4fbc1e
+  tag: 0.4.5
   specs:
     monster (0.4.5)
       browserstack-local

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: git@bitbucket.org:onfido/monster.git
-  revision: 0968425c4990d4805b4fb7f89e65eabd7e3f7ec8
-  tag: 0.3.3
+  revision: a015d9672586fb7dd27adff5ca5a123e3a824463
+  branch: feature/add-multiple-tabs-CX-1504
   specs:
-    monster (0.3.3)
+    monster (0.4.5)
       browserstack-local
       chronic
       faker
@@ -97,9 +97,9 @@ GEM
       mini_portile2 (~> 2.3.0)
     oauth (0.5.3)
     parallel (1.12.0)
-    parallel_tests (2.18.0)
+    parallel_tests (2.19.0)
       parallel
-    pry (0.11.2)
+    pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     pry-byebug (3.5.0)

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git@bitbucket.org:onfido/monster.git
-  revision: a015d9672586fb7dd27adff5ca5a123e3a824463
+  revision: 6b3065fcb36a9bed9331810616baddb33dc23bc4
   branch: feature/add-multiple-tabs-CX-1504
   specs:
     monster (0.4.5)

--- a/test/features/cross_device.feature
+++ b/test/features/cross_device.feature
@@ -13,6 +13,7 @@ Feature: SDK Cross device steps
     And I upload my document and selfie
     Then page_title () should contain "Uploads successful"
     When I switch to tab 1
-    Then I wait until page_title () contains "Great, that’s everything we need"
+    Then I wait for 1 second
+    Then page_title () should contain "Great, that’s everything we need"
     When I click on primary_button ()
     Then page_title () should contain "Verification complete"

--- a/test/features/cross_device.feature
+++ b/test/features/cross_device.feature
@@ -8,12 +8,11 @@ Feature: SDK Cross device steps
     When I open cross_device_link () in a new tab
     Then page_title () should contain "Upload front of document"
     When I switch to tab 1
-    Then page_title () should contain "Connected to your mobile"
+    Then I wait until page_title () contains "Connected to your mobile"
     When I switch to tab 2
     And I upload my document and selfie
     Then page_title () should contain "Uploads successful"
     When I switch to tab 1
-    Then I wait for 1 second
-    Then page_title () should contain "Great, that’s everything we need"
+    Then I wait until page_title () contains "Great, that’s everything we need"
     When I click on primary_button ()
     Then page_title () should contain "Verification complete"

--- a/test/features/cross_device.feature
+++ b/test/features/cross_device.feature
@@ -13,6 +13,7 @@ Feature: SDK Cross device steps
     And I upload my document and selfie
     Then page_title () should contain "Uploads successful"
     When I switch to tab 1
+    Then I wait for 1 second
     Then page_title () should contain "Great, that’s everything we need"
     When I click on primary_button ()
     Then page_title () should contain "Verification complete"

--- a/test/features/page_objects/sdk.rb
+++ b/test/features/page_objects/sdk.rb
@@ -4,7 +4,7 @@ class SDK
     @driver = driver
   end
 
-  def verify_identity
+  def primary_button
     @driver.find_element(:css, '.onfido-sdk-ui-Theme-btn-primary')
   end
 

--- a/test/features/page_objects/sdk.rb
+++ b/test/features/page_objects/sdk.rb
@@ -83,6 +83,18 @@ class SDK
   def back
     @driver.find_element(:css, '.onfido-sdk-ui-NavigationBar-back')
   end
+
+  def cross_device_button
+    @driver.find_element(:css, '.onfido-sdk-ui-SwitchDevice-container')
+  end
+
+  def cross_device_header
+    @driver.find_element(:css, '.onfido-sdk-ui-SwitchDevice-header')
+  end
+
+  def cross_device_link
+    @driver.find_element(:css, '.onfido-sdk-ui-CrossDeviceLink-linkText')
+  end
 end
 
 Given(/^I navigate to the SDK$/) do

--- a/test/features/page_objects/sdk.rb
+++ b/test/features/page_objects/sdk.rb
@@ -24,10 +24,6 @@ class SDK
     @driver.find_element(:css, '.onfido-sdk-ui-DocumentSelector-icon-passport')
   end
 
-  def upload_icon
-    @driver.find_element(:css, '.onfido-sdk-ui-Uploader-icon')
-  end
-
   def file_upload
     element = @driver.find_element(:css, '.onfido-sdk-ui-Uploader-dropzone input[type="file"]')
     @driver.execute_script("return arguments[0].setAttribute('style','display: true');", element)

--- a/test/features/sdk_flow.feature
+++ b/test/features/sdk_flow.feature
@@ -1,6 +1,15 @@
 @browser @sdk
 Feature: SDK File Upload Tests
 
+  Scenario: Test multiple tabs/windows
+    Given I verify with passport
+    When I click on cross_device_button ()
+    Then page_title () should contain "Continue verification on your mobile"
+    When I open cross_device_link () in a new tab
+    Then page_title () should contain "Upload front of document"
+    And master flow should show connected
+
+
   Scenario Outline: I should be able to upload a passport and an image of a face correctly.
     Given I verify with passport
     When I try to upload passport <type>

--- a/test/features/sdk_flow.feature
+++ b/test/features/sdk_flow.feature
@@ -1,14 +1,21 @@
 @browser @sdk
 Feature: SDK File Upload Tests
 
-  Scenario: Test multiple tabs/windows
+  Scenario: Test cross device flow
     Given I verify with passport
     When I click on cross_device_button ()
     Then page_title () should contain "Continue verification on your mobile"
     When I open cross_device_link () in a new tab
     Then page_title () should contain "Upload front of document"
-    And master flow should show connected
-
+    When I switch to tab 1
+    Then page_title () should contain "Connected to your mobile"
+    When I switch to tab 2
+    And I upload my document and selfie
+    Then page_title () should contain "Uploads successful"
+    When I switch to tab 1
+    Then page_title () should contain "Great, that’s everything we need"
+    When I click on primary_button ()
+    Then page_title () should contain "Verification complete"
 
   Scenario Outline: I should be able to upload a passport and an image of a face correctly.
     Given I verify with passport

--- a/test/features/sdk_flow.feature
+++ b/test/features/sdk_flow.feature
@@ -1,21 +1,5 @@
-@browser @sdk
+@browser
 Feature: SDK File Upload Tests
-
-  Scenario: Test cross device flow
-    Given I verify with passport
-    When I click on cross_device_button ()
-    Then page_title () should contain "Continue verification on your mobile"
-    When I open cross_device_link () in a new tab
-    Then page_title () should contain "Upload front of document"
-    When I switch to tab 1
-    Then page_title () should contain "Connected to your mobile"
-    When I switch to tab 2
-    And I upload my document and selfie
-    Then page_title () should contain "Uploads successful"
-    When I switch to tab 1
-    Then page_title () should contain "Great, that’s everything we need"
-    When I click on primary_button ()
-    Then page_title () should contain "Verification complete"
 
   Scenario Outline: I should be able to upload a passport and an image of a face correctly.
     Given I verify with passport

--- a/test/features/step_definitions/sdk_steps.rb
+++ b/test/features/step_definitions/sdk_steps.rb
@@ -5,6 +5,7 @@ Given(/^I verify with (passport|identity_card|drivers_license)$/) do |document_t
     Then I should see 3 document_select_buttons ()
     When I click on #{document_type} ()
     Then page_title () should contain "Upload front of document"
+    And cross_device_header () should contain "Need to use your mobile to take photos?"
   }
 end
 
@@ -29,5 +30,22 @@ Then(/^I can navigate back to the previous page with title "([^"]*)"$/) do | tit
   steps %Q{
     When I click on back ()
     Then page_title () should contain "#{title}"
+  }
+end
+
+element = '(\w+(?:|\(.*\)) \(\w*\)(?:| index \d+))'
+
+When(/^I open #{element} in a new tab$/) do |element|
+  url = element.text
+  @driver.execute_script("window.open()")
+  @tab1, @tab2 = @driver.window_handles
+  @driver.switch_to.window(@tab2)
+  @driver.get url
+end
+
+Then(/^master flow should show connected$/) do
+  @driver.switch_to.window(@tab1)
+  steps %Q{
+    Then page_title () should contain "Connected to your mobile"
   }
 end

--- a/test/features/step_definitions/sdk_steps.rb
+++ b/test/features/step_definitions/sdk_steps.rb
@@ -1,7 +1,7 @@
 Given(/^I verify with (passport|identity_card|drivers_license)$/) do |document_type|
   steps %Q{
     Given I navigate to the SDK
-    When I click on verify_identity (SDK)
+    When I click on primary_button (SDK)
     Then I should see 3 document_select_buttons ()
     When I click on #{document_type} ()
     Then page_title () should contain "Upload front of document"
@@ -43,9 +43,15 @@ When(/^I open #{element} in a new tab$/) do |element|
   @driver.get url
 end
 
-Then(/^master flow should show connected$/) do
-  @driver.switch_to.window(@tab1)
+When(/^I switch to tab (\d+)$/) do |number|
+  tab = self.instance_variable_get("@tab#{number}")
+  @driver.switch_to.window(tab)
+end
+
+When(/^I upload my document and selfie$/) do
   steps %Q{
-    Then page_title () should contain "Connected to your mobile"
+    When I try to upload passport
+    Then page_title () should contain "Upload a selfie"
+    When I try to upload one_face
   }
 end

--- a/test/features/step_definitions/sdk_steps.rb
+++ b/test/features/step_definitions/sdk_steps.rb
@@ -33,21 +33,6 @@ Then(/^I can navigate back to the previous page with title "([^"]*)"$/) do | tit
   }
 end
 
-element = '(\w+(?:|\(.*\)) \(\w*\)(?:| index \d+))'
-
-When(/^I open #{element} in a new tab$/) do |element|
-  url = element.text
-  @driver.execute_script("window.open()")
-  @tab1, @tab2 = @driver.window_handles
-  @driver.switch_to.window(@tab2)
-  @driver.get url
-end
-
-When(/^I switch to tab (\d+)$/) do |number|
-  tab = self.instance_variable_get("@tab#{number}")
-  @driver.switch_to.window(tab)
-end
-
 When(/^I upload my document and selfie$/) do
   steps %Q{
     When I try to upload passport

--- a/test/features/support/cross_device.feature
+++ b/test/features/support/cross_device.feature
@@ -1,0 +1,18 @@
+@browser
+Feature: SDK Cross device steps
+
+  Scenario: Test cross device flow
+    Given I verify with passport
+    When I click on cross_device_button ()
+    Then page_title () should contain "Continue verification on your mobile"
+    When I open cross_device_link () in a new tab
+    Then page_title () should contain "Upload front of document"
+    When I switch to tab 1
+    Then page_title () should contain "Connected to your mobile"
+    When I switch to tab 2
+    And I upload my document and selfie
+    Then page_title () should contain "Uploads successful"
+    When I switch to tab 1
+    Then page_title () should contain "Great, that’s everything we need"
+    When I click on primary_button ()
+    Then page_title () should contain "Verification complete"

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -97,14 +97,14 @@ const PROD_CONFIG = {
   'PUBLIC_PATH' : `https://s3-eu-west-1.amazonaws.com/onfido-assets-production/web-sdk-releases/${packageJson.version}/`,
 }
 
-const TEST_CONFIG = { ...PROD_CONFIG, PUBLIC_PATH: '/', 'MOBILE_URL' : 'localhost' }
+const TEST_CONFIG = { ...PROD_CONFIG, PUBLIC_PATH: '/', 'MOBILE_URL' : '/' }
 
 const STAGING_CONFIG = {
   'ONFIDO_API_URL': 'https://apidev.onfido.com',
   'ONFIDO_SDK_URL': 'https://sdk-staging.onfido.com',
   'JWT_FACTORY': 'https://token-factory-dev.onfido.com/sdk_token',
   'DESKTOP_SYNC_URL' : 'https://sync-dev.onfido.com',
-  'MOBILE_URL' : 'localhost',
+  'MOBILE_URL' : '/',
   'SMS_DELIVERY_URL' : 'https://telephony-dev.onfido.com',
   'PUBLIC_PATH' : '/',
 }

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -97,14 +97,14 @@ const PROD_CONFIG = {
   'PUBLIC_PATH' : `https://s3-eu-west-1.amazonaws.com/onfido-assets-production/web-sdk-releases/${packageJson.version}/`,
 }
 
-const TEST_CONFIG = { ...PROD_CONFIG, PUBLIC_PATH: '/' }
+const TEST_CONFIG = { ...PROD_CONFIG, PUBLIC_PATH: '/', 'MOBILE_URL' : 'localhost' }
 
 const STAGING_CONFIG = {
   'ONFIDO_API_URL': 'https://apidev.onfido.com',
   'ONFIDO_SDK_URL': 'https://sdk-staging.onfido.com',
   'JWT_FACTORY': 'https://token-factory-dev.onfido.com/sdk_token',
   'DESKTOP_SYNC_URL' : 'https://sync-dev.onfido.com',
-  'MOBILE_URL' : 'https://id-dev.onfido.com',
+  'MOBILE_URL' : 'localhost',
   'SMS_DELIVERY_URL' : 'https://telephony-dev.onfido.com',
   'PUBLIC_PATH' : '/',
 }


### PR DESCRIPTION
Related monster changes here: https://bitbucket.org/onfido/monster/pull-requests/21/add-steps-to-open-links-in-a-new-tab/diff

**Update:** I've added a change that when `MOBILE_URL=/` we use the current server to host the cross device client. This is useful for local development, automated testing, and acceptance testing on surge. **However I am nervous about this change so please review critically!**

**Notes**
The surge cross device link is too long for the textarea, but we should not have this problem in production
![screen shot 2017-11-22 at 18 34 15](https://user-images.githubusercontent.com/6737066/33144127-ebd38148-cfb3-11e7-9ec8-566aae248b24.png)
