### PR TITLE
Fix missing liveness translation

### DIFF
--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -77,7 +77,7 @@
         "left": "izquierdo",
         "done_next": "Cuando esté listo, presione continuar",
         "done_stop": "Cuando esté listo, presione parar",
-        "next": "Next"
+        "next": "Siguiente"
       }
     }
   },


### PR DESCRIPTION
# Problem
A string is not correctly being translated for liveness challenges

# Solution
Add translation

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
