### PR TITLE
Disable autocapture on mobile devices

### DIFF
--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -215,7 +215,7 @@ class Capture extends Component {
   }
 
   render ({useWebcam, back, i18n, termsAccepted, liveness, ...other}) {
-    const useCapture = (!this.state.uploadFallback && useWebcam && this.state.hasWebcam)
+    const useCapture = (!this.state.uploadFallback && useWebcam && isDesktop && this.state.hasWebcam)
     return (
       process.env.PRIVACY_FEATURE_ENABLED && !termsAccepted ?
         <PrivacyStatement {...{i18n, back, acceptTerms: this.acceptTerms, ...other}}/> :


### PR DESCRIPTION
# Problem
User should not see document auto-capture UI when they are on a mobile device

# Solution
Revert removing `isDesktop` in conditional

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [x] Have new automated tests been implemented?
- [x] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [x] Have any new strings been translated?
