### PR TITLE
Fix uncallable callback

### DIFF
--- a/src/components/Camera/AutoCapture.js
+++ b/src/components/Camera/AutoCapture.js
@@ -42,7 +42,7 @@ export default class AutoCapture extends React.Component<CameraType> {
         <CameraPure {...{
           ...this.props,
           webcamRef: (c) => { this.webcam = c },
-          onFallbackClick: () => { this.capture.stop }
+          onFallbackClick: () => this.capture.stop(),
         }}/>
       </div>
     )


### PR DESCRIPTION
# Problem
When `onFallbackClick` gets called, `this.capture.stop` won't be invoked.

# Solution
Invoke `this.capture.stop` when `onFallbackClick` gets called

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
