### PR TITLE
Feature/deprecate doc webcam cx 1736

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Fixed
 - Internal: Fixed the `tearDown` method to clear the onComplete callback functions.
 
-### Removed
+### Deprecated
 - Internal: Removed references to `useWebcam` option from README.md and return console warning if the option is used.
 
 ## [2.2.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Fixed
 - Internal: Fixed the `tearDown` method to clear the onComplete callback functions.
 
+### Removed
+- Internal: Removed references to `useWebcam` option from README.md and return console warning if the option is used.
+
 ## [2.2.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -263,18 +263,12 @@ A number of options are available to allow you to customise the SDK:
         title: 'Open your new bank account'
       }
     },
-    {
-      type: 'document',
-      options: {
-        useWebcam: true // This is in beta!
-      }
-    },
+    'document',
     'face'
   ]
   ```
 
-  In the example above, the SDK flow is consisted of three steps: `welcome`, `document` and `face`. Note that the `title` option of the `
-  welcome` step and the `useWebcam` option of the `document` step are being overridden, while the `face` step is not being customised.
+  In the example above, the SDK flow is consisted of three steps: `welcome`, `document` and `face`. Note that the `title` option of the `welcome` step is being overridden, while the other steps are not being customised.
 
   Below are descriptions of the steps and the custom options that you can specify inside the `options` property. Unless overridden, the default option values will be used:
 
@@ -288,9 +282,7 @@ A number of options are available to allow you to customise the SDK:
 
   ### document ###
 
-  This is the document capture step. Users will be asked to select the document type and to provide images of their selected documents. They will also have a chance to check the quality of the images before confirming. The custom options are:
-
-  - useWebcam (boolean - note that this is an *experimental* beta option)
+  This is the document capture step. Users will be asked to select the document type and to provide images of their selected documents. They will also have a chance to check the quality of the images before confirming. No customisation options are available for this step.
 
   ### face ###
 

--- a/src/index.js
+++ b/src/index.js
@@ -61,10 +61,19 @@ const formatOptions = ({steps, ...otherOptions}) => ({
   steps: (steps || ['welcome','document','face','complete']).map(formatStep)
 })
 
+const deprecationWarnings = ({steps}) => {
+  const useWebcamOption = steps.some(step => step.options && step.options.useWebcam)
+  if (useWebcamOption) {
+    console.warn("`useWebcam` is an experimental option and is currently discouraged")
+  }
+}
+
 Onfido.init = (opts) => {
   console.log("onfido_sdk_version", process.env.SDK_VERSION)
   Tracker.track()
   const options = formatOptions({ ...defaults, ...opts, events })
+  deprecationWarnings(options)
+
   bindOnComplete(options)
 
   const containerEl = document.getElementById(options.containerId)


### PR DESCRIPTION
# Problem
The `useWebcam` option is experimental and its use should not be encouraged.

# Solution
* Removed references to `useWebcam` from documentation
* Show a warning in the console if the option is used

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
