### PR TITLE
Fix flag icons in phone number input only showing a "corner of a flag"  on IE

### DIFF
--- a/src/components/PhoneNumberInput/index.js
+++ b/src/components/PhoneNumberInput/index.js
@@ -5,6 +5,16 @@ import 'react-phone-number-input/style.css'
 
 import style from './style.css'
 
+const FlagComponent = ({ countryCode, flagsPath }) => (
+  <span
+    className="react-phone-number-input__icon"
+    style={{
+      'background': `url(${ flagsPath }${ countryCode.toLowerCase() }.svg) no-repeat center`,
+      'background-size': '100%',
+    }}
+  />
+);
+
 class PhoneNumberInput extends Component {
   constructor(props) {
     super(props)
@@ -36,6 +46,7 @@ class PhoneNumberInput extends Component {
         country={this.state.country}
         inputClassName={`${style.mobileInput}`}
         className={`${style.phoneNumberContainer}`}
+        flagComponent={ FlagComponent }
       />
     </form>
 }

--- a/src/components/PhoneNumberInput/index.js
+++ b/src/components/PhoneNumberInput/index.js
@@ -1,16 +1,16 @@
 import { h, Component } from 'preact'
 import PhoneNumber, {isValidPhoneNumber} from 'react-phone-number-input'
+import classNames from 'classnames';
+
 import 'react-phone-number-input/rrui.css'
 import 'react-phone-number-input/style.css'
-
 import style from './style.css'
 
 const FlagComponent = ({ countryCode, flagsPath }) => (
   <span
-    className="react-phone-number-input__icon"
+    className={ classNames('react-phone-number-input__icon', style.flagIcon) }
     style={{
-      'background': `url(${ flagsPath }${ countryCode.toLowerCase() }.svg) no-repeat center`,
-      'background-size': '100%',
+      'background-image': `url(${ flagsPath }${ countryCode.toLowerCase() }.svg)`,
     }}
   />
 );

--- a/src/components/PhoneNumberInput/style.css
+++ b/src/components/PhoneNumberInput/style.css
@@ -40,3 +40,10 @@
   border-bottom: none;
   overflow: hidden;
 }
+
+
+.flagIcon {
+  background-size: 100%;
+  background-repeat: no-repeat;
+  background-position: center;
+}


### PR DESCRIPTION
# Problem
Flag icons in phone number input only show a "corner of a flag"  on IE.

IE doesn't scale SVG images without `viewBox` attribute. 

# Solution
Since icons are loaded from another project and we can't add an attribute, the chosen approach is to use a custom `flagComponent` component, rendered as a `span` element with a background image instead of an `img` tag.

## Checklist
- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a ] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
