### PR TITLE
Fix media queries overlap

### DIFF
--- a/src/components/Theme/constants.css
+++ b/src/components/Theme/constants.css
@@ -1,5 +1,5 @@
-@custom-media --large (min-width: 30em);
-@custom-media --small-viewport (max-width: 30em);
+@custom-media --large (min-width: 480px);
+@custom-media --small-viewport (max-width: 479px);
 @large-text-margin: 40px;
 @small-text-margin: 24px;
 

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -17,7 +17,7 @@
       body, button {
         -webkit-font-smoothing: antialiased;
       }
-      @media (min-width: 30em) {
+      @media (min-width: 480px) {
         #onfido-mount {
           position: relative;
           top: 10%;


### PR DESCRIPTION
This PR fixes the issue with the SDK disappearing if screen width is 480px. This was due to media queries overlap.
I have used `px` instead of `em` because `calc` doesn't work with media queries.