### PR TITLE
Adjust permission primer layout

### DIFF
--- a/src/components/Camera/Permissions/Recover/index.js
+++ b/src/components/Camera/Permissions/Recover/index.js
@@ -6,10 +6,12 @@ import {preventDefaultOnClick} from 'components/utils'
 import { trackComponent } from 'Tracker'
 
 const Recover = ({onRefresh, i18n}) => (
-  <div className={theme.fullHeightMobileContainer}>
-    <Title title={i18n.t('webcam_permissions.access_denied')} />
+  <div className={theme.fullHeightContainer}>
+    <Title
+      title={i18n.t('webcam_permissions.access_denied')}
+      subTitle={i18n.t('webcam_permissions.recover_access')}
+    />
     <div className={theme.thickWrapper}>
-      {i18n.t('webcam_permissions.recover_access')}
       <div className={style.instructions}>
         <span className={style.recovery}>{i18n.t('webcam_permissions.recovery')}</span>
         <p className={style.instructionsTitle}>{i18n.t('webcam_permissions.follow_steps')}</p>

--- a/src/components/Theme/style.css
+++ b/src/components/Theme/style.css
@@ -9,12 +9,16 @@
   flex-direction: column;
 }
 
+.fullHeightContainer {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
 .fullHeightMobileContainer {
   @media (--small-viewport) {
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+    .fullHeightContainer();
   }
 }
 
@@ -31,11 +35,9 @@
 .content {
   flex: 1 0 auto;
   position: relative;
-  @media (--small-viewport) {
-    display: flex;
-    > * {
-      flex-grow: 1;
-    }
+  display: flex;
+  > * {
+    flex-grow: 1;
   }
 }
 


### PR DESCRIPTION
# Problem
Permission primer layout should be adjusted to match designs.

![image](https://user-images.githubusercontent.com/1504258/43204525-7d20b630-8ff7-11e8-8457-5bcd17f46a4d.png)

![image](https://user-images.githubusercontent.com/1504258/43204537-89c0102a-8ff7-11e8-81a6-d3a9f5fca0d2.png)


# Solution
Move body copy as `subTitle` of the `Title` component.

Additionally, the component needs to take the full height of its parent. In order to do so, `theme.content` needs to be `display: flex`, and its first direct child set to `flex-grow: 1`. This is the current behaviour on small viewports, and was needed for the same purpose. I checked other screens and couldn't find any regressions because of this change.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [x] Have new automated tests been implemented?
- [x] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [x] Have any new strings been translated?
