### PR TITLE
Feature/x device flow intro cx 2202

### DIFF
--- a/MANUAL_REGRESSION.md
+++ b/MANUAL_REGRESSION.md
@@ -247,7 +247,7 @@ Outcome:
 7. Click `Block`
 8. You should see the permission denied / recovery screen
 
-##### 19. Check permission denied / recovery screen displays when webcam is available and permission was previously denied
+##### 20. Check permission denied / recovery screen displays when webcam is available and permission was previously denied
 (on Firefox, Safari, IE11 and Microsoft Edge browsers)
 
 1. Go through the flow to document capture
@@ -256,6 +256,21 @@ Outcome:
 4. You should see a permission priming screen
 5. Click `Enable webcam`
 6. You should see the permission denied / recovery screen
+
+##### 21. Check an intro screen is displayed when entering the cross-device  flow
+(on Firefox, Safari, IE11 and Microsoft Edge browsers)
+
+1. Go through the flow to document capture
+2. Click `Need to use your mobile to take photos?`
+3. You should see the cross-device intro screen
+
+##### 22. Check flow changes to cross device when no webcam available
+(no webcam / webcam disabled)
+
+1. Go through the flow to document capture
+2. Upload a valid document
+3. Click `Confirm`
+4. You should see the cross-device intro screen
 
 ## Non-functional
 

