### PR TITLE
Feature/timed upload fallback cx 2316

### DIFF
--- a/src/components/Camera/CameraTypes.js
+++ b/src/components/Camera/CameraTypes.js
@@ -13,6 +13,7 @@ type CameraCommonType = {
   onUserMedia: void => void,
   i18n: Object,
   isFullScreen: boolean,
+  cameraError: Object,
 }
 
 type CameraActionType = {
@@ -39,12 +40,14 @@ type CameraType = {
   onVideoRecorded: ?Blob => void,
   trackScreen: Function,
   hasError?: boolean,
+  liveness: boolean,
 }
 
 type CameraStateType = {
   hasError: boolean,
   hasGrantedPermission: ?boolean,
   hasSeenPermissionsPrimer: boolean,
+  cameraError: Object,
 }
 
 export type { CameraPureType, CameraType, CameraActionType, CameraStateType};

--- a/src/components/Camera/CameraTypes.js
+++ b/src/components/Camera/CameraTypes.js
@@ -41,6 +41,7 @@ type CameraType = {
   trackScreen: Function,
   hasError?: boolean,
   liveness: boolean,
+  hasGrantedPermission?: boolean,
 }
 
 type CameraStateType = {

--- a/src/components/Camera/Photo.js
+++ b/src/components/Camera/Photo.js
@@ -49,8 +49,8 @@ export default class Photo extends React.Component<CameraType, PhotoStateType> {
       <div>
         <CameraPure {...{
             ...this.props,
-            hasError: this.props.hasError || this.state.hasError,
-            cameraError: this.props.cameraError || this.state.cameraError,
+            hasError: this.state.hasError,
+            cameraError: this.state.cameraError,
             webcamRef: (c) => { this.webcam = c }
           }}
         />

--- a/src/components/Camera/Photo.js
+++ b/src/components/Camera/Photo.js
@@ -10,7 +10,7 @@ import { screenshot } from '../utils/camera.js'
 import { CameraPure, CaptureActions } from './index.js'
 
 type PhotoStateType = {
-  hasCameraTimeout: boolean
+  hasCameraTimedout: boolean
 }
 
 export default class Photo extends React.Component<CameraType, PhotoStateType> {
@@ -18,13 +18,13 @@ export default class Photo extends React.Component<CameraType, PhotoStateType> {
   selfieTimeoutId = null
 
   state: PhotoStateType = {
-    hasCameraTimeout: false,
+    hasCameraTimedout: false,
   }
 
   componentDidMount () {
     this.clearSelfieTimeout()
     this.selfieTimeoutId = setTimeout(() => {
-      this.setState({hasCameraTimeout: true})
+      this.setState({hasCameraTimedout: true})
     }, 8000)
   }
 
@@ -40,7 +40,7 @@ export default class Photo extends React.Component<CameraType, PhotoStateType> {
   buttonClass = () => classNames({ [style.fullScreenBtn]: this.props.isFullScreen })
   cameraErrorOrWarning = () => {
     if (this.props.hasError) return this.props.cameraError
-    return this.state.hasCameraTimeout ? { name: 'CAMERA_INACTIVE', type: 'warning' } : {}
+    return this.state.hasCameraTimedout ? { name: 'CAMERA_INACTIVE', type: 'warning' } : {}
   }
 
   render() {
@@ -48,7 +48,7 @@ export default class Photo extends React.Component<CameraType, PhotoStateType> {
       <div>
         <CameraPure {...{
             ...this.props,
-            hasError: this.props.hasError || this.state.hasCameraTimeout,
+            hasError: this.props.hasError || this.state.hasCameraTimedout,
             cameraError: this.cameraErrorOrWarning(),
             webcamRef: (c) => { this.webcam = c }
           }}

--- a/src/components/Camera/Photo.js
+++ b/src/components/Camera/Photo.js
@@ -9,8 +9,36 @@ import { screenshot } from '../utils/camera.js'
 
 import { CameraPure, CaptureActions } from './index.js'
 
-export default class Photo extends React.Component<CameraType> {
+type PhotoStateType = {
+  hasError?: boolean,
+  cameraError?: Object,
+}
+
+export default class Photo extends React.Component<CameraType, PhotoStateType> {
   webcam = null
+  selfieTimeoutId = null
+
+  state: PhotoStateType = {
+    hasError: !!this.props.hasError,
+    cameraError: this.props.cameraError,
+  }
+
+  componentDidMount () {
+    this.clearSelfieTimeout()
+    this.selfieTimeoutId = setTimeout(() => {
+      // Only show camera_inactive warning if camera hasn't errored
+      if (!this.props.hasError) {
+        this.setState({hasError: true, cameraError: { name: 'CAMERA_INACTIVE', type: 'warning' }})
+      }
+    }, 8000)
+  }
+
+  componentWillUnmount() {
+    this.clearSelfieTimeout()
+  }
+
+  clearSelfieTimeout = () =>
+    this.selfieTimeoutId && clearTimeout(this.selfieTimeoutId)
 
   screenshot = () => screenshot(this.webcam, this.props.onScreenshot)
   buttonText = () => {if (this.props.i18n) return this.props.i18n.t('capture.face.button')}
@@ -21,6 +49,8 @@ export default class Photo extends React.Component<CameraType> {
       <div>
         <CameraPure {...{
             ...this.props,
+            hasError: this.props.hasError || this.state.hasError,
+            cameraError: this.props.cameraError || this.state.cameraError,
             webcamRef: (c) => { this.webcam = c }
           }}
         />

--- a/src/components/Camera/Photo.js
+++ b/src/components/Camera/Photo.js
@@ -21,11 +21,14 @@ export default class Photo extends React.Component<CameraType, PhotoStateType> {
     hasCameraTimedout: false,
   }
 
-  componentDidMount () {
-    this.clearSelfieTimeout()
-    this.selfieTimeoutId = setTimeout(() => {
-      this.setState({hasCameraTimedout: true})
-    }, 8000)
+  componentWillUpdate() {
+    // only start the timeout if permissions have been granted
+    if (this.props.hasGrantedPermission && !this.selfieTimeoutId) {
+      this.clearSelfieTimeout()
+      this.selfieTimeoutId = setTimeout(() => {
+        this.setState({hasCameraTimedout: true})
+      }, 8000)
+    }
   }
 
   componentWillUnmount() {

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -60,10 +60,10 @@ class CameraError extends React.Component<CameraErrorType> {
     }
   }
 
-  errorInstructions = (type, text) =>
+  errorInstructions = (text) =>
     <span onClick={this.onFallbackClick} className={style.errorLink}>
       { text }
-      <input type="file" accept={type === 'uploadFallback' ? 'image/*' : 'image/*;capture=camera'}
+      <input type="file" accept='image/*' capture
         ref={(ref) => this.fileInput = ref} style={'display: none'}
         onChange={this.handleFallback}
       />
@@ -76,7 +76,7 @@ class CameraError extends React.Component<CameraErrorType> {
         className={style.errorMessage}
         error={this.props.cameraError}
         renderInstruction={ str =>
-          parseTags(str, ({type,text}) => this.errorInstructions(type,text))}
+          parseTags(str, ({text}) => this.errorInstructions(text))}
         smaller
       />
     </div>

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -35,6 +35,7 @@ type CameraErrorType = {
   fileInput?: React.Ref<'input'>,
   trackScreen: Function,
   i18n: Object,
+  cameraError: Object,
 }
 
 class CameraError extends React.Component<CameraErrorType> {
@@ -139,7 +140,7 @@ export default class Camera extends React.Component<CameraType, CameraStateType>
     hasError: false,
     hasGrantedPermission: undefined,
     hasSeenPermissionsPrimer: false,
-    cameraError: {}
+    cameraError: {},
   }
 
   componentDidMount () {

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -130,7 +130,6 @@ const permissionErrors = ['PermissionDeniedError', 'NotAllowedError', 'NotFoundE
 
 export default class Camera extends React.Component<CameraType, CameraStateType> {
   webcam: ?React$ElementRef<typeof Webcam> = null
-  selfieTimeoutId = null
 
   static defaultProps = {
     onFailure: () => {},
@@ -147,22 +146,11 @@ export default class Camera extends React.Component<CameraType, CameraStateType>
     this.props.trackScreen('camera')
     checkIfWebcamPermissionGranted(hasGrantedPermission =>
       this.setState({ hasGrantedPermission: hasGrantedPermission || undefined }))
-    this.clearSelfieTimeout()
-    this.selfieTimeoutId = setTimeout(() => {
-      this.setState({hasError: true, cameraError: { name: 'CAMERA_INACTIVE', type: 'warning' }})
-    }, 8000)
-  }
-
-  componentWillUnmount() {
-    this.clearSelfieTimeout()
   }
 
   setPermissionsPrimerSeen = () => {
     this.setState({ hasSeenPermissionsPrimer: true })
   }
-
-  clearSelfieTimeout = () =>
-    this.selfieTimeoutId && clearTimeout(this.selfieTimeoutId)
 
   renderCamera = () => {
     const props = {

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -47,7 +47,7 @@ class CameraError extends React.Component<CameraErrorType> {
     }
   }
 
-  handleUpload = (event) => {
+  handleFallback = (event) => {
     if (this.fileInput) { this.props.onUploadFallback(this.fileInput.files[0]) }
     // Remove target value to allow upload of the same file if needed
     event.target.value = null

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -70,7 +70,7 @@ class CameraError extends React.Component<CameraErrorType> {
     </span>
 
   render = () =>
-    <div className={style.errorContainer}>
+    <div className={classNames(style.errorContainer, style[`${this.props.cameraError.type}ContainerType`])}>
       <Error
         i18n={this.props.i18n}
         className={style.errorMessage}
@@ -158,7 +158,8 @@ export default class Camera extends React.Component<CameraType, CameraStateType>
       onUserMedia: this.handleUserMedia,
       onFailure: this.handleWebcamFailure,
       hasError: this.state.hasError,
-      cameraError: this.state.cameraError
+      cameraError: this.state.cameraError,
+      hasGrantedPermission: this.state.hasGrantedPermission,
     };
     if (this.props.autoCapture) return <AutoCapture {...props} />
     return process.env.LIVENESS_ENABLED && this.props.liveness ?

--- a/src/components/Camera/style.css
+++ b/src/components/Camera/style.css
@@ -157,7 +157,9 @@
   @media (--small-viewport) {
     top: 40px;
   }
+}
 
+.errorContainerType {
   &::before {
     content: '';
     display: block;

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -215,7 +215,10 @@ class Capture extends Component {
   }
 
   render ({useWebcam, back, i18n, termsAccepted, liveness, ...other}) {
-    const useCapture = (!this.state.uploadFallback && useWebcam && isDesktop && this.state.hasWebcam)
+    const canUseWebcam = this.state.hasWebcam && !this.state.uploadFallback
+    const shouldUseWebcam = useWebcam && (this.props.method === 'face' || isDesktop)
+    const useCapture = canUseWebcam && shouldUseWebcam
+
     return (
       process.env.PRIVACY_FEATURE_ENABLED && !termsAccepted ?
         <PrivacyStatement {...{i18n, back, acceptTerms: this.acceptTerms, ...other}}/> :

--- a/src/components/Error/style.css
+++ b/src/components/Error/style.css
@@ -62,9 +62,7 @@
   position: absolute;
   height: 100%;
   width: @icon-width;
-  @media (--small-viewport) {
-    width: @icon-width-small;
-  }
+  width: @icon-width-small;
   margin-top: 5px;
   background-position: left top;
   background-repeat: no-repeat;

--- a/src/components/Error/style.css
+++ b/src/components/Error/style.css
@@ -62,7 +62,9 @@
   position: absolute;
   height: 100%;
   width: @icon-width;
-  width: @icon-width-small;
+  @media (--small-viewport) {
+    width: @icon-width-small;
+  }
   margin-top: 5px;
   background-position: left top;
   background-repeat: no-repeat;
@@ -91,6 +93,10 @@
   margin: 8px;
 
   .title-icon-error {
+    width: @icon-width-small;
+  }
+
+  .title-icon-warning {
     width: @icon-width-small;
   }
 

--- a/src/components/strings/errors.js
+++ b/src/components/strings/errors.js
@@ -10,4 +10,5 @@ export const errors = (i18n) => ({
   'SMS_FAILED': { message: i18n.t('errors.sms_failed.message'), instruction: i18n.t('errors.sms_failed.instruction')},
   'SMS_OVERUSE': { message: i18n.t('errors.sms_overuse.message'), instruction: i18n.t('errors.sms_overuse.instruction')},
   'CAMERA_NOT_WORKING': { message: i18n.t('errors.camera_not_working.message'), instruction: i18n.t('errors.camera_not_working.instruction')},
+  'CAMERA_INACTIVE': { message: i18n.t('errors.camera_inactive.message'), instruction: i18n.t('errors.camera_inactive.instruction')},
 })

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -230,7 +230,11 @@
     },
     "camera_not_working": {
       "message": "Your camera isn’t working",
-      "instruction": "It may be disconnected or not functional. <retry>Try again.</retry>"
+      "instruction": "It may be disconnected or not functional. <uploadFallback>Try again.</uploadFallback>"
+    },
+    "camera_inactive": {
+      "message": "Having camera problems?",
+      "instruction": "<uploadFallback>Upload a selfie image</uploadFallback> to continue"
     }
   },
   "passport": "Passport",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -224,7 +224,11 @@
     },
     "camera_not_working": {
       "message": "Su cámara no esta funcionando",
-      "instruction": "Puede estar desconectada o no funcionando. <retry>Reintentar.</retry>"
+      "instruction": "Puede estar desconectada o no funcionando. <uploadFallback>Reintentar.</uploadFallback>"
+    },
+    "camera_inactive": {
+      "message": "Algun problema con su cámara?",
+      "instruction": "<uploadFallback>Suba una selfie</uploadFallback> para continuar"
     }
   },
   "passport": "Pasaporte",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -227,7 +227,7 @@
       "instruction": "Puede estar desconectada o no funcionando. <uploadFallback>Reintentar.</uploadFallback>"
     },
     "camera_inactive": {
-      "message": "Algun problema con su cámara?",
+      "message": "¿Algun problema con su cámara?",
       "instruction": "<uploadFallback>Suba una selfie</uploadFallback> para continuar"
     }
   },

--- a/src/locales/mobilePhrases/en.json
+++ b/src/locales/mobilePhrases/en.json
@@ -24,5 +24,11 @@
     "face": {
       "instructions": "Take a selfie showing your face"
     }
+  },
+  "errors": {
+    "camera_inactive": {
+      "message": "Having camera problems?",
+      "instruction": "<native>Try the basic camera</native> mode instead"
+    }
   }
 }

--- a/src/locales/mobilePhrases/en.json
+++ b/src/locales/mobilePhrases/en.json
@@ -28,7 +28,7 @@
   "errors": {
     "camera_inactive": {
       "message": "Having camera problems?",
-      "instruction": "<native>Try the basic camera</native> mode instead"
+      "instruction": "<nativeCamera>Try the basic camera</nativeCamera> mode instead"
     }
   }
 }

--- a/src/locales/mobilePhrases/en.json
+++ b/src/locales/mobilePhrases/en.json
@@ -27,7 +27,6 @@
   },
   "errors": {
     "camera_inactive": {
-      "message": "Having camera problems?",
       "instruction": "<nativeCamera>Try the basic camera</nativeCamera> mode instead"
     }
   }

--- a/src/locales/mobilePhrases/es.json
+++ b/src/locales/mobilePhrases/es.json
@@ -24,5 +24,10 @@
     "face": {
       "instructions": "Tome una selfie que muestre su cara"
     }
+  },
+  "errors": {
+    "camera_inactive": {
+      "instruction": "<nativeCamera>Pruebe el modo de cámara básica</nativeCamera> en su lugar"
+    }
   }
 }


### PR DESCRIPTION
# Problem
User should be able to submit a selfie if they are struggling to take a live capture in their browser.

# Solution
Allow users to upload a selfie/use native camera if they don't take a selfie within 8 seconds.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [x] Have new manual tests been written down?
- [x] Have tests passed locally?
- [x] Have any new strings been translated?
