### PR TITLE
Clear error on configuration received, increase timeout to 10s

### DIFF
--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -72,7 +72,7 @@ class CrossDeviceMobileRouter extends Component {
     this.clearConfigTimeout()
     this.configTimeoutId = setTimeout(() => {
       if (this.state.loading) this.setError()
-    }, 5000)
+    }, 10000)
   }
 
   clearConfigTimeout = () =>
@@ -98,7 +98,7 @@ class CrossDeviceMobileRouter extends Component {
       sendError(`Token has expired: ${token}`)
       return this.setError()
     }
-    this.setState({token, steps, step, loading: false, i18n: initializeI18n(language)})
+    this.setState({token, steps, step, loading: false, crossDeviceError: false, i18n: initializeI18n(language)})
     actions.setDocumentType(documentType)
     actions.acceptTerms()
   }


### PR DESCRIPTION
# Problem

When users want to continue the verification using their mobile devices, and open the link on an Android mobile devices, they see an error 50% of the times when they try to open the link using Chrome.

Reason: The content download time is > 5s.


# Solution

Clear out the error when configuration received and increase timeout from 5 to 10 seconds, since we have seen few cases of content download time taking longer than 5 seconds.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
