### PR TITLE
Rebuild component list to get previous component type

### DIFF
--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -155,13 +155,8 @@ class MainRouter extends Component {
     return {steps, token, language, documentType, step: this.state.crossDeviceInitialStep, woopraCookie}
   }
 
-  onFlowChange = (newFlow, newStep, previousFlow, previousStep, previousStepType) => {
-    if (newFlow === "crossDeviceSteps") {
-      this.setState({
-        crossDeviceInitialStep: previousStep,
-        crossDeviceInitialStepType: previousStepType,
-      })
-    }
+  onFlowChange = (newFlow, newStep, previousFlow, previousStep) => {
+    if (newFlow === "crossDeviceSteps") this.setState({crossDeviceInitialStep: previousStep})
   }
 
   componentWillReceiveProps(nextProps) {
@@ -175,7 +170,6 @@ class MainRouter extends Component {
       steps={props.options.steps}
       onFlowChange={this.onFlowChange}
       mobileConfig={this.mobileConfig()}
-      crossDeviceInitialStepType={this.state.crossDeviceInitialStepType}
       i18n={this.state.i18n}
     />
 }
@@ -202,22 +196,18 @@ class HistoryRouter extends Component {
   }
 
   disableNavigation = () => {
-    return this.initialStep() || this.getStepType(this.state.step) === 'complete'
-  }
-
-  getStepType = index => {
     const componentList = this.componentsList()
-    const { step = {} }  = componentList[index] || {}
-    return step.type
+    const currentStepIndex = this.state.step
+    const currentStepType = componentList[currentStepIndex].step.type
+    return this.initialStep() || currentStepType === 'complete'
   }
 
   initialStep = () => this.state.initialStep === this.state.step && this.state.flow === 'captureSteps'
 
   changeFlowTo = (newFlow, newStep=0) => {
     const {flow: previousFlow, step: previousStep} = this.state
-    const previousStepType = this.getStepType(previousStep)
     if (previousFlow === newFlow) return
-    this.props.onFlowChange(newFlow, newStep, previousFlow, previousStep, previousStepType)
+    this.props.onFlowChange(newFlow, newStep, previousFlow, previousStep)
     this.setStepIndex(newStep, newFlow)
   }
 

--- a/src/components/crossDevice/Intro/index.js
+++ b/src/components/crossDevice/Intro/index.js
@@ -5,9 +5,13 @@ import style from './style.css'
 import Title from '../../Title'
 import { trackComponent } from '../../../Tracker'
 import {preventDefaultOnClick} from '../../utils'
+import {componentsList} from '../../Router/StepComponentMap'
 
-const Intro = ({i18n, nextStep, crossDeviceInitialStepType}) => {
-  const isFace = crossDeviceInitialStepType === 'face'
+const previousComponentType = ({flow = 'captureSteps', documentType, steps, step}) =>
+  componentsList({ flow, documentType, steps })[step || 0].step.type
+
+const Intro = ({i18n, nextStep, mobileConfig}) => {
+  const isFace = previousComponentType(mobileConfig) === 'face'
   const stages = {
     'sms': 'sms',
     'take-photos': `${ isFace ? 'face' : 'document' }.take_photos`,


### PR DESCRIPTION
- Revert adding `prevStepType` state var
- Rebuild component list in `Intro` to access `step.type` based on previous step index.

Also not perfect, since a child component is accessing a domain far outside its predictable area of knowledge, but at least it doesn't require adding more state to one of its ancestors.