### PR TITLE
Feature/use array find cx 2097

### DIFF
--- a/src/components/Router/StepComponentMap.js
+++ b/src/components/Router/StepComponentMap.js
@@ -1,5 +1,4 @@
 import { h } from 'preact'
-import 'babel-polyfill'
 
 import Welcome from '../Welcome'
 import Select from '../Select'
@@ -45,7 +44,7 @@ const createDocumentComponents = (documentType) => {
 
 const crossDeviceSteps = (steps) => {
   const baseSteps = [{'type': 'crossDevice'}]
-  const completeStep = steps.find(isComplete)
+  const completeStep = Array.find(steps, isComplete)
   return hasCompleteStep(steps) ? [...baseSteps, completeStep] : baseSteps
 }
 

--- a/src/components/Router/StepComponentMap.js
+++ b/src/components/Router/StepComponentMap.js
@@ -1,4 +1,5 @@
 import { h } from 'preact'
+import 'babel-polyfill'
 
 import Welcome from '../Welcome'
 import Select from '../Select'


### PR DESCRIPTION
# Problem
`Array.prototype.find()` doesn't work on IE11.

# Solution
Use `Array.find(arr, fn)` instead.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
