### PR TITLE
Changed copy on cross device link component

### DIFF
--- a/src/components/crossDevice/CrossDeviceLink/index.js
+++ b/src/components/crossDevice/CrossDeviceLink/index.js
@@ -177,12 +177,11 @@ class CrossDeviceLinkUI extends Component {
             <h1 className={`${theme.title} ${style.title}`}>Continue verification on your mobile</h1> }
         </div>
         <div className={theme.thickWrapper}>
-          <div>We’ll text a secure link to your mobile</div>
+          <div className={style.subTitle}>We’ll text a one-time secure link to your mobile</div>
 
           <div className={style.smsSection}>
             <div className={style.fieldLabel}>
               <div className={style.label}>Mobile number</div>
-              <div className={style.sublabel}>(We won’t keep or share your number)</div>
             </div>
             <div className={style.numberInputSection}>
               <div className={classNames(style.inputContainer, {[style.fieldError]: invalidNumber})}>

--- a/src/components/crossDevice/CrossDeviceLink/index.js
+++ b/src/components/crossDevice/CrossDeviceLink/index.js
@@ -180,9 +180,7 @@ class CrossDeviceLinkUI extends Component {
           <div className={style.subTitle}>We’ll text a one-time secure link to your mobile</div>
 
           <div className={style.smsSection}>
-            <div className={style.fieldLabel}>
-              <div className={style.label}>Mobile number</div>
-            </div>
+            <div className={style.label}>Mobile number</div>
             <div className={style.numberInputSection}>
               <div className={classNames(style.inputContainer, {[style.fieldError]: invalidNumber})}>
                 <PhoneNumberInputLazy { ...this.props} clearErrors={this.clearErrors} />

--- a/src/components/crossDevice/CrossDeviceLink/style.css
+++ b/src/components/crossDevice/CrossDeviceLink/style.css
@@ -8,10 +8,6 @@
   font-weight: 600;
 }
 
-.fieldLabel{
-  margin-bottom: 4px;
-}
-
 .label {
   font-weight: 600;
   text-align: left;

--- a/src/components/crossDevice/CrossDeviceLink/style.css
+++ b/src/components/crossDevice/CrossDeviceLink/style.css
@@ -4,6 +4,10 @@
   margin-top: 56px;
 }
 
+.subTitle{
+  font-weight: 600;
+}
+
 .fieldLabel{
   margin-bottom: 4px;
 }
@@ -12,12 +16,6 @@
   font-weight: 600;
   text-align: left;
   color: #2C3E4F;
-  float: left;
-}
-
-.sublabel {
-  font-size: 14px;
-  margin-left: 4px;
   float: left;
 }
 


### PR DESCRIPTION
* Changed subtitle text within `CrossDeviceLink` component to "We’ll text a one-time secure link to your mobile". The subtitle is bold.
* Removed "(we wont keep or share...)" 
CC: @danielspagnolo 