### PR TITLE
Always show webcam on face step

### DIFF
--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -215,7 +215,10 @@ class Capture extends Component {
   }
 
   render ({useWebcam, back, i18n, termsAccepted, liveness, ...other}) {
-    const useCapture = (!this.state.uploadFallback && useWebcam && isDesktop && this.state.hasWebcam)
+    const canUseWebcam = this.state.hasWebcam && !this.state.uploadFallback
+    const shouldUseWebcam = useWebcam && (this.props.method === 'face' || isDesktop)
+    const useCapture = canUseWebcam && shouldUseWebcam
+
     return (
       process.env.PRIVACY_FEATURE_ENABLED && !termsAccepted ?
         <PrivacyStatement {...{i18n, back, acceptTerms: this.acceptTerms, ...other}}/> :


### PR DESCRIPTION
# Problem
- doc step +  mobile: user should not see phonecam
- face step + mobile: user should ALWAYS see phonecam (regardless of `useWebcam` setting) as `useWebcam` only applies to doc step 

# Solution


## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
