### PR TITLE
Feature/fix edge video cx 2224

### DIFF
--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -146,4 +146,3 @@ export default class Camera extends React.Component<CameraType, CameraStateType>
     )
   }
 }
-

--- a/src/components/Camera/style.css
+++ b/src/components/Camera/style.css
@@ -104,11 +104,12 @@
 }
 
 /* this will only apply styles to Edge */
-@supports (object-fit: cover) and (-ms-ime-align:auto) {
+@supports (-ms-ime-align:auto) {
   .video {
     width:auto;
     @media (--small-viewport) {
-      /* HACK: this will make the video look centered on small screens */
+      /* HACK: this will make the video (kind of) look centered on small screens in absence of `object-fit:cover`.
+      It might not work on all screen sizes*/
       left: -50%;
     }
   }

--- a/src/components/Camera/style.css
+++ b/src/components/Camera/style.css
@@ -94,6 +94,7 @@
   display: block;
   position: absolute;
   height: 100%;
+  width:100%
   top: 0;
   left: 0;
   margin: auto;
@@ -102,9 +103,6 @@
   /*Mirroring transform: scale(-1, 1); */
 }
 
-@supports (object-fit: cover){
-  .video{height: 100%; width:100%}
-}
 /* this will only apply styles to Edge */
 @supports (object-fit: cover) and (-ms-ime-align:auto) {
   .video {

--- a/src/components/Camera/style.css
+++ b/src/components/Camera/style.css
@@ -94,7 +94,7 @@
   display: block;
   position: absolute;
   height: 100%;
-  width:100%
+  width:100%;
   top: 0;
   left: 0;
   margin: auto;

--- a/src/components/Camera/style.css
+++ b/src/components/Camera/style.css
@@ -105,7 +105,7 @@
 @supports (object-fit: cover){
   .video{height: 100%; width:100%}
 }
-/* this will only apply styles to Edge (and IE)*/
+/* this will only apply styles to Edge */
 @supports (object-fit: cover) and (-ms-ime-align:auto) {
   .video {
     height:100%;

--- a/src/components/Camera/style.css
+++ b/src/components/Camera/style.css
@@ -106,7 +106,6 @@
 /* this will only apply styles to Edge */
 @supports (object-fit: cover) and (-ms-ime-align:auto) {
   .video {
-    height:100%;
     width:auto;
     @media (--small-viewport) {
       /* HACK: this will make the video look centered on small screens */

--- a/src/components/Camera/style.css
+++ b/src/components/Camera/style.css
@@ -93,7 +93,6 @@
 .video {
   display: block;
   position: absolute;
-  width: 100%;
   height: 100%;
   top: 0;
   left: 0;
@@ -101,6 +100,21 @@
   object-fit: cover;
   z-index: 0;
   /*Mirroring transform: scale(-1, 1); */
+}
+
+@supports (object-fit: cover){
+  .video{height: 100%; width:100%}
+}
+/* ie edge only gets the following rule */
+@supports (object-fit: cover) and (-ms-ime-align:auto) {
+  .video {
+    height:100%;
+    width:auto;
+    @media (--small-viewport) {
+      /* HACK: this will make the video look centered on small screens */
+      left: -50%;
+    }
+  }
 }
 
 .uploadFallback {

--- a/src/components/Camera/style.css
+++ b/src/components/Camera/style.css
@@ -105,7 +105,7 @@
 @supports (object-fit: cover){
   .video{height: 100%; width:100%}
 }
-/* ie edge only gets the following rule */
+/* this will only apply styles to Edge (and IE)*/
 @supports (object-fit: cover) and (-ms-ime-align:auto) {
   .video {
     height:100%;

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -237,7 +237,7 @@ const CaptureMode = ({method, documentType, side, useCapture, i18n, liveness, ..
     useCapture ?
       <Camera {...{i18n, method, title, subTitle, liveness, ...other}}/> :
       <Uploader {...{i18n, instructions, parentheses, title, subTitle, ...other}}/>
-  )
+    )
 }
 
 const mapStateToProps = (state, props) => {

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -60,7 +60,7 @@
         'welcome',
         {
           type:'document',
-          options:{
+          options: {
             useWebcam: options.useWebcam === "true",
             documentTypes: {}
           }

--- a/src/index.js
+++ b/src/index.js
@@ -68,9 +68,11 @@ const formatOptions = ({steps, ...otherOptions}) => ({
 const deprecationWarnings = ({steps}) => {
   const isDocument = (step) => step.type === 'document'
   const documentStep = Array.find(steps, isDocument)
-  const useWebcamOption = documentStep.options && documentStep.options.useWebcam
-  if (useWebcamOption) {
-    console.warn("`useWebcam` is an experimental option and is currently discouraged")
+  if (documentStep) {
+    const useWebcamOption = documentStep.options.length && documentStep.options.useWebcam
+    if (useWebcamOption) {
+      console.warn("`useWebcam` is an experimental option and is currently discouraged")
+    }
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -68,11 +68,9 @@ const formatOptions = ({steps, ...otherOptions}) => ({
 const deprecationWarnings = ({steps}) => {
   const isDocument = (step) => step.type === 'document'
   const documentStep = Array.find(steps, isDocument)
-  if (documentStep) {
-    const useWebcamOption = documentStep.options.length && documentStep.options.useWebcam
-    if (useWebcamOption) {
-      console.warn("`useWebcam` is an experimental option and is currently discouraged")
-    }
+  const useWebcamOption = documentStep && documentStep.options && documentStep.options.useWebcam
+  if (useWebcamOption) {
+    console.warn("`useWebcam` is an experimental option and is currently discouraged")
   }
 }
 


### PR DESCRIPTION
# Problem
Edge has partial `object-fit` support (for `<img>` not for `<video>`)  therefore the live capture stream is not full screen.

# Solution

Apply browser specific styles to handle missing `object-fit` support.


## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
