### PR TITLE
Fix flexbox issue on IE11

### DIFF
--- a/src/components/Uploader/style.css
+++ b/src/components/Uploader/style.css
@@ -26,6 +26,8 @@
 }
 
 .uploaderWrapper {
+  display: flex;
+  flex-direction: column;
   margin: 0rem 1rem;
 }
 


### PR DESCRIPTION
# Problem
Flexbox column direction doesn't work when the container has `min-height`.
![screen shot 2018-02-07 at 14 23 11](https://user-images.githubusercontent.com/7127427/35927792-7ab9a986-0c23-11e8-9686-f7c9146cd98c.png)

# Solution
The workaround is "to add a wrapper element around the flex container that is itself a flex container in the column direction."
Reference:
https://github.com/philipwalton/flexbugs/commit/306eebb50d2d66f8845c3ad063d4e2a0001c992b

Output (tested on IE11 on VM using WIN7) : 
![screen shot 2018-02-07 at 16 27 45](https://user-images.githubusercontent.com/7127427/35927954-e3557d4e-0c23-11e8-9831-faacdc89dc92.png)

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
