### PR TITLE
Use browser specific styles

### DIFF
--- a/src/components/Camera/style.css
+++ b/src/components/Camera/style.css
@@ -126,14 +126,27 @@
   display: block;
   height: 100%;
   z-index: 0;
+  /* Use `object-fit: cover` on every browser but Edge */
+  @supports not (-ms-ime-align:auto) {
+    width:100%;
+    top: 0;
+    left: 0;
+    margin: auto;
+    object-fit: cover;
+  }
 }
 
-.webcamContainer {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  margin: auto;
-  transform: translate(-50%, 0%);
+
+  .webcamContainer {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    /* Only apply styles on Edge where there is no `object-fit:cover` support for video */
+    @supports (-ms-ime-align:auto) {
+      left: 50%;
+      margin: auto;
+      transform: translate(-50%, 0%);
+    }
 }
 
 .uploadFallback {


### PR DESCRIPTION
# Problem
After removing `object-fit: cover`, as it was not supported on Edge, the video stream looks larger on most browsers. 

# Solution
Use browser specific styles. Use `object-fit: cover` on every browser apart from Edge.

Before
<img width="570" alt="screen shot 2018-08-30 at 14 46 39" src="https://user-images.githubusercontent.com/7127427/44855917-08d9d200-ac64-11e8-82b8-b0ed7760c056.png">

After
<img width="546" alt="screen shot 2018-08-30 at 14 46 56" src="https://user-images.githubusercontent.com/7127427/44855918-08d9d200-ac64-11e8-9cac-e168a94a0294.png">


## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
