### PR TITLE
Use milliseconds instead of seconds for challenge switch

### DIFF
--- a/src/components/Liveness/index.js
+++ b/src/components/Liveness/index.js
@@ -6,7 +6,7 @@ import LivenessCamera from '../Camera/LivenessCamera'
 import type { CameraType } from '../Camera/CameraTypes'
 import type { ChallengeType } from './Challenge'
 import { requestChallenges } from '../utils/onfidoApi'
-import { currentSeconds } from '../utils'
+import { currentMilliseconds } from '../utils'
 
 const serverError = { name: 'SERVER_ERROR', type: 'error' }
 
@@ -53,12 +53,12 @@ export default class Liveness extends Component<CameraType, State> {
 
   handleChallengeSwitch = () => {
     if (this.state.startedAt) {
-      this.setState({ switchSeconds: currentSeconds() - this.state.startedAt })
+      this.setState({ switchSeconds: currentMilliseconds() - this.state.startedAt })
     }
   }
 
   handleVideoRecordingStart = () => {
-    this.setState({ startedAt: currentSeconds() })
+    this.setState({ startedAt: currentMilliseconds() })
   }
 
   handleVideoRecorded = (blob: ?Blob) => {

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -67,3 +67,5 @@ export const parseTags = (str, handleTag) => {
 }
 
 export const currentSeconds = () => Math.floor(Date.now() / 1000)
+
+export const currentMilliseconds = () => new Date().getTime()


### PR DESCRIPTION
# Problem
When we submit a new video to the `/v2/live_videos` endpoint, we are sending the value of `challenge_switch_at` in seconds instead of using milliseconds.

# Solution
Use milliseconds instead

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
