### PR TITLE
Improvement/reduce bundle size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11174,9 +11174,12 @@
       }
     },
     "react-webcam-onfido": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/react-webcam-onfido/-/react-webcam-onfido-0.1.0.tgz",
-      "integrity": "sha512-GMejXSylBgawAJN255KdEfIWu+WZLO77nzo6JmBzyWs/TqoVojHYopFVmPBSPKK4rqzhvxtStwOycBrdoosCmg=="
+      "version": "0.1.1-rc1",
+      "resolved": "https://registry.npmjs.org/react-webcam-onfido/-/react-webcam-onfido-0.1.1-rc1.tgz",
+      "integrity": "sha512-EDYKKNcT/alxfQXeoO/jywTQQLhQla2RJjrr+QBCyCx9UlPvlERDms6FQdC+9CxphgwIb59enjV9vkvHiAdwPA==",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "read": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "react-native-listener": "1.0.1",
     "react-phone-number-input": "^0.15.2",
     "react-redux": "4.4.6",
-    "react-webcam-onfido": "^0.1.0",
+    "react-webcam-onfido": "^0.1.1-rc1",
     "redux": "3.5.2",
     "reselect": "2.5.1",
     "socket.io-client": "^2.0.4",

--- a/src/Tracker/index.js
+++ b/src/Tracker/index.js
@@ -1,7 +1,7 @@
 import { h, Component } from 'preact'
 import Raven from 'raven-js'
 import {cleanFalsy, wrapArray} from '../components/utils/array'
-require('script-loader!../../node_modules/wpt/wpt.js')
+require('script-loader!../../node_modules/wpt/wpt.min.js')
 import mapObject from 'object-loops/map'
 
 const RavenTracker = Raven.config('https://6e3dc0335efc49889187ec90288a84fd@sentry.io/109946')


### PR DESCRIPTION
# Problem

https://319-pr-onfido-sdk-ui-onfido.surge.sh/reports/bundle_dist_size.html
Looking at this report one can see some dependencies are bigger than they should.
Dependencies which should be looked into:
1. Woopra (The biggest module!)
2. React Webcam (it's 1 file, it should not be so big)

Motivation: https://github.com/onfido/onfido-sdk-ui/issues/317

# Solution

1. Use woopra minified. Apparently webpack does not minify js files which are not commonjs. So using the already minified woopra file gave a gain of 40KB
2. Made react webcam use babel runtime so that babel code can be shared with the sdk. Waiting for this PR: https://github.com/onfido/react-webcam/pull/15. 15KB save.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
