### PR TITLE
Improve release guidelines

### DIFF
--- a/release_guidelines.md
+++ b/release_guidelines.md
@@ -25,14 +25,14 @@ An example release candidate version `<VERSION_RC>` could be `2.0.0-rc.1`
     - `npm install`
 9. Build the dist files for release candidate
     - `npm run build`
-10. Deploy dist files to the incremented `<BASE_32_VERSION>` on AWS production:
+10. **[Cross Device]** Deploy dist files to the incremented `<BASE_32_VERSION>` on AWS production:
     - `aws s3 sync ./dist s3://onfido-assets-production/web-sdk/<BASE_32_VERSION>/ --exclude "*.html" --exclude "*.map" --acl public-read --delete`
-11. [Deploy dist files to the release candidate <VERSION_RC> on S3 production](#deploying-the-release-to-S3-production)
-    - `aws s3 sync ./dist s3://onfido-assets-production/web-sdk-releases/<VERSION_RC> --exclude "*.html" --exclude "*.map" --acl public-read --delete`
+11. **[Lazy loading]** [Deploy dist files to the release candidate <VERSION_RC> on S3 production](#deploying-the-release-to-S3-production)
+    - use `<VERSION_RC>`
 12. Create a release branch: `release/<VERSION>`. Use the final version rather than a release candidate in the branch name
     - `git checkout -b release/<VERSION>`
-13. [Update JSFiddle demo](#update-jsfiddle-demo) link in README.md
-14. Commit all the changes. Put `<VERSION_RC>` as part of the commit message
+13. Commit all changes with commit message including `Bump version to <VERSION_RC>`
+14. [Update JSFiddle demo](#update-jsfiddle-demo) link in README.md
 15. Create release candidate tag in `npm`:
     - `npm publish --tag next`
     - (if you don't have access, get credentials to npm from OneLogin)
@@ -53,11 +53,11 @@ An example release version `<VERSION>` could be `2.0.0`
 1. Bump version `package.json` to release version `<VERSION>`
 2. Build the dist files for release version
     - `npm run build`
-3. Deploy dist files to the `<BASE_32_VERSION>` on AWS production:
+3. **[Cross Device]** Deploy dist files to the `<BASE_32_VERSION>` on AWS production:
     - `aws s3 sync ./dist s3://onfido-assets-production/web-sdk/<BASE_32_VERSION>/ --exclude "*.html" --exclude "*.map" --acl public-read --delete`
-4. [Deploy the release dist to S3 production](#deploying-the-release-to-S3-production)
-    - `aws s3 sync ./dist s3://onfido-assets-production/web-sdk-releases/<VERSION> --exclude "*.html" --exclude "*.map" --acl public-read --delete`
-5. Commit all the changes above including `Bump version to <VERSION>` in commit message
+4. **[Lazy loading]** [Deploy the release dist to S3 production](#deploying-the-release-to-S3-production)
+    - use `<VERSION>`
+5. Commit all changes with commit message including `Bump version to <VERSION>`
 6. [Update JSFiddle demo](#update-jsfiddle-demo) link in README.md
 7. *Once release PR is approved*, on release branch create a tag with release version (without `rc`):
     * `git tag <VERSION>`
@@ -82,6 +82,7 @@ Deploying `dist/` folder to S3 is a crucial part of the release. It allows us to
 - Make sure version is bumped in `package.json`
 - Make sure the `dist/` folder is updated and commited (by `npm run build`)
 - Run `aws s3 sync ./dist s3://onfido-assets-production/web-sdk-releases/<VERSION> --exclude "*.html" --exclude "*.map" --acl public-read --delete`
+  - **Note:** Mind that `<VERSION>` should be used only for release version and `<VERSION_RC>` should be used for release candidates instead. Apply according to instructions in guidelines!
 - Make sure `dist/style.css`, `dist/onfido.min.js` and `dist/onfido.crossDevice.min.js` are in the S3 folder
 
 Now you can go on and update JSFiddle.

--- a/release_guidelines.md
+++ b/release_guidelines.md
@@ -11,8 +11,8 @@ We follow [semver](http://semver.org/) for versioning. Given a version number MA
 An example release candidate version `<VERSION_RC>` could be `2.0.0-rc.1`
 
 1. Make sure all features for the forthcoming release have been merged to `development` branch.
-2. Checkout and pull `develop` branch
-    - `git checkout develop && git pull`
+2. Checkout and pull `development` branch
+    - `git checkout development && git pull`
 3. Make sure README.md file has been updated
 4. Make sure CHANGELOG.md has been updated
     - with new version number
@@ -20,7 +20,7 @@ An example release candidate version `<VERSION_RC>` could be `2.0.0-rc.1`
 5. Make sure MIGRATION.md has been updated, if applicable.
 6. Update the SDK package version in `package.json` to `<VERSION_RC>`
 7. Increment `BASE_32_VERSION` in `webpack.config.babel.js` e.g. `AA` => `AB`
-    - do it only ONCE per release, *not* per release candidate
+    - do it only if a breaking change is introduced between SDK and cross device client. This must be done only ONCE per release, *not* per release candidate
 8. Install npm dependencies
     - `npm install`
 9. Build the dist files for release candidate
@@ -69,7 +69,7 @@ An example release version `<VERSION>` could be `2.0.0`
 11. Merge `release/<release_version>` PR to `master`
 12. Merge `master` to `development`
     * `git checkout master && git pull -p`
-    * `git checkout develop && git pull -p`
+    * `git checkout development && git pull -p`
     * `git merge master`
     * `git push`
 13. After the release: [Update Sample App](#update-sample-app)
@@ -95,6 +95,7 @@ Now you can go on and update JSFiddle.
   - `https://cdn.rawgit.com/onfido/onfido-sdk-ui/<tag>/dist/onfido.min.js`
 - Follow the migration notes and update the code if necessary
 - Test the happy path
+- Copy the new JSFiddle link into README.md
 
 ## Update Sample App
 - https://github.com/onfido/onfido-sdk-web-sample-app

--- a/release_guidelines.md
+++ b/release_guidelines.md
@@ -8,73 +8,96 @@ We follow [semver](http://semver.org/) for versioning. Given a version number MA
 
 ## Creating a Release Candidate
 
-An example `<VERSION_RC>` could be `2.0.0-rc.1`
+An example release candidate version `<VERSION_RC>` could be `2.0.0-rc.1`
 
-* Create a release branch: `release/<version>`. Use the final version rather than a release candidate in the branch name.
-* Update the SDK package version in `package.json` to `<VERSION_RC>`
-* Update the change log following [this](http://keepachangelog.com/)
-* Increment `BASE_32_VERSION` in `webpack.config.babel.js` e.g. `AA` => `AB`
-  * You only need to do this once per release, *not* per release candidate
-* Build the dist files with `npm run build`
-* Run `aws s3 sync ./dist s3://onfido-assets-production/web-sdk/<BASE_32_VERSION>/ --exclude "*.html" --exclude "*.map" --acl public-read --delete`
-* [Deploying the release to S3 production](#deploying-the-release-to-S3-production)
-  * Run `aws s3 sync ./dist s3://onfido-assets-production/web-sdk-releases/<VERSION_RC> --exclude "*.html" --exclude "*.map" --acl public-read --delete`
-* Commit the above using the version as the commit message
-* Create a pull request from the release branch into master
-* [Update JSFiddle demo](#update-jsfiddle-demo)
-* On the release branch run `npm publish --tag next`
-  * Get the credentials from One Login
-  * Read about npm and release candidates [here](https://medium.com/@mbostock/prereleases-and-npm-e778fc5e2420)
-* Check the `latest` tag had not moved with `npm dist-tag ls onfido-sdk-ui`
-* Check you can install the package with `npm install onfido-sdk-ui@<VERSION_RC>`
-* Create a git tag with rc version on github, i.e `2.0.0-rc.1`:
-  * Pointing to the release commit on the release branch
-  * The release tag and title should be the version
-  * The description should be the change log entry for the release
-* Test the SDK deployment on surge associated with the PR
+1. Make sure all features for the forthcoming release have been merged to `development` branch.
+2. Checkout and pull `develop` branch
+    - `git checkout develop && git pull`
+3. Make sure README.md file has been updated
+4. Make sure CHANGELOG.md has been updated
+    - with new version number
+    - with all Public, Internal and UI changes
+5. Make sure MIGRATION.md has been updated, if applicable.
+6. Update the SDK package version in `package.json` to `<VERSION_RC>`
+7. Increment `BASE_32_VERSION` in `webpack.config.babel.js` e.g. `AA` => `AB`
+    - do it only ONCE per release, *not* per release candidate
+8. Install npm dependencies
+    - `npm install`
+9. Build the dist files for release candidate
+    - `npm run build`
+10. Run `aws s3 sync ./dist s3://onfido-assets-production/web-sdk/<BASE_32_VERSION>/ --exclude "*.html" --exclude "*.map" --acl public-read --delete`
+11. [Deploy the release to S3 production](#deploying-the-release-to-S3-production)
+    - run `aws s3 sync ./dist s3://onfido-assets-production/web-sdk-releases/<VERSION_RC> --exclude "*.html" --exclude "*.map" --acl public-read --delete`
+12. Create a release branch: `release/<VERSION>`. Use the final version rather than a release candidate in the branch name
+    - `git checkout -b release/<VERSION>`
+13. [Update JSFiddle demo](#update-jsfiddle-demo) link in README.md
+14. Commit all the changes above including the `<VERSION_RC>` in the commit message
+15. Create release candidate tag in `npm`:
+    - `npm publish --tag next`
+    - if you don't have access, get credentials to npm from OneLogin
+16. Check the `latest` tag had not moved:
+    - `npm dist-tag ls onfido-sdk-ui`
+17. Check you can install the package with `npm install onfido-sdk-ui@<VERSION_RC>`
+18. On `release/<release_version>` branch, create a git tag for release candidate:
+    - `git tag -a <VERSION_RC>`
+    - `git push --tags`
+19. Perform [regression testing](#MANUAL_REGRESSION)
+    - test the SDK deployment on surge link associated with the PR
 
 ## Publishing a release
 
-An example `<VERSION>` could be `2.0.0`
+An example release version `<VERSION>` could be `2.0.0`
 
-* Create a release candidate
-* On the release branch update the version in `package.json` to `<VERSION>`
-* Build the dist files with `npm run build`
-* Run `aws s3 sync ./dist s3://onfido-assets-production/web-sdk/<BASE_32_VERSION>/ --exclude "*.html" --exclude "*.map" --acl public-read --delete`
-* [Deploying the release to S3 production](#deploying-the-release-to-S3-production)
-  * Run `aws s3 sync ./dist s3://onfido-assets-production/web-sdk-releases/<VERSION> --exclude "*.html" --exclude "*.map" --acl public-read --delete`
-* Update the change log entry of the release candidate you are using
-* [Update JSFiddle demo](#update-jsfiddle-demo)
-* Perform the release: on the release branch run `npm publish`
-* Check you can install your release with `npm install onfido-sdk-ui`
-* Create a new release on GitHub
-* Commit and merge the release branch into master
-* After the release: [Update Sample App](#update-sample-app)
+1. Bump version `package.json` to release version `<VERSION>`
+2. Build the dist files for release version
+    - `npm run build`
+3. Deploy dist to staging on AWS
+    - `aws s3 sync ./dist s3://onfido-assets-production/web-sdk/<BASE_32_VERSION>/ --exclude "*.html" --exclude "*.map" --acl public-read --delete`
+4. [Deploy the release dist to production on AWS](#deploying-the-release-to-S3-production)
+    - `aws s3 sync ./dist s3://onfido-assets-production/web-sdk-releases/<VERSION> --exclude "*.html" --exclude "*.map" --acl public-read --delete`
+5. [Update JSFiddle demo](#update-jsfiddle-demo) link in README.md
+6. Commit all the changes above including `Bump version to <VERSION>` in commit message
+7. *Once release PR is approved*, on release branch create a tag with release version (without `rc`):
+    * `git tag <VERSION>`
+8. *Perform the release on the release branch:*
+    - `npm publish`
+9. Check you can install your release with `npm install onfido-sdk-ui`
+    - latest `<VERSION>` release should be installed
+10. Create a new release on GitHub, using release tag:
+    - title should be a version number `<VERSION>`
+    - as description use the entries for that version from CHANGELOG.md
+11. Merge `release/<release_version>` PR to `master`
+12. Merge `master` to `development`
+    * `git checkout master && git pull -p`
+    * `git checkout develop && git pull -p`
+    * `git merge master`
+    * `git push`
+13. After the release: [Update Sample App](#update-sample-app)
 
 ## Deploying the release to S3 production
 Deploying `dist/` folder to S3 is a crucial part of the release. It allows us to have a working demo of the SDK in JSFiddle and, more importantly, to support code splitting and lazy loading when the SDK is imported using HTML.
 
-* Make sure version is bumped in `package.json`
-* Make sure the `dist/` folder is updated and commited (by `npm run build`)
-* Run `aws s3 sync ./dist s3://onfido-assets-production/web-sdk-releases/<VERSION> --exclude "*.html" --exclude "*.map" --acl public-read --delete`
-* Make sure `dist/style.css`, `dist/onfido.min.js` and `dist/onfido.crossDevice.min.js` are in the S3 folder
+- Make sure version is bumped in `package.json`
+- Make sure the `dist/` folder is updated and commited (by `npm run build`)
+- Run `aws s3 sync ./dist s3://onfido-assets-production/web-sdk-releases/<VERSION> --exclude "*.html" --exclude "*.map" --acl public-read --delete`
+- Make sure `dist/style.css`, `dist/onfido.min.js` and `dist/onfido.crossDevice.min.js` are in the S3 folder
 
 Now you can go on and update JSFiddle.
 
 ## Update JSFiddle Demo
-* Make sure [Deploying the release to S3 production](#deploying-the-release-to-S3-production) step is executed before
-* See if these exist:
-  * `https://raw.githubusercontent.com/onfido/onfido-sdk-ui/<tag>/dist/style.css`
-  * `https://raw.githubusercontent.com/onfido/onfido-sdk-ui/<tag>/dist/onfido.min.js`
-* If they exist, copy each of them and paste on https://rawgit.com
-* Open the JSFiddle and update its resources to the following:
-  * `https://cdn.rawgit.com/onfido/onfido-sdk-ui/<tag>/dist/style.css`
-  * `https://cdn.rawgit.com/onfido/onfido-sdk-ui/<tag>/dist/onfido.min.js`
-* Follow the migration notes and update the code if necessary
-* Test the happy path
+- Make sure [Deploying the release to S3 production](#deploying-the-release-to-S3-production) step has been executed before
+- See if these exist:
+  - `https://raw.githubusercontent.com/onfido/onfido-sdk-ui/<tag>/dist/style.css`
+  - `https://raw.githubusercontent.com/onfido/onfido-sdk-ui/<tag>/dist/onfido.min.js`
+- If they exist, copy each of them and paste to https://rawgit.com
+- Open the JSFiddle and update its resources to the following:
+  - `https://cdn.rawgit.com/onfido/onfido-sdk-ui/<tag>/dist/style.css`
+  - `https://cdn.rawgit.com/onfido/onfido-sdk-ui/<tag>/dist/onfido.min.js`
+- Follow the migration notes and update the code if necessary
+- Test the happy path
 
 ## Update Sample App
-* https://github.com/onfido/onfido-sdk-web-sample-app
-* After the release, bump Onfido SDK version in `package.json` of Sample App
-* If Onfido SDK release introduced breaking changes, apply them according to migration guide
-* Issue PR with mentioned changes to master
+- https://github.com/onfido/onfido-sdk-web-sample-app
+- After the release, bump Onfido SDK version in `package.json` of Sample App
+- If Onfido SDK release introduced breaking changes, apply them according to migration guide
+- Issue PR with mentioned changes to master

--- a/release_guidelines.md
+++ b/release_guidelines.md
@@ -20,22 +20,23 @@ An example release candidate version `<VERSION_RC>` could be `2.0.0-rc.1`
 5. Make sure MIGRATION.md has been updated, if applicable.
 6. Update the SDK package version in `package.json` to `<VERSION_RC>`
 7. Increment `BASE_32_VERSION` in `webpack.config.babel.js` e.g. `AA` => `AB`
-    - do it only if a breaking change is introduced between SDK and cross device client. This must be done only ONCE per release, *not* per release candidate
+    - **NOTE:** do it only if a breaking change is introduced between SDK and cross device client. This must be done only ONCE per release, *not* per release candidate
 8. Install npm dependencies
     - `npm install`
 9. Build the dist files for release candidate
     - `npm run build`
-10. Run `aws s3 sync ./dist s3://onfido-assets-production/web-sdk/<BASE_32_VERSION>/ --exclude "*.html" --exclude "*.map" --acl public-read --delete`
-11. [Deploy the release to S3 production](#deploying-the-release-to-S3-production)
-    - run `aws s3 sync ./dist s3://onfido-assets-production/web-sdk-releases/<VERSION_RC> --exclude "*.html" --exclude "*.map" --acl public-read --delete`
+10. Deploy dist files to the incremented `<BASE_32_VERSION>` on AWS production:
+    - `aws s3 sync ./dist s3://onfido-assets-production/web-sdk/<BASE_32_VERSION>/ --exclude "*.html" --exclude "*.map" --acl public-read --delete`
+11. [Deploy dist files to the release candidate <VERSION_RC> on S3 production](#deploying-the-release-to-S3-production)
+    - `aws s3 sync ./dist s3://onfido-assets-production/web-sdk-releases/<VERSION_RC> --exclude "*.html" --exclude "*.map" --acl public-read --delete`
 12. Create a release branch: `release/<VERSION>`. Use the final version rather than a release candidate in the branch name
     - `git checkout -b release/<VERSION>`
 13. [Update JSFiddle demo](#update-jsfiddle-demo) link in README.md
-14. Commit all the changes above including the `<VERSION_RC>` in the commit message
+14. Commit all the changes. Put `<VERSION_RC>` as part of the commit message
 15. Create release candidate tag in `npm`:
     - `npm publish --tag next`
-    - if you don't have access, get credentials to npm from OneLogin
-16. Check the `latest` tag had not moved:
+    - (if you don't have access, get credentials to npm from OneLogin)
+16. Check that the `latest` tag has not been changed, only the `next` one:
     - `npm dist-tag ls onfido-sdk-ui`
 17. Check you can install the package with `npm install onfido-sdk-ui@<VERSION_RC>`
 18. On `release/<release_version>` branch, create a git tag for release candidate:
@@ -48,15 +49,16 @@ An example release candidate version `<VERSION_RC>` could be `2.0.0-rc.1`
 
 An example release version `<VERSION>` could be `2.0.0`
 
+0. If the release candidate has not uncovered any bugs.
 1. Bump version `package.json` to release version `<VERSION>`
 2. Build the dist files for release version
     - `npm run build`
-3. Deploy dist to staging on AWS
+3. Deploy dist files to the `<BASE_32_VERSION>` on AWS production:
     - `aws s3 sync ./dist s3://onfido-assets-production/web-sdk/<BASE_32_VERSION>/ --exclude "*.html" --exclude "*.map" --acl public-read --delete`
-4. [Deploy the release dist to production on AWS](#deploying-the-release-to-S3-production)
+4. [Deploy the release dist to S3 production](#deploying-the-release-to-S3-production)
     - `aws s3 sync ./dist s3://onfido-assets-production/web-sdk-releases/<VERSION> --exclude "*.html" --exclude "*.map" --acl public-read --delete`
-5. [Update JSFiddle demo](#update-jsfiddle-demo) link in README.md
-6. Commit all the changes above including `Bump version to <VERSION>` in commit message
+5. Commit all the changes above including `Bump version to <VERSION>` in commit message
+6. [Update JSFiddle demo](#update-jsfiddle-demo) link in README.md
 7. *Once release PR is approved*, on release branch create a tag with release version (without `rc`):
     * `git tag <VERSION>`
 8. *Perform the release on the release branch:*
@@ -86,13 +88,9 @@ Now you can go on and update JSFiddle.
 
 ## Update JSFiddle Demo
 - Make sure [Deploying the release to S3 production](#deploying-the-release-to-S3-production) step has been executed before
-- See if these exist:
-  - `https://raw.githubusercontent.com/onfido/onfido-sdk-ui/<tag>/dist/style.css`
-  - `https://raw.githubusercontent.com/onfido/onfido-sdk-ui/<tag>/dist/onfido.min.js`
-- If they exist, copy each of them and paste to https://rawgit.com
 - Open the JSFiddle and update its resources to the following:
-  - `https://cdn.rawgit.com/onfido/onfido-sdk-ui/<tag>/dist/style.css`
-  - `https://cdn.rawgit.com/onfido/onfido-sdk-ui/<tag>/dist/onfido.min.js`
+  - `https://s3-eu-west-1.amazonaws.com/onfido-assets-production/web-sdk-releases/<VERSION>/dist/style.css`
+  - `https://s3-eu-west-1.amazonaws.com/onfido-assets-production/web-sdk-releases/<VERSION>/dist/onfido.min.js`
 - Follow the migration notes and update the code if necessary
 - Test the happy path
 - Copy the new JSFiddle link into README.md


### PR DESCRIPTION
# Problem
We have uncomplete, unclear release guidelines for JS SDK. That caused troubles when other people were making JS release.

# Solution
RELEASE_GUIDELINES.md has been updated with more details provided and also to reflect manual regression testing.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
