### PR TITLE
brough back the console functionality of updating the sdk options

### DIFF
--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -7,7 +7,7 @@ use the onfido bundle, the one that clients will use as well.
  */
 const Onfido = window.Onfido
 
-const options = window.location
+const queryStrings = window.location
                       .search.slice(1)
                       .split('&')
                       .reduce((/*Object*/ a, /*String*/ b) => {
@@ -15,31 +15,31 @@ const options = window.location
                         a[b[0]] = decodeURIComponent(b[1]);
                         return a;
                       }, {});
-const useModal = options.useModal === "true"
+const useModal = queryStrings.useModal === "true"
 
 const steps = [
   'welcome',
   {
     type:'document',
     options: {
-      useWebcam: options.useWebcam === "true",
+      useWebcam: queryStrings.useWebcam === "true",
       documentTypes: {}
     }
   },
   {
     type: 'face',
     options:{
-      variant: options.liveness === "true" ? 'video' : 'photo',
-      useWebcam: options.useWebcam !== "false",
+      variant: queryStrings.liveness === "true" ? 'video' : 'photo',
+      useWebcam: queryStrings.useWebcam !== "false",
     }
   },
   'complete'
 ]
 
-const language = options.language === "customTranslations" ? {
+const language = queryStrings.language === "customTranslations" ? {
   locale: 'fr',
   phrases: {'welcome.title': 'Ouvrez votre nouveau compte bancaire'}
-} : options.language
+} : queryStrings.language
 
 const getToken = function(onSuccess) {
   const url = process.env.JWT_FACTORY
@@ -99,7 +99,7 @@ class Demo extends Component{
     isModalOpen: false
   }
 
-  sdkOptions = (options = {})=> ({
+  sdkOptions = (clientSdkOptions={})=> ({
     token: this.state.token,
     useModal,
     onComplete: () => {
@@ -108,11 +108,11 @@ class Demo extends Component{
     isModalOpen: this.state.isModalOpen,
     language,
     steps,
-    mobileFlow: !!options.link_id,
+    mobileFlow: !!queryStrings.link_id,
     onModalRequestClose: () => {
       this.setState({isModalOpen: false})
     },
-    ...options
+    ...clientSdkOptions
   })
 
   render () {
@@ -124,7 +124,7 @@ class Demo extends Component{
             Verify identity
         </button>
       }
-      {options.async === "false" && this.state.token === null ?
+      {queryStrings.async === "false" && this.state.token === null ?
         null : <SDK options={this.sdkOptions(this.props.options)}></SDK>
       }
     </div>

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -99,7 +99,7 @@ class Demo extends Component{
     isModalOpen: false
   }
 
-  sdkOptions = ()=> ({
+  sdkOptions = (options = {})=> ({
     token: this.state.token,
     useModal,
     onComplete: () => {
@@ -111,7 +111,8 @@ class Demo extends Component{
     mobileFlow: !!options.link_id,
     onModalRequestClose: () => {
       this.setState({isModalOpen: false})
-    }
+    },
+    ...options
   })
 
   render () {
@@ -124,11 +125,15 @@ class Demo extends Component{
         </button>
       }
       {options.async === "false" && this.state.token === null ?
-        null : <SDK options={this.sdkOptions()}></SDK>
+        null : <SDK options={this.sdkOptions(this.props.options)}></SDK>
       }
     </div>
   }
 }
 
 
-render(<Demo/>, document.getElementById("demo-app") )
+const container = render(<Demo/>, document.getElementById("demo-app") )
+
+window.updateOptions = (newOptions)=>{
+  render(<Demo options={newOptions}/>, document.getElementById("demo-app"), container )
+}


### PR DESCRIPTION
# Problem

The console functionality, on the demo app, that allowed one to update the sdk properties was lost in the PR of demo react conversion

# Solution

Since the new approach is React and it's wrapping the instance object of the sdk, things were a little more tricky. It was not possible to just expose the internal instance, because any render triggered would override any previous console call. Therefore a similar approach is used to how the sdk itself exposes the react component through a classical interface.
A new demo `window` function has been exposed of sudo type `updateOptions(options: SDKoptions)`

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a ] Have new automated tests been implemented?
- [ n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [ n/a] Have any new strings been translated?
