### PR TITLE
Change flow to x-device if there is no camera

### DIFF
--- a/src/components/Liveness/Intro.js
+++ b/src/components/Liveness/Intro.js
@@ -1,44 +1,57 @@
 // @flow
 import * as React from 'react'
-import { h } from 'preact'
+import { h, Component } from 'preact'
 import classNames from 'classnames'
 import style from './style.css'
 import theme from '../Theme/style.css'
 import Title from '../Title'
-import {preventDefaultOnClick} from '../utils'
+import { preventDefaultOnClick, checkIfHasWebcam } from '../utils'
 import {parseI18nWithXmlTags} from '../../locales'
 import { trackComponent } from '../../Tracker'
 
 type Props = {
+  changeFlowTo: (string, ?number, ?boolean) => void,
   i18n: Object,
   nextStep: void => void,
 };
 
-const Intro = ({ i18n, nextStep }: Props) => (
-  <div className={theme.fullHeightContainer}>
-    <Title title={i18n.t('capture.liveness.intro.title')} />
-    <div className={classNames(theme.thickWrapper, style.introCopy)}>
-      <ul className={style.introBullets}>
-      {
-        ['two_actions', 'speak_out_loud'].map(key =>
-          <li key={key} className={style.introBullet}>
-            <span className={classNames(style.introIcon, style[`${key}Icon`])} />
-            { parseI18nWithXmlTags(i18n, `capture.liveness.intro.${key}`, ({ text }) => (
-               <span className={style.bolder}>{text}</span>
-            ))}
-          </li>
-        )
-      }
-      </ul>
-    </div>
-    <div className={theme.thickWrapper}>
-      <button
-        className={classNames(theme.btn, theme['btn-primary'], theme['btn-centered'])}
-        onClick={preventDefaultOnClick(nextStep)}>
-        {i18n.t('capture.liveness.intro.continue')}
-      </button>
-    </div>
-  </div>
-)
+const noop = () => {}
+
+class Intro extends Component<Props> {
+  componentDidMount() {
+    const { changeFlowTo } = this.props
+    checkIfHasWebcam(hasWebcam => !hasWebcam && changeFlowTo('crossDeviceSteps'))
+  }
+
+  render() {
+    const { i18n, nextStep } = this.props
+    return (
+      <div className={theme.fullHeightContainer}>
+        <Title title={i18n.t('capture.liveness.intro.title')} />
+        <div className={classNames(theme.thickWrapper, style.introCopy)}>
+          <ul className={style.introBullets}>
+          {
+            ['two_actions', 'speak_out_loud'].map(key =>
+              <li key={key} className={style.introBullet}>
+                <span className={classNames(style.introIcon, style[`${key}Icon`])} />
+                { parseI18nWithXmlTags(i18n, `capture.liveness.intro.${key}`, ({ text }) => (
+                   <span className={style.bolder}>{text}</span>
+                ))}
+              </li>
+            )
+          }
+          </ul>
+        </div>
+        <div className={theme.thickWrapper}>
+          <button
+            className={classNames(theme.btn, theme['btn-primary'], theme['btn-centered'])}
+            onClick={preventDefaultOnClick(nextStep)}>
+            {i18n.t('capture.liveness.intro.continue')}
+          </button>
+        </div>
+      </div>
+    )
+  }
+}
 
 export default trackComponent(Intro)


### PR DESCRIPTION
# Problem
Given liveness is being requested, and there is no webcam, user should be taken to the x-device flow to complete the video check. If photo variant is being requested, the current x-device behaviour should be retained.

# Solution
Detect camera presence when mounting the intro component, and change flow if no camera is detected

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
