### PR TITLE
Set video height to 100%

### DIFF
--- a/src/components/Confirm/style.css
+++ b/src/components/Confirm/style.css
@@ -10,8 +10,9 @@
 }
 
 .livenessVideo {
-  width: 100%   !important;
-  height: auto  !important;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .actionsContainer {


### PR DESCRIPTION
# Problem
Users cannot submit video on mobile devices. Users should see video preview scaled in the same way that we current scale the selfie image.

# Solution
Do not set height to auto in case video proportions are portrait, therefore overflowing its container and 
sitting on top of submit buttons.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
