### PR TITLE
Wrapped all components in theme layout

### DIFF
--- a/src/components/PhoneNumberInput/index.js
+++ b/src/components/PhoneNumberInput/index.js
@@ -30,12 +30,14 @@ class PhoneNumberInput extends Component {
   }
 
   render = ({i18n}) =>
-    <PhoneNumber placeholder={i18n.t('cross_device.phone_number_placeholder')}
-      onChange={this.onChange}
-      country={this.state.country}
-      inputClassName={`${style.mobileInput}`}
-      className={`${style.phoneNumberContainer}`}
-    />
+    <form>
+      <PhoneNumber placeholder={i18n.t('cross_device.phone_number_placeholder')}
+        onChange={this.onChange}
+        country={this.state.country}
+        inputClassName={`${style.mobileInput}`}
+        className={`${style.phoneNumberContainer}`}
+      />
+    </form>
 }
 
 export default PhoneNumberInput

--- a/src/components/Router/StepsRouter.js
+++ b/src/components/Router/StepsRouter.js
@@ -2,8 +2,7 @@ import { h, Component } from 'preact'
 
 import {sendScreen} from '../../Tracker'
 import {wrapArray} from '../utils/array'
-import NavigationBar from '../NavigationBar'
-import theme from '../Theme/style.css'
+import {themeWrap} from '../Theme'
 
 class StepsRouter extends Component {
   constructor(props) {
@@ -25,21 +24,13 @@ class StepsRouter extends Component {
   render = ({options: {...globalUserOptions}, ...otherProps}) => {
     const componentBlob = this.currentComponent()
     const CurrentComponent = componentBlob.component
-    const {back, i18n, disableBackNavigation} = this.props
+    const WrappedApp = themeWrap(CurrentComponent)
     const options = componentBlob.step.options
     const isFullScreen = this.state.fullScreen
 
     return (
-      <div className={theme.step}>
-        <NavigationBar {...{back, i18n, isFullScreen}} disabled={disableBackNavigation} className={theme.navigationBar}
-        />
-        <div className={theme.content}>
-          <CurrentComponent
-            {...{...options, ...globalUserOptions, ...otherProps, isFullScreen}}
-            trackScreen={this.trackScreen} useFullScreen={this.useFullScreen} />
-        </div>
-        <div className={theme.footer} />
-      </div>
+      <WrappedApp {...{...options, ...globalUserOptions, ...otherProps, isFullScreen}}
+        trackScreen={this.trackScreen} useFullScreen={this.useFullScreen} />
     )
   }
 }

--- a/src/components/Router/StepsRouter.js
+++ b/src/components/Router/StepsRouter.js
@@ -2,7 +2,8 @@ import { h, Component } from 'preact'
 
 import {sendScreen} from '../../Tracker'
 import {wrapArray} from '../utils/array'
-import {themeWrap} from '../Theme'
+import NavigationBar from '../NavigationBar'
+import theme from '../Theme/style.css'
 
 class StepsRouter extends Component {
   constructor(props) {
@@ -24,13 +25,20 @@ class StepsRouter extends Component {
   render = ({options: {...globalUserOptions}, ...otherProps}) => {
     const componentBlob = this.currentComponent()
     const CurrentComponent = componentBlob.component
-    const WrappedApp = themeWrap(CurrentComponent)
+    const {back, i18n, disableNavigation} = this.props
     const options = componentBlob.step.options
     const isFullScreen = this.state.fullScreen
 
     return (
-      <WrappedApp {...{...options, ...globalUserOptions, ...otherProps, isFullScreen}}
-        trackScreen={this.trackScreen} useFullScreen={this.useFullScreen} />
+      //TODO: Wrap CurrentComponent in themeWrap HOC
+      <div className={theme.step}>
+        <NavigationBar {...{back, i18n, isFullScreen}} disabled={disableNavigation} className={theme.navigationBar}/>
+        <div className={theme.content}>
+          <CurrentComponent {...{...options, ...globalUserOptions, ...otherProps, isFullScreen}}
+            trackScreen={this.trackScreen} useFullScreen={this.useFullScreen} />
+        </div>
+        <div className={theme.footer} />
+      </div>
     )
   }
 }

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -7,6 +7,7 @@ import URLSearchParams from 'url-search-params'
 
 import { componentsList } from './StepComponentMap'
 import StepsRouter from './StepsRouter'
+import { themeWrap } from '../Theme'
 import Spinner from '../Spinner'
 import GenericError from '../crossDevice/GenericError'
 import { unboundActions } from '../../core'
@@ -21,6 +22,10 @@ const Router = (props) =>{
   const RouterComponent = props.options.mobileFlow ? CrossDeviceMobileRouter : MainRouter
   return <RouterComponent {...props} allowCrossDeviceFlow={!props.options.mobileFlow && isDesktop}/>
 }
+
+// Wrap components with theme that include navigation and footer
+const WrappedSpinner = themeWrap(Spinner)
+const WrappedError = themeWrap(GenericError)
 
 class CrossDeviceMobileRouter extends Component {
   constructor(props) {
@@ -124,8 +129,8 @@ class CrossDeviceMobileRouter extends Component {
   }
 
   render = (props) =>
-    this.state.loading ? <Spinner /> :
-      this.state.crossDeviceError ? <GenericError i18n={this.state.i18n}/> :
+    this.state.loading ? <WrappedSpinner i18n={this.state.i18n} disableNavigation={true} /> :
+      this.state.crossDeviceError ? <WrappedError i18n={this.state.i18n} disableNavigation={true} /> :
         <HistoryRouter {...props} {...this.state}
           onStepChange={this.onStepChange}
           sendClientSuccess={this.sendClientSuccess}
@@ -190,7 +195,7 @@ class HistoryRouter extends Component {
     this.unlisten()
   }
 
-  disableBackNavigation = () => {
+  disableNavigation = () => {
     const componentList = this.componentsList()
     const currentStepIndex = this.state.step
     const currentStepType = componentList[currentStepIndex].step.type
@@ -245,7 +250,7 @@ class HistoryRouter extends Component {
       <StepsRouter {...props}
         componentsList={this.componentsList()}
         step={this.state.step}
-        disableBackNavigation={this.disableBackNavigation()}
+        disableNavigation={this.disableNavigation()}
         changeFlowTo={this.changeFlowTo}
         nextStep={this.nextStep}
         previousStep={this.previousStep}

--- a/src/components/Theme/index.js
+++ b/src/components/Theme/index.js
@@ -9,7 +9,7 @@ export const themeWrap = (WrappedComponent) => (props) => {
   return (
     <div className={theme.step}>
       <NavigationBar {...{back, i18n, isFullScreen}} disabled={disableNavigation} className={theme.navigationBar} />
-      <div className={theme.content}>{<WrappedComponent {...props} />}</div>
+      <div className={theme.content}><WrappedComponent {...props} /></div>
       <div className={theme.footer} />
     </div>
   )

--- a/src/components/Theme/index.js
+++ b/src/components/Theme/index.js
@@ -1,0 +1,16 @@
+import { h } from 'preact'
+
+import NavigationBar from '../NavigationBar'
+import theme from './style.css'
+
+export const themeWrap = (WrappedComponent) => (props) => {
+  const {back, i18n, isFullScreen, disableNavigation} = props
+
+  return (
+    <div className={theme.step}>
+      <NavigationBar {...{back, i18n, isFullScreen}} disabled={disableNavigation} className={theme.navigationBar} />
+      <div className={theme.content}>{<WrappedComponent {...props} />}</div>
+      <div className={theme.footer} />
+    </div>
+  )
+}

--- a/src/components/crossDevice/CrossDeviceLink/index.js
+++ b/src/components/crossDevice/CrossDeviceLink/index.js
@@ -180,7 +180,7 @@ class CrossDeviceLinkUI extends Component {
     const buttonCopy = this.state.sending ? i18n.t('cross_device.link.button_copy.status')  : i18n.t('cross_device.link.button_copy.action')
     const invalidNumber = !this.state.validNumber
     return (
-      <div className={style.container}>
+      <div>
         { error.type ?
           <SmsError error={error} trackScreen={this.props.trackScreen} i18n={i18n}/> :
           <Title title={i18n.t('cross_device.link.title')} /> }

--- a/src/components/crossDevice/CrossDeviceLink/style.css
+++ b/src/components/crossDevice/CrossDeviceLink/style.css
@@ -1,13 +1,6 @@
 @import (less) "../../Theme/constants.css";
 @parent-width: 432;
 
-.container {
-  position: absolute;
-  @media (--large) {
-    top: 48px;
-  }
-}
-
 .smsSection {
   height: 76px;
   margin-top: 56px;


### PR DESCRIPTION
# Problem

Some screens like the generic error and the spinner on cross device client do not have "Powered by Onfido" footer.
The cause of the issue is that these components are not part of the StepsRouter because they are displayed when we are loading the configuration or when there was a problem fetching the data needed to render the StepsRouter


# Solution
Use a High Order Component to wrap any component with the theme.
This PR also fixes a small UI inconsistency within the CrossDeviceLink component, by removing the container wrapper for the component.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
