### PR TITLE
Remove target value to allow upload of the same file

### DIFF
--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -44,8 +44,10 @@ class CameraError extends React.Component<CameraErrorType> {
     this.props.trackScreen('camera_error')
   }
 
-  handleUpload = () => {
+  handleUpload = (event) => {
     if (this.fileInput) { this.props.onUploadFallback(this.fileInput.files[0]) }
+    // Remove target value to allow upload of the same file if needed
+    event.target.value = null
   }
 
   onFallbackClick = () => { if (this.fileInput) { this.fileInput.click(); } }


### PR DESCRIPTION
# Problem
When trying to upload an image on the face step camera fallback, the `onChange` event is not fired if you try to upload the same file multiple times. It's only fired when the input value does change.

# Solution
Set the `event.target.value` to `null` after selecting a file.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
