### PR TITLE
Prevent default on enter key

### DIFF
--- a/src/components/PhoneNumberInput/index.js
+++ b/src/components/PhoneNumberInput/index.js
@@ -29,8 +29,10 @@ class PhoneNumberInput extends Component {
     this.props.actions.setMobileNumber({number, valid})
   }
 
+  handleEnterKey = (e) => { if (e.key === 'Enter') { e.preventDefault() } }
+
   render = ({i18n}) =>
-    <form>
+    <form onKeyPress={this.handleEnterKey}>
       <PhoneNumber placeholder={i18n.t('cross_device.phone_number_placeholder')}
         onChange={this.onChange}
         country={this.state.country}

--- a/src/components/PhoneNumberInput/index.js
+++ b/src/components/PhoneNumberInput/index.js
@@ -29,10 +29,8 @@ class PhoneNumberInput extends Component {
     this.props.actions.setMobileNumber({number, valid})
   }
 
-  handleEnterKey = (e) => { if (e.key === 'Enter') { e.preventDefault() } }
-
   render = ({i18n}) =>
-    <form onKeyPress={this.handleEnterKey}>
+    <form onSubmit={(e) => e.preventDefault()}>
       <PhoneNumber placeholder={i18n.t('cross_device.phone_number_placeholder')}
         onChange={this.onChange}
         country={this.state.country}


### PR DESCRIPTION
# Problem

When a user enters the mobile number in the sms input form and hits the Enter key the flow reloads.

# Solution
Prevent default event handling on input form

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a]Have any new strings been translated?
