### PR TITLE
Forward click event to hidden file input

### DIFF
--- a/src/components/CustomFileInput/index.js
+++ b/src/components/CustomFileInput/index.js
@@ -22,6 +22,13 @@ export default class CustomFileInput extends React.Component<Props> {
 
   input: ?HTMLInputElement
 
+  handleClick = () => {
+    if (this.input) {
+      this.input.click()
+    }
+    this.props.onClick();
+  }
+
   handleChange = (event: SyntheticEvent<HTMLInputElement>) => {
     if (this.input) {
       this.props.onChange(this.input.files[0])
@@ -32,14 +39,13 @@ export default class CustomFileInput extends React.Component<Props> {
   render = () => {
     const { children, className, onClick, onChange, ...other } = this.props // eslint-disable-line no-unused-vars
     return (
-      <div className={classNames(style.container, className)}>
+      <div onClick={this.handleClick} className={classNames(style.container, className)}>
         { children }
         <input
           type="file"
           className={style.input}
           ref={ ref => this.input = ref }
           onChange={this.handleChange}
-          onClick={onClick}
           {...other}
         />
       </div>

--- a/src/components/CustomFileInput/style.css
+++ b/src/components/CustomFileInput/style.css
@@ -1,12 +1,12 @@
 .container {
   position: relative;
+  cursor: pointer;
 }
 
 .input {
   bottom: 0;
-  cursor: pointer;
   left: 0;
-  opacity: 0;
+  display: none;
   position: absolute;
   right: 0;
   top: 0;


### PR DESCRIPTION
# Problem
File input is not correctly being resized on IE, it doesn't take the full height of its container as expected.
Therefore, clicking on the upload button doesn't work.

# Solution
Instead of receiving the input's events with `opacity:0`, set input to `display:none` and forward the click events of its container, that will scale properly.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [n/a] Have any new strings been translated?
