### PR TITLE
Use Array.find instead of Array.prototype.find

### DIFF
--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -196,6 +196,7 @@ export default class Camera extends React.Component<CameraType, CameraStateType>
   }
 
   handleWebcamFailure = (error: Error) => {
+    // $FlowFixMe
     if (Array.includes(permissionErrors, error.name)) {
       this.setState({ hasGrantedPermission: false })
     } else {

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -196,7 +196,7 @@ export default class Camera extends React.Component<CameraType, CameraStateType>
   }
 
   handleWebcamFailure = (error: Error) => {
-    if (permissionErrors.includes(error.name)) {
+    if (Array.includes(permissionErrors, error.name)) {
       this.setState({ hasGrantedPermission: false })
     } else {
       this.setState({ hasError: true, cameraError: { name: 'CAMERA_NOT_WORKING', type: 'error' }})

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -182,7 +182,7 @@ class Confirm extends Component  {
     this.setState({captureId: id})
 
     if (method === 'document') {
-      const isPoA = poaDocumentTypes.includes(documentType)
+      const isPoA = Array.includes(poaDocumentTypes, documentType)
       const shouldDetectGlare = !isOfFileType(['pdf'], blob) && !isPoA
       const shouldDetectDocument = !isPoA
       const validations = {

--- a/src/components/DocumentSelector/index.js
+++ b/src/components/DocumentSelector/index.js
@@ -149,4 +149,4 @@ export const getDocumentTypeGroup = (documentType: string): groupType  =>
   find({
     'proof_of_address': poaDocumentTypes,
     'identity': identityDocumentTypes,
-  }, types => types.includes(documentType))
+  }, types => Array.includes(types, documentType))

--- a/src/components/DocumentSelector/index.js
+++ b/src/components/DocumentSelector/index.js
@@ -149,4 +149,7 @@ export const getDocumentTypeGroup = (documentType: string): groupType  =>
   find({
     'proof_of_address': poaDocumentTypes,
     'identity': identityDocumentTypes,
-  }, types => Array.includes(types, documentType))
+  }, types =>
+    // $FlowFixMe
+    Array.includes(types, documentType)
+  )

--- a/src/components/Router/StepComponentMap.js
+++ b/src/components/Router/StepComponentMap.js
@@ -27,7 +27,7 @@ const clientCaptureSteps = (steps) =>
   hasCompleteStep(steps) ? steps : [...steps, {type: 'complete'}]
 
 const shouldUseLiveness = steps => {
-  const { options: faceOptions } = steps.find(({ type }) => type === 'face') || {}
+  const { options: faceOptions } = Array.find(steps, ({ type }) => type === 'face') || {}
   return (faceOptions || {}).requestedVariant === 'video' && window.MediaRecorder
 }
 

--- a/src/components/utils/object.js
+++ b/src/components/utils/object.js
@@ -1,2 +1,2 @@
 export const find = (obj = {}, fn) =>
-  Object.keys(obj).find(key => fn(obj[key], key))
+  Array.find(Object.keys(obj), key => fn(obj[key], key))


### PR DESCRIPTION
# Problem
Build is broken on IE due to lack of support (and polyfilling) of Array.prototype.find 

# Solution
Use `Array.find()` instead.

Same issue is experienced with `Array.prototype.includes`, and similar workaround used.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [] Have tests passed locally?
- [n/a] Have any new strings been translated?
