### PR TITLE
Add max supported camera resolution height detection

### DIFF
--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -10,7 +10,7 @@ import {cloneCanvas} from '../utils/canvas.js'
 import { asyncFunc } from '../utils/func'
 import { Overlay } from '../Overlay'
 import Title from '../Title'
-import { checkIfWebcamPermissionGranted } from '../utils'
+import { checkIfWebcamPermissionGranted, detectWebcamMaxSupportedHeight } from '../utils'
 import theme from '../Theme/style.css'
 import style from './style.css'
 import PermissionsPrimer from './PermissionsPrimer'
@@ -45,7 +45,6 @@ type CameraCommonType = {
   onUserMedia: Function,
   onUploadFallback: File => void,
   onWebcamError: Function,
-  onUserMedia: void => void,
   i18n: Object,
   isFullScreen: boolean,
 }
@@ -55,15 +54,25 @@ type CameraPureType = {
   onFallbackClick: void => void,
   faceCaptureClick: void => void,
   useFullScreen: boolean => void,
+  onUserMedia: void => void, 
   webcamRef: React.Ref<typeof Webcam>,
+};
+
+type CameraPureStateType = {
+  maxSupportedHeight: ?number,
 };
 
 // Specify just a camera height (no width) because on safari if you specify both
 // height and width you will hit an OverconstrainedError if the camera does not
 // support the precise resolution.
-class CameraPure extends React.Component<CameraPureType> {
+class CameraPure extends React.Component<CameraPureType, CameraPureStateType> {
   static defaultProps = {
     useFullScreen: () => {},
+    onUserMedia: () => {},
+  }
+
+  state:CameraPureStateType = {
+    maxSupportedHeight: undefined,
   }
 
   componentDidMount() {
@@ -76,10 +85,17 @@ class CameraPure extends React.Component<CameraPureType> {
     this.props.useFullScreen(false)
   }
 
+  handleUserMedia = () => {
+    const heights = [480, 720, 960, 1080]
+    detectWebcamMaxSupportedHeight(heights)
+      .then(maxSupportedHeight => this.setState({ maxSupportedHeight }))
+    this.props.onUserMedia()
+  }
+
   render() {
     const {method, autoCapture, title, subTitle, onUploadFallback, onFallbackClick,
-      onUserMedia, faceCaptureClick, webcamRef, isFullScreen, onWebcamError, i18n} = this.props;
-
+      faceCaptureClick, webcamRef, isFullScreen, onWebcamError, i18n} = this.props;
+    const { maxSupportedHeight } = this.state;
     return (
       <div className={style.camera}>
         <Title {...{title, subTitle, isFullScreen}} smaller={true}/>
@@ -87,8 +103,9 @@ class CameraPure extends React.Component<CameraPureType> {
           <Webcam
             className={style.video}
             audio={false}
-            height={720}
-            {...{onUserMedia, ref: webcamRef, onFailure: onWebcamError}}
+            onUserMedia={this.handleUserMedia}
+            {...(maxSupportedHeight ? { height: maxSupportedHeight } : {}) }
+            {...{ref: webcamRef, onFailure: onWebcamError}}
           />
           <Overlay {...{method, isFullScreen}}/>
           <UploadFallback {...{onUploadFallback, onFallbackClick, method, i18n}}/>

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -1,9 +1,13 @@
 import parseUnit from 'parse-unit'
 import { h } from 'preact'
 import enumerateDevices from 'enumerate-devices'
+export {
+  checkIfHasWebcam,
+  checkIfWebcamPermissionGranted,
+  detectWebcamMaxSupportedHeight,
+} from './webcam'
 
 export const functionalSwitch = (key, hash) => (hash[key] || (()=>null))()
-
 
 export const getCSSValue = (expectedUnit, cssUnit) => {
   const [value, resUnit] = parseUnit(cssUnit)
@@ -26,33 +30,6 @@ export const preventDefaultOnClick = callback => event => {
 // Copied from https://github.com/muaz-khan/DetectRTC/blob/master/DetectRTC.js
 export const isDesktop = !(/Android|webOS|iPhone|iPad|iPod|BB10|BlackBerry|IEMobile|Opera Mini|Mobile|mobile/i.test(navigator.userAgent || ''))
 
-const enumerateDevicesInternal = (onSuccess, onError) => {
-  try {
-    enumerateDevices().then(onSuccess).catch(onError);
-  }
-  catch (exception){
-    onError(exception)
-  }
-}
-
-const checkDevicesInfo = checkFn =>
-  onResult =>
-    enumerateDevicesInternal(
-      devices => onResult(checkFn(devices)),
-      () => onResult(false)
-    )
-
-const isVideoDevice = ({ kind = '' }) => kind.includes('video')
-
-const hasDevicePermission = ({ label }) => !!label
-
-export const checkIfHasWebcam = checkDevicesInfo(
-  devices => devices.some(isVideoDevice)
-)
-
-export const checkIfWebcamPermissionGranted = checkDevicesInfo(
-  devices => devices.filter(isVideoDevice).some(hasDevicePermission)
-)
 
 export const humanizeField = (str) => {
   return str.substr(0, 1).toUpperCase() + str.substr(1).split('_').join(' ')

--- a/src/components/utils/webcam.js
+++ b/src/components/utils/webcam.js
@@ -1,0 +1,42 @@
+import enumerateDevices from 'enumerate-devices'
+
+const enumerateDevicesInternal = (onSuccess, onError) => {
+  try {
+    enumerateDevices().then(onSuccess).catch(onError);
+  }
+  catch (exception){
+    onError(exception)
+  }
+}
+
+const checkDevicesInfo = checkFn =>
+  onResult =>
+    enumerateDevicesInternal(
+      devices => onResult(checkFn(devices)),
+      () => onResult(false)
+    )
+
+const isVideoDevice = ({ kind = '' }) => kind.includes('video')
+
+const hasDevicePermission = ({ label }) => !!label
+
+export const checkIfHasWebcam = checkDevicesInfo(
+  devices => devices.some(isVideoDevice)
+)
+
+export const checkIfWebcamPermissionGranted = checkDevicesInfo(
+  devices => devices.filter(isVideoDevice).some(hasDevicePermission)
+)
+
+const { mediaDevices = {} } = navigator;
+const { getUserMedia = () => Promise.reject() } = mediaDevices;
+const noop = () => {}
+
+export const detectWebcamMaxSupportedHeight = heights =>
+  heights.reduce((promise, height) =>
+    promise.then(maxSupportedHeight =>
+      getUserMedia.call(mediaDevices, { video: { height }, audio: false }, noop, noop)
+        .then(() => height)
+        .catch(() => Promise.resolve(maxSupportedHeight))
+    )
+  , Promise.resolve(undefined))


### PR DESCRIPTION
# Problem
Certain devices, mostly Android, only accept set resolutions that match exactly the supported resolution. This causes problems because we cannot find out easily what are the supported resolutions

# Solution
Create a fallback list of height resolutions and try them all in order until one works `[1080, 960, 720, 480]`

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
