### PR TITLE
Enable React dev tools

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,10 @@ import Modal from './components/Modal'
 import Router from './components/Router'
 import Tracker from './Tracker'
 
+if (process.env.NODE_ENV === 'development') {
+  require('preact/devtools');
+}
+
 const events = new EventEmitter()
 
 Tracker.setUp()


### PR DESCRIPTION
# Problem
React Dev Tools not working with Preact

# Solution
Import `preact/devtools` as described in https://github.com/developit/preact/pull/339

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
