### PR TITLE
Add upload fallback to camera error

### DIFF
--- a/src/components/Camera/CameraTypes.js
+++ b/src/components/Camera/CameraTypes.js
@@ -23,13 +23,6 @@ type CameraActionType = {
   btnDisabled: boolean,
 }
 
-type CameraErrorType = {
-  onUploadFallback: File => void,
-  fileInput?: React.Ref<'input'>,
-  trackScreen: Function,
-  i18n: Object,
-}
-
 type CameraPureType = {
   ...CameraCommonType,
   hasError?: boolean,
@@ -54,4 +47,4 @@ type CameraStateType = {
   hasSeenPermissionsPrimer: boolean,
 }
 
-export type { CameraPureType, CameraType, CameraActionType, CameraStateType, CameraErrorType};
+export type { CameraPureType, CameraType, CameraActionType, CameraStateType};

--- a/src/components/Camera/CameraTypes.js
+++ b/src/components/Camera/CameraTypes.js
@@ -12,23 +12,31 @@ type CameraCommonType = {
   onFailure: Function,
   onUserMedia: void => void,
   i18n: Object,
-  isFullScreen: boolean
+  isFullScreen: boolean,
 }
 
 type CameraActionType = {
   handleClick: Function,
   btnText: string,
   isFullScreen: boolean,
-  btnClass: string
+  btnClass: string,
+  btnDisabled: boolean,
+}
+
+type CameraErrorType = {
+  onUploadFallback: File => void,
+  fileInput?: React.Ref<'input'>,
+  trackScreen: Function,
+  i18n: Object,
 }
 
 type CameraPureType = {
   ...CameraCommonType,
   hasError?: boolean,
-  onFallbackClick?: void => void,
   webcamRef: React.Ref<typeof Webcam>,
+  trackScreen: Function,
   useFullScreen: boolean => void,
-  video?: boolean
+  video?: boolean,
 }
 
 type CameraType = {
@@ -37,6 +45,7 @@ type CameraType = {
   onScreenshot: Function,
   onVideoRecorded: ?Blob => void,
   trackScreen: Function,
+  hasError?: boolean,
 }
 
 type CameraStateType = {
@@ -45,4 +54,4 @@ type CameraStateType = {
   hasSeenPermissionsPrimer: boolean,
 }
 
-export type { CameraPureType, CameraType, CameraActionType, CameraStateType};
+export type { CameraPureType, CameraType, CameraActionType, CameraStateType, CameraErrorType};

--- a/src/components/Camera/Photo.js
+++ b/src/components/Camera/Photo.js
@@ -28,6 +28,7 @@ export default class Photo extends React.Component<CameraType> {
           btnText={this.buttonText()}
           handleClick={this.screenshot}
           btnClass={this.buttonClass()}
+          btnDisabled={!!this.props.hasError}
            />
       </div>
     )

--- a/src/components/Camera/Video.js
+++ b/src/components/Camera/Video.js
@@ -57,6 +57,7 @@ export default class Video extends React.Component<CameraType, VideoState> {
           btnText={this.buttonText()}
           handleClick={this.handleVideoClick}
           btnClass={this.buttonClass()}
+          btnDisabled={!!this.props.hasError}
         />
       </div>
     )

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -15,7 +15,7 @@ import PermissionsRecover from './Permissions/Recover'
 
 import classNames from 'classnames'
 import style from './style.css'
-import type { CameraPureType, CameraType, CameraActionType, CameraStateType, CameraErrorType} from './CameraTypes'
+import type { CameraPureType, CameraType, CameraActionType, CameraStateType} from './CameraTypes'
 import { checkIfWebcamPermissionGranted, parseTags } from '../utils'
 
 export const CaptureActions = ({handleClick, btnText, isFullScreen, btnClass, btnDisabled}: CameraActionType) => {
@@ -28,6 +28,13 @@ export const CaptureActions = ({handleClick, btnText, isFullScreen, btnClass, bt
       </button>
     </div>
   )
+}
+
+type CameraErrorType = {
+  onUploadFallback: File => void,
+  fileInput?: React.Ref<'input'>,
+  trackScreen: Function,
+  i18n: Object,
 }
 
 class CameraError extends React.Component<CameraErrorType> {
@@ -43,8 +50,8 @@ class CameraError extends React.Component<CameraErrorType> {
 
   onFallbackClick = () => { if (this.fileInput) { this.fileInput.click(); } }
 
-  errorInstructions = (text, onFallbackClick) =>
-    <span onClick={onFallbackClick} className={style.errorLink}>
+  errorInstructions = (text) =>
+    <span onClick={this.onFallbackClick} className={style.errorLink}>
       { text }
       <input type="file" id="fallback"
         ref={(ref) => this.fileInput = ref} style={'display: none'}
@@ -59,7 +66,7 @@ class CameraError extends React.Component<CameraErrorType> {
         className={style.errorMessage}
         error={{ name: 'CAMERA_NOT_WORKING', type: 'error' }}
         renderInstruction={ str =>
-          parseTags(str, ({ text }) => this.errorInstructions(text, this.onFallbackClick))}
+          parseTags(str, ({ text }) => this.errorInstructions(text))}
         smaller
       />
     </div>

--- a/src/components/Camera/style.css
+++ b/src/components/Camera/style.css
@@ -36,6 +36,10 @@
   }
 }
 
+.btn:disabled {
+  background-color: #8A9293;
+}
+
 .btn:extend(.btn, .btn-centered, .btn-primary) {
   @media (--small-viewport) {
     padding: 0;


### PR DESCRIPTION
# Problem
At the moment, if there is a camera error after permissions have been granted the user is stuck.


# Solution
Add upload fallback to camera error screen.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [x] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