--- a/src/components/Camera/CameraTypes.js
+++ b/src/components/Camera/CameraTypes.js
@@ -8,7 +8,7 @@ type CameraCommonType = {
   title: string,
   subTitle: string,
   onUserMedia: Function,
-  onUploadFallback: File => void,
+  onFileUpload: File => void,
   onFailure: Function,
   onUserMedia: void => void,
   i18n: Object,

--- a/src/components/Camera/Permissions/Recover/style.css
+++ b/src/components/Camera/Permissions/Recover/style.css
@@ -1,12 +1,5 @@
 @import (less) "../../../Theme/constants.css";
 
-.container {
-  @media (--small-viewport) {
-    position: relative;
-    height: auto;
-  }
-}
-
 .text {
   margin-top: 64px;
   margin-bottom: 80px;

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -18,11 +18,11 @@ import style from './style.css'
 import type { CameraPureType, CameraType, CameraActionType, CameraStateType} from './CameraTypes'
 import { checkIfWebcamPermissionGranted } from '../utils'
 
-const UploadFallback = ({onUploadFallback, onFallbackClick, method, i18n}) => {
+const UploadFallback = ({onFileUpload, onFallbackClick, method, i18n}) => {
   const text = i18n && method ? i18n.t(`capture.${method}.help`) : ''
   return (
     <Dropzone
-      onDrop={([file]) => onUploadFallback(file)}
+      onDrop={([file]) => onFileUpload(file)}
       className={style.uploadFallback}
       multiple={false}>
       <button onClick={onFallbackClick}>{text}</button>
@@ -62,7 +62,7 @@ export class CameraPure extends React.Component<CameraPureType> {
   }
 
   render() {
-    const {method, title, subTitle, onUploadFallback, onFallbackClick,
+    const {method, title, subTitle, onFileUpload, onFallbackClick,
       onUserMedia, onFailure, webcamRef, isFullScreen, i18n, video} = this.props;
     return (
       <div className={style.camera}>
@@ -75,7 +75,7 @@ export class CameraPure extends React.Component<CameraPureType> {
             {...{onUserMedia, ref: webcamRef, onFailure}}
           />
           <Overlay {...{method, isFullScreen}}/>
-          { !video && <UploadFallback {...{onUploadFallback, onFallbackClick, method, i18n}}/> }
+          { !video && <UploadFallback {...{onFileUpload, onFallbackClick, method, i18n}}/> }
         </div>
       </div>
     )

--- a/src/components/Capture/index.js
+++ b/src/components/Capture/index.js
@@ -2,11 +2,16 @@ import { h } from 'preact'
 import Capture from './capture.js'
 import { appendToTracking } from '../../Tracker'
 
-const DocumentCapture = props => <Capture autoCapture={true} {...props} />
+const webcamSupportChangeHandler = ({ changeFlowTo, useWebcam }) =>
+  useWebcam ? {
+    onWebcamSupportChange: hasWebcam => !hasWebcam && changeFlowTo('crossDeviceSteps'),
+  } : {}
+
+const DocumentCapture = props => <Capture autoCapture={true} {...props} {...webcamSupportChangeHandler(props)}/>
 
 DocumentCapture.defaultProps = {
   useWebcam: false,
-  method: 'document'
+  method: 'document',
 }
 
 const FrontDocumentCapture = options => <DocumentCapture {...options} />
@@ -16,8 +21,8 @@ const BackDocumentCapture = options => <DocumentCapture {...options} />
 
 BackDocumentCapture.defaultProps = { side: 'back' }
 
-const FaceCapture = options =>
-  <Capture autoCapture={false} {...options} />
+const FaceCapture = props =>
+  <Capture autoCapture={false} {...props} {...webcamSupportChangeHandler(props)} />
 
 FaceCapture.defaultProps = {
   useWebcam: true,

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -234,6 +234,6 @@ const FaceConfirm = (props) =>
   <MapConfirm {...props} method= 'face' />
 
 const DocumentFrontConfirm = appendToTracking(DocumentFrontWrapper, 'front')
-const DocumentBackConfrim = appendToTracking(DocumentBackWrapper, 'back')
+const DocumentBackConfirm = appendToTracking(DocumentBackWrapper, 'back')
 
-export { DocumentFrontConfirm, DocumentBackConfrim, FaceConfirm }
+export { DocumentFrontConfirm, DocumentBackConfirm, FaceConfirm }

--- a/src/components/Router/StepComponentMap.js
+++ b/src/components/Router/StepComponentMap.js
@@ -3,11 +3,12 @@ import { h } from 'preact'
 import Welcome from '../Welcome'
 import Select from '../Select'
 import {FrontDocumentCapture, BackDocumentCapture, FaceCapture} from '../Capture'
-import {DocumentFrontConfirm, DocumentBackConfrim, FaceConfirm} from '../Confirm'
+import {DocumentFrontConfirm, DocumentBackConfirm, FaceConfirm} from '../Confirm'
 import Complete from '../Complete'
 import MobileFlow from '../crossDevice/MobileFlow'
 import CrossDeviceLink from '../crossDevice/CrossDeviceLink'
 import ClientSuccess from '../crossDevice/ClientSuccess'
+import CrossDeviceIntro from '../crossDevice/Intro'
 
 export const componentsList = ({flow, documentType, steps, mobileFlow}) => {
   const captureSteps = mobileFlow ? clientCaptureSteps(steps) : steps
@@ -37,7 +38,7 @@ const createDocumentComponents = (documentType) => {
   const double_sided_docs = ['driving_licence', 'national_identity_card']
   const frontDocumentFlow = [Select, FrontDocumentCapture, DocumentFrontConfirm]
   if (Array.includes(double_sided_docs, documentType)) {
-    return [...frontDocumentFlow, BackDocumentCapture, DocumentBackConfrim]
+    return [...frontDocumentFlow, BackDocumentCapture, DocumentBackConfirm]
   }
   return frontDocumentFlow
 }
@@ -49,7 +50,7 @@ const crossDeviceSteps = (steps) => {
 }
 
 const crossDeviceComponents = {
-  crossDevice: () => [CrossDeviceLink, MobileFlow],
+  crossDevice: () => [CrossDeviceIntro, CrossDeviceLink, MobileFlow],
   complete: () => [Complete]
 }
 

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -155,8 +155,13 @@ class MainRouter extends Component {
     return {steps, token, language, documentType, step: this.state.crossDeviceInitialStep, woopraCookie}
   }
 
-  onFlowChange = (newFlow, newStep, previousFlow, previousStep) => {
-    if (newFlow === "crossDeviceSteps") this.setState({crossDeviceInitialStep: previousStep})
+  onFlowChange = (newFlow, newStep, previousFlow, previousStep, previousStepType) => {
+    if (newFlow === "crossDeviceSteps") {
+      this.setState({
+        crossDeviceInitialStep: previousStep,
+        crossDeviceInitialStepType: previousStepType,
+      })
+    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -170,6 +175,7 @@ class MainRouter extends Component {
       steps={props.options.steps}
       onFlowChange={this.onFlowChange}
       mobileConfig={this.mobileConfig()}
+      crossDeviceInitialStepType={this.state.crossDeviceInitialStepType}
       i18n={this.state.i18n}
     />
 }
@@ -196,18 +202,22 @@ class HistoryRouter extends Component {
   }
 
   disableNavigation = () => {
+    return this.initialStep() || this.getStepType(this.state.step) === 'complete'
+  }
+
+  getStepType = index => {
     const componentList = this.componentsList()
-    const currentStepIndex = this.state.step
-    const currentStepType = componentList[currentStepIndex].step.type
-    return this.initialStep() || currentStepType === 'complete'
+    const { step = {} }  = componentList[index] || {}
+    return step.type
   }
 
   initialStep = () => this.state.initialStep === this.state.step && this.state.flow === 'captureSteps'
 
   changeFlowTo = (newFlow, newStep=0) => {
     const {flow: previousFlow, step: previousStep} = this.state
+    const previousStepType = this.getStepType(previousStep)
     if (previousFlow === newFlow) return
-    this.props.onFlowChange(newFlow, newStep, previousFlow, previousStep)
+    this.props.onFlowChange(newFlow, newStep, previousFlow, previousStep, previousStepType)
     this.setStepIndex(newStep, newFlow)
   }
 

--- a/src/components/Theme/style.css
+++ b/src/components/Theme/style.css
@@ -10,10 +10,7 @@
 }
 
 .fullHeightContainer {
-  position: absolute;
   width: 100%;
-  height: 0;/*necessary for IE11 */
-  min-height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -32,6 +29,11 @@
 .content {
   flex: 1 0 auto;
   position: relative;
+  display: flex;
+
+  > * {
+    flex-grow: 1;
+  }
 }
 
 .fullScreenContentWrapper {

--- a/src/components/crossDevice/Intro/assets/connection-large.svg
+++ b/src/components/crossDevice/Intro/assets/connection-large.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="48px" height="48px" viewBox="0 0 48 48" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: sketchtool 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
+    <title>D49705B4-9A37-43F1-808E-7C81D1D0F2E5</title>
+    <desc>Created with sketchtool.</desc>
+    <defs></defs>
+    <g id="playground" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="desktop-512pt-xdevice-only" transform="translate(-41.000000, -210.000000)">
+            <g id="Group-2" transform="translate(40.000000, 210.000000)">
+                <g id="icons/mobile-sent/large" transform="translate(1.000000, 0.000000)">
+                    <g id="connection-large">
+                        <circle id="circle-BG" fill="#00C9A1" cx="24" cy="24" r="24"></circle>
+                        <g id="icons/mobile" transform="translate(12.000000, 4.000000)">
+                            <g id="mobile-small">
+                                <rect id="Rectangle-5" stroke="#2C3E4F" stroke-width="1.33333333" fill="#FFFFFF" x="0.666666667" y="4.66666667" width="22.6666667" height="38.6666667" rx="2.66666667"></rect>
+                                <circle id="Oval" stroke="#283E4F" stroke-width="0.666666667" fill="#FFFFFF" cx="12" cy="39" r="1.66666667"></circle>
+                                <rect id="Rectangle-4-Copy-2" fill="#2C3E4F" x="7.33333333" y="7.33333333" width="9.33333333" height="1" rx="0.5"></rect>
+                                <g id="ring" transform="translate(22.333333, 0.000000)" fill="#2C3E4F">
+                                    <path d="M3.16666667,5 L5.5,5 C5.77614237,5 6,5.22385763 6,5.5 L6,5.5 C6,5.77614237 5.77614237,6 5.5,6 L3.16666667,6 C2.89052429,6 2.66666667,5.77614237 2.66666667,5.5 L2.66666667,5.5 C2.66666667,5.22385763 2.89052429,5 3.16666667,5 Z" id="Rectangle-4-Copy-3"></path>
+                                    <path d="M-0.5,1.33333333 L1.83333333,1.33333333 C2.10947571,1.33333333 2.33333333,1.55719096 2.33333333,1.83333333 L2.33333333,1.83333333 C2.33333333,2.10947571 2.10947571,2.33333333 1.83333333,2.33333333 L-0.5,2.33333333 C-0.776142375,2.33333333 -1,2.10947571 -1,1.83333333 L-1,1.83333333 C-1,1.55719096 -0.776142375,1.33333333 -0.5,1.33333333 Z" id="Rectangle-4-Copy-4" transform="translate(0.666667, 1.833333) rotate(90.000000) translate(-0.666667, -1.833333) "></path>
+                                    <path d="M2.36539803,2.03206469 L4.69873136,2.03206469 C4.97487373,2.03206469 5.19873136,2.25592232 5.19873136,2.53206469 L5.19873136,2.53206469 C5.19873136,2.80820707 4.97487373,3.03206469 4.69873136,3.03206469 L2.36539803,3.03206469 C2.08925565,3.03206469 1.86539803,2.80820707 1.86539803,2.53206469 L1.86539803,2.53206469 C1.86539803,2.25592232 2.08925565,2.03206469 2.36539803,2.03206469 Z" id="Rectangle-4-Copy-5" transform="translate(3.532065, 2.532065) rotate(-45.000000) translate(-3.532065, -2.532065) "></path>
+                                </g>
+                                <g id="notification" transform="translate(2.666667, 16.000000)">
+                                    <rect id="container" stroke="#8B9094" stroke-width="0.5" fill="#F3F3F4" x="0.25" y="0.25" width="18.1666667" height="4.83333333" rx="0.666666667"></rect>
+                                    <path d="M2,2.66666667 C2.36818983,2.66666667 2.66666667,2.36818983 2.66666667,2 C2.66666667,1.63181017 2.36818983,1.33333333 2,1.33333333 C1.63181017,1.33333333 1.33333333,1.63181017 1.33333333,2 C1.33333333,2.36818983 1.63181017,2.66666667 2,2.66666667 Z" id="notification-circle" fill="#00C8A0"></path>
+                                    <rect id="msg-title" fill="#8B9094" x="3.66666667" y="1.66666667" width="10.3333333" height="1" rx="0.5"></rect>
+                                    <rect id="msg-title-copy" fill="#8B9094" x="3.66666667" y="3.33333333" width="13" height="1" rx="0.5"></rect>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/components/crossDevice/Intro/assets/mobile-use-small.svg
+++ b/src/components/crossDevice/Intro/assets/mobile-use-small.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="48px" height="48px" viewBox="0 0 48 48" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: sketchtool 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
+    <title>1484AA58-5A8E-43A4-A248-8031E95EFD15</title>
+    <desc>Created with sketchtool.</desc>
+    <defs></defs>
+    <g id="playground" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="desktop-512pt-xdevice-only" transform="translate(-40.000000, -290.000000)">
+            <g id="Group-2" transform="translate(40.000000, 210.000000)">
+                <g id="icons/cross-device" transform="translate(0.000000, 80.000000)">
+                    <g id="mobile-use-small">
+                        <circle id="circle-BG" fill="#00C8A0" cx="24" cy="24" r="24"></circle>
+                        <g id="cross-device-small-icon" transform="translate(4.666667, 8.000000)">
+                            <g id="icons/mobile/small" transform="translate(10.000000, 0.000000)">
+                                <g id="mobile" transform="translate(-0.000000, 0.000000)">
+                                    <rect id="Rectangle-5" stroke="#2C3E4F" stroke-width="1.33333333" fill="#FFFFFF" x="0.666666667" y="0.666666667" width="17.3333333" height="30.6666667" rx="2.66666667"></rect>
+                                    <rect id="Rectangle-4" fill="#2C3E4F" x="6" y="2.66666667" width="6.66666667" height="1" rx="0.5"></rect>
+                                    <circle id="Oval" stroke="#2C3E4F" stroke-width="0.666666667" fill="#FFFFFF" cx="9.33333333" cy="28.6666667" r="1"></circle>
+                                </g>
+                            </g>
+                            <g id="id-card" transform="translate(12.912456, 15.934497) rotate(-15.000000) translate(-12.912456, -15.934497) translate(1.912456, 8.601163)">
+                                <g id="icons/id-card" transform="translate(0.141105, 0.545187)">
+                                    <g id="id-card">
+                                        <path d="M1.33333333,0.333333333 C0.781048584,0.333333333 0.333333333,0.781048584 0.333333333,1.33333333 L0.333333333,12.0001288 C0.333333333,12.5524136 0.781048584,13.0001288 1.33333333,13.0001288 L20.0000095,13.0001288 C20.5522943,13.0001288 21.0000095,12.5524136 21.0000095,12.0001288 L21.0000095,1.33333333 C21.0000095,0.781048584 20.5522943,0.333333333 20.0000095,0.333333333 L1.33333333,0.333333333 Z" id="container" stroke="#283E4F" stroke-width="0.666666667" fill="#FFFFFF"></path>
+                                        <g id="inset" transform="translate(10.666667, 3.333333)" fill="#283E4F">
+                                            <rect id="Rectangle" x="0" y="4" width="6" height="1" rx="0.5"></rect>
+                                            <rect id="Rectangle-Copy" x="0" y="2" width="8.66666667" height="1" rx="0.5"></rect>
+                                            <rect id="Rectangle-Copy-2" x="0" y="0" width="8.66666667" height="1" rx="0.5"></rect>
+                                        </g>
+                                        <g id="body" transform="translate(1.333333, 9.333333)" fill="#283E4F" fill-rule="nonzero">
+                                            <path d="M3.98053366,0.666666667 C5.22085913,0.666666667 6.61210704,1.74638835 7.33333333,3.33333333 L8,3.33333333 C7.20689614,1.3430308 5.7039984,0 3.98053366,0 C2.28487011,0 0.802715028,1.39585988 1.57e-14,3.33333333 L0.666666667,3.33333333 C1.40748586,1.75979681 2.79452926,0.666666667 3.98053366,0.666666667 Z" id="Oval-2"></path>
+                                        </g>
+                                        <g id="face" transform="translate(2.411765, 1.600000)" stroke="#283E4F" stroke-width="0.666666667">
+                                            <path d="M3.25490196,6.73333333 C4.64157485,6.73333333 5.92156863,5.14396276 5.92156863,3.51111111 C5.92156863,1.97432894 4.72489429,0.733333333 3.25490196,0.733333333 C2.27771938,0.733333333 1.39216911,1.28573493 0.923811811,2.16102673 C0.704847287,2.57023964 0.588235294,3.03143516 0.588235294,3.51111111 C0.588235294,5.14396276 1.86822907,6.73333333 3.25490196,6.73333333 Z" id="Oval"></path>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                            <rect id="mobile-left-frame" fill="#283E4F" x="10" y="8" width="1.33333333" height="20.6666667"></rect>
+                            <rect id="overlay" fill-opacity="0.670000017" fill="#FFFFFF" x="11.3333333" y="6.66666667" width="16" height="18"></rect>
+                            <rect id="mobile-screen-frame" stroke="#FFFFFF" stroke-width="0.666666667" x="11.6666667" y="6.33333333" width="15.3333333" height="17.3333333"></rect>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/components/crossDevice/Intro/assets/return-to-computer-large.svg
+++ b/src/components/crossDevice/Intro/assets/return-to-computer-large.svg
@@ -1,0 +1,35 @@
+<svg width="144" height="144" viewBox="0 0 144 144" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>
+    return-to-computer-large
+  </title>
+  <defs>
+    <rect id="a" width="48" height="80" rx="8"/>
+    <circle id="b" cx="24" cy="69" r="5"/>
+    <rect id="c" width="96" height="64" rx="8"/>
+  </defs>
+  <g fill="none" fill-rule="evenodd">
+    <circle fill="#00C8A0" cx="72" cy="72" r="72"/>
+    <g transform="translate(10 10)">
+      <use fill="#FFF" xlink:href="#a"/>
+      <rect stroke="#2C3E4F" stroke-width="4" x="2" y="2" width="44" height="76" rx="8"/>
+      <use fill="#FFF" xlink:href="#b"/>
+      <circle stroke="#283E4F" stroke-width="2" cx="24" cy="69" r="4"/>
+      <rect fill="#2C3E4F" x="15" y="8" width="18" height="2" rx="1"/>
+    </g>
+    <g transform="translate(22 37)">
+      <circle fill="#00C8A0" cx="12" cy="12" r="12"/>
+      <path d="M16.17 7.52l-5.87 6.22-1.47-1.55c-.65-.7-1.7-.7-2.34 0-.66.68-.66 1.8 0 2.48l2.63 2.8c.64.7 1.7.7 2.34 0L18.5 10c.66-.68.66-1.8 0-2.48-.63-.7-1.68-.7-2.33 0z" fill="#FFF"/>
+    </g>
+    <g transform="translate(42 48)">
+      <use fill="#FFF" xlink:href="#c"/>
+      <rect stroke="#2C3E4F" stroke-width="4" x="2" y="2" width="92" height="60" rx="8"/>
+      <rect fill="#2C3E4F" x="24" y="72" width="48" height="4" rx="2"/>
+      <path d="M25 54h46c.55 0 1 .45 1 1s-.45 1-1 1H25c-.55 0-1-.45-1-1s.45-1 1-1z" fill="#2C3E4F"/>
+      <rect fill="#2C3E4F" x="46" y="60" width="4" height="16" rx="2"/>
+    </g>
+    <g stroke="#2C3E4F" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M75.12 59.37C77.5 50 71.86 40.25 62.56 37.6c-4.66-1.3-9.35-.6-13.17 1.6"/>
+      <path d="M79.3 59.35l-5.2 3-3-5.2"/>
+    </g>
+  </g>
+</svg>

--- a/src/components/crossDevice/Intro/index.js
+++ b/src/components/crossDevice/Intro/index.js
@@ -1,0 +1,40 @@
+import { h } from 'preact'
+import classNames from 'classnames'
+import theme from '../../Theme/style.css'
+import style from './style.css'
+import Title from '../../Title'
+import { trackComponent } from '../../../Tracker'
+import {preventDefaultOnClick} from '../../utils'
+
+const Intro = ({i18n, nextStep}) => {
+  return (
+    <div className={classNames(theme.fullHeightContainer, style.container)}>
+      <Title
+        title={i18n.t('cross_device.intro.title')}
+        subTitle={i18n.t('cross_device.intro.sub_title')}
+      />
+      <div className={classNames(theme.thickWrapper, style.content)}>
+      {
+        ['sms', 'take_photos', 'return_computer'].map(step =>
+          <div key={step} className={style.step}>
+            <div className={classNames(style.stepIcon, style[`stepIcon-${step}`])}></div>
+            <div className={style.stepMessage}>
+              {i18n.t(`cross_device.intro.${step}`)}
+            </div>
+          </div>
+        )  
+      }
+      </div>
+      <div className={theme.thickWrapper}>
+        <button
+          className={`${theme.btn} ${theme["btn-primary"]} ${theme["btn-centered"]}`}
+          onClick={preventDefaultOnClick(nextStep)}
+        >
+        {i18n.t('cross_device.intro.lets_start')}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default trackComponent(Intro)

--- a/src/components/crossDevice/Intro/index.js
+++ b/src/components/crossDevice/Intro/index.js
@@ -6,20 +6,26 @@ import Title from '../../Title'
 import { trackComponent } from '../../../Tracker'
 import {preventDefaultOnClick} from '../../utils'
 
-const Intro = ({i18n, nextStep}) => {
+const Intro = ({i18n, nextStep, componentsList, crossDeviceInitialStepType}) => {
+  const isFace = crossDeviceInitialStepType === 'face'
+  const steps = {
+    'sms': 'sms',
+    'take-photos': `${ isFace ? 'face' : 'document' }.take_photos`,
+    'return-computer': 'return_computer',
+  }
   return (
     <div className={classNames(theme.fullHeightContainer, style.container)}>
       <Title
-        title={i18n.t('cross_device.intro.title')}
+        title={i18n.t(`cross_device.intro.${ isFace ? 'face' : 'document' }.title`)}
         subTitle={i18n.t('cross_device.intro.sub_title')}
       />
       <div className={classNames(theme.thickWrapper, style.content)}>
       {
-        ['sms', 'take_photos', 'return_computer'].map(step =>
-          <div key={step} className={style.step}>
-            <div className={classNames(style.stepIcon, style[`stepIcon-${step}`])}></div>
+        Object.keys(steps).map(key =>
+          <div key={key} className={style.step}>
+            <div className={classNames(style.stepIcon, style[`stepIcon-${key}`])}></div>
             <div className={style.stepMessage}>
-              {i18n.t(`cross_device.intro.${step}`)}
+              {i18n.t(`cross_device.intro.${steps[key]}`)}
             </div>
           </div>
         )  

--- a/src/components/crossDevice/Intro/style.css
+++ b/src/components/crossDevice/Intro/style.css
@@ -39,11 +39,11 @@
     background-image: url('assets/connection-large.svg')
   }
 
-  &-take_photos {
+  &-take-photos {
     background-image: url('assets/mobile-use-small.svg')
   }
 
-  &-return_computer {
+  &-return-computer {
     background-image: url('assets/return-to-computer-large.svg')
   }
 }

--- a/src/components/crossDevice/Intro/style.css
+++ b/src/components/crossDevice/Intro/style.css
@@ -1,0 +1,55 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  justify-content: center;
+}
+
+.step {
+  display: flex;
+  padding-bottom: 32px;
+  position: relative;
+
+  &::before {
+    content: '';
+    display: block;
+    background-color: #2C3E4F;
+    width: 2px;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 23px;
+  }
+
+  &:last-child::before {
+    display: none;
+  }
+}
+
+.stepIcon {
+  background-size: contain;
+  flex-shrink: 0;
+  float: left;
+  height: 48px;
+  width: 48px;
+  position: relative;
+  z-index: 1;
+
+  &-sms {
+    background-image: url('assets/connection-large.svg')
+  }
+
+  &-take_photos {
+    background-image: url('assets/mobile-use-small.svg')
+  }
+
+  &-return_computer {
+    background-image: url('assets/return-to-computer-large.svg')
+  }
+}
+
+.stepMessage {
+  text-align: left;
+  margin-left: 15px;
+  flex-grow: 1;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -84,6 +84,14 @@
     "submessage": "Thank you."
   },
   "cross_device": {
+    "intro": {
+      "title": "Take pictures on your mobile",
+      "sub_title": "Continue verification on your mobile for best results. It’s easy, fast and secure.",
+      "sms": "We’ll SMS a secure link to your mobile (no app download required)",
+      "take_photos": "We’ll walk you through taking the ID photos",
+      "return_computer": "Return to your computer to complete your verification",
+      "lets_start": "Let’s start"
+    },
     "client_success": {
       "title":"Uploads successful",
       "sub_title":"You can now return to your computer to continue",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -85,7 +85,14 @@
   },
   "cross_device": {
     "intro": {
-      "title": "Take pictures on your mobile",
+      "document": {
+        "title": "Take pictures on your mobile",
+        "take_photos": "We’ll walk you through taking the ID photos"
+      },
+      "face": {
+        "title": "Take a selfie on your mobile",
+        "take_photos": "We’ll walk you through taking your selfie"
+      },
       "sub_title": "Continue verification on your mobile for best results. It’s easy, fast and secure.",
       "sms": "We’ll SMS a secure link to your mobile (no app download required)",
       "take_photos": "We’ll walk you through taking the ID photos",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -84,6 +84,14 @@
     "submessage": "Gracias."
   },
   "cross_device": {
+    "intro": {
+      "title": "Tome fotos con su móvil",
+      "sub_title": "Continue la verificación en su móvil para obtener mejores resultados. Es fácil, rápido y seguro.",
+      "sms": "Enviaremos un vínculo seguro a su móvil por SMS (no requiere descargar una aplicación)",
+      "take_photos": "Lo guiaremos en cómo tomar fotos de identificación",
+      "return_computer": "Vuelva a su computadora para completar la verificación",
+      "lets_start": "Empecemos"
+    },
     "client_success": {
       "title": "Carga completa",
       "sub_title": "Ahora puede volver a su computadora para continuar",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -85,10 +85,16 @@
   },
   "cross_device": {
     "intro": {
-      "title": "Tome fotos con su móvil",
+      "document": {
+        "title": "Tome fotos con su móvil",
+        "take_photos": "Lo guiaremos en cómo tomar fotos de identificación"
+      },
+      "face": {
+        "title": "Tome una selfie con su móvil",
+        "take_photos": "Lo guiaremos en cómo tomar una selfie"
+      },
       "sub_title": "Continue la verificación en su móvil para obtener mejores resultados. Es fácil, rápido y seguro.",
       "sms": "Enviaremos un vínculo seguro a su móvil por SMS (no requiere descargar una aplicación)",
-      "take_photos": "Lo guiaremos en cómo tomar fotos de identificación",
       "return_computer": "Vuelva a su computadora para completar la verificación",
       "lets_start": "Empecemos"
     },

--- a/test/features/cross_device.feature
+++ b/test/features/cross_device.feature
@@ -4,6 +4,8 @@ Feature: SDK Cross device steps
   Scenario Outline: Test cross device flow
     Given I verify with passport with <locale>
     When I click on cross_device_button ()
+    Then page_title should include translation for "cross_device.intro.document.title"
+    When I click on primary_button ()
     Then page_title should include translation for "cross_device.link.title"
     When I open cross_device_link () in a new tab
     Then page_title should include translation for "capture.passport.front.title"


### PR DESCRIPTION
# Problem
- Users without webcam should enter the x-device flow straightaway, with intro screen.
- Users with webcam should see the webcam view straightaway without the file upload or the x-device options

# Solution
By default users without a webcam in the regular flow will be taken into the cross-device flow when trying to upload a face (unless `useWebcam` is explicitly set to `false`, necessary for the `face` step in tests)

If camera presence changes while the user is on the face capture step, they will also be taken to the cross-device flow.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [x] Have new manual tests been written down?
- [x] Have tests passed locally?
- [x] Have any new strings been translated?
