### PR TITLE
Ensure onStepChange prop gets called when changing step

### DIFF
--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -119,7 +119,7 @@ class CrossDeviceMobileRouter extends Component {
   onDisconnectPong = () =>
     this.clearPingTimeout()
 
-  onStepChange = ({step}) => {
+  onStepChange = step => {
     this.setState({step})
   }
 
@@ -186,8 +186,13 @@ class HistoryRouter extends Component {
     this.setStepIndex(this.state.step, this.state.flow)
   }
 
+  componentWillUpdate(nextProps, nextState) {
+    if (nextState.step !== this.state.step) {
+      this.props.onStepChange(nextState.step);
+    }
+  }
+
   onHistoryChange = ({state:historyState}) => {
-    this.props.onStepChange(historyState)
     this.setState({...historyState})
   }
 
@@ -234,15 +239,15 @@ class HistoryRouter extends Component {
 
   setStepIndex = (newStepIndex, newFlow, excludeStepFromHistory) => {
     const {flow:currentFlow} = this.state
-    const historyState = {
+    const newState = {
       step: newStepIndex,
       flow: newFlow || currentFlow,
     }
     if (excludeStepFromHistory) {
-      this.onHistoryChange({ state: historyState })
+      this.setState(newState)
     } else {
       const path = `${location.pathname}${location.search}${location.hash}`
-      history.push(path, historyState)
+      history.push(path, newState)
     }
   }
 

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -239,7 +239,7 @@ class HistoryRouter extends Component {
       flow: newFlow || currentFlow,
     }
     if (excludeStepFromHistory) {
-      this.setState(historyState)
+      this.onHistoryChange({ state: historyState })
     } else {
       const path = `${location.pathname}${location.search}${location.hash}`
       history.push(path, historyState)


### PR DESCRIPTION
...without changing history

# Problem

`onStepChange` should be called, even if history doesn't change.

See discussion:
https://github.com/onfido/onfido-sdk-ui/pull/360#discussion_r202410030

# Solution

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
