### PR TITLE
Remove geoip location

### DIFF
--- a/src/components/PhoneNumberInput/index.js
+++ b/src/components/PhoneNumberInput/index.js
@@ -15,40 +15,25 @@ const FlagComponent = ({ countryCode, flagsPath }) => (
   />
 );
 
-class PhoneNumberInput extends Component {
-  constructor(props) {
-    super(props)
-    this.state = { country: 'GB' }
-    this.getCountry()
-  }
+const PhoneNumberInput = ({ i18n, clearErrors, actions = {}}) => {
 
-  getCountry = () => {
-    const url = 'https://freegeoip.net/json/'
-    const request = new XMLHttpRequest()
-    request.open('GET', url)
-    request.onload = () => {
-      const country = JSON.parse(request.response)['country_code']
-      this.setState({country})
-    }
-    request.send()
-  }
-
-  onChange = (number) => {
-    this.props.clearErrors()
+  const onChange = (number) => {
+    clearErrors()
     const valid = isValidPhoneNumber(number)
-    this.props.actions.setMobileNumber({number, valid})
+    actions.setMobileNumber({number, valid})
   }
 
-  render = ({i18n}) =>
+  return (
     <form onSubmit={(e) => e.preventDefault()}>
       <PhoneNumber placeholder={i18n.t('cross_device.phone_number_placeholder')}
-        onChange={this.onChange}
-        country={this.state.country}
+        onChange={onChange}
+        country="GB"
         inputClassName={`${style.mobileInput}`}
         className={`${style.phoneNumberContainer}`}
         flagComponent={ FlagComponent }
       />
     </form>
+  )
 }
 
 export default PhoneNumberInput


### PR DESCRIPTION
# Problem
Currently a request to freegeoip performed to detect the user's country and pre-fill country phone code. Recently, https://freegeoip.io/ has been taken down so requests always fail.

# Solution
Stop using freegeoip to detect country, and use GB as the default country.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
