### PR TITLE
Removed countdown reference from manual testing

### DIFF
--- a/MANUAL_REGRESSION.md
+++ b/MANUAL_REGRESSION.md
@@ -12,7 +12,7 @@
     - photo capture frame should display preview from webcam
     - user should be able to upload a picture anyway
 3. Take photo with a webcam
-    - 3-second counter should start and then photo should be taken
+    - Photo should be taken
     - confirmation screen should show up containing photo that was taken
     - user should be able to retake or continue with taken photo
 


### PR DESCRIPTION
# Problem

Applause testers found a problem by following the manual regression document, but the problem didn't exist because we changed the behaviour.

issue: https://platform.applause.com/products/19993/testcycles/191826/issues/3360537

# Solution

Remove reference of countdown from document.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ n/a] Have new automated tests been implemented?
- [ n/a] Have new manual tests been written down?
- [ n/a] Have tests passed locally?
- [n/a ] Have any new strings been translated?
