### PR TITLE
Remove padding from retake button

### DIFF
--- a/src/components/Confirm/style.css
+++ b/src/components/Confirm/style.css
@@ -50,6 +50,7 @@
 
 .retake {
   width: 136px;
+  padding: 0;
   @media (--small-viewport) {
     width: 112px;
   }


### PR DESCRIPTION
# Problem
Long copy overflows when breaking in two lines, in the redo button on the confirm screen.

# Solution
Remove padding from button

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
