### PR TITLE
added reminder to update documentation

### DIFF
--- a/release_guidelines.md
+++ b/release_guidelines.md
@@ -104,3 +104,6 @@ Now you can go on and update JSFiddle.
 - After the release, bump Onfido SDK version in `package.json` of Sample App
 - If Onfido SDK release introduced breaking changes, apply them according to migration guide
 - Issue PR with mentioned changes to master
+
+## Confluence
+Review and update, if necessary, the "feature matrix" and the relevant subpages under the SDK (Web & Mobile) section of the Onfido product documentation.


### PR DESCRIPTION
# Problem

we need to help product documentation in sync

# Solution

adding a reminder in the release process

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [yes] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
