### PR TITLE
explicit documentation of the document step options

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,16 @@ A number of options are available to allow you to customise the SDK:
 
   ### document ###
 
-  This is the document capture step. Users will be asked to select the document type and to provide images of their selected documents. They will also have a chance to check the quality of the images before confirming. The custom options are:
-  - documentTypes (object - it can contain the following keys: `passport`, `driving_licence`, `national_identity_card`. The value for each key should be a boolean)
+  This is the document capture step. Users will be asked to select the document type and to provide images of their selected documents. They will also have a chance to check the quality of the images before confirming.
+  The custom options are:
+  - documentTypes
+  ```
+    {
+        passport: boolean,
+        driving_licence: boolean,
+        national_identity_card: boolean
+    }
+  ```
 
   ### face ###
 


### PR DESCRIPTION
# Problem
The typing of some step options in object form can be a bit hard to read and understand.
Motivation, to make it more clear to users: https://github.com/onfido/onfido-sdk-ui/issues/358

# Solution
Instead of explaining the structure of the object, I write the object in sudo typing.

## Checklist

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
