### PR TITLE
Feature/track video screens cx 2109

### DIFF
--- a/src/components/Capture/index.js
+++ b/src/components/Capture/index.js
@@ -42,5 +42,5 @@ export default {
   FrontDocumentCapture: appendToTracking(FrontDocumentCapture, 'front_capture'),
   BackDocumentCapture: appendToTracking(BackDocumentCapture, 'back_capture'),
   FaceCapture: appendToTracking(FaceCapture, 'capture'),
-  LivenessCapture: appendToTracking(LivenessCapture, 'video_facial'),
+  LivenessCapture: appendToTracking(LivenessCapture, 'video'),
 }

--- a/src/components/Capture/index.js
+++ b/src/components/Capture/index.js
@@ -41,6 +41,6 @@ const LivenessCapture = props =>
 export default {
   FrontDocumentCapture: appendToTracking(FrontDocumentCapture, 'front_capture'),
   BackDocumentCapture: appendToTracking(BackDocumentCapture, 'back_capture'),
-  FaceCapture: appendToTracking(FaceCapture, 'capture'),
-  LivenessCapture: appendToTracking(LivenessCapture, 'video'),
+  FaceCapture: appendToTracking(FaceCapture, 'selfie_capture'),
+  LivenessCapture: appendToTracking(LivenessCapture, 'video_capture'),
 }

--- a/src/components/Capture/index.js
+++ b/src/components/Capture/index.js
@@ -42,5 +42,5 @@ export default {
   FrontDocumentCapture: appendToTracking(FrontDocumentCapture, 'front_capture'),
   BackDocumentCapture: appendToTracking(BackDocumentCapture, 'back_capture'),
   FaceCapture: appendToTracking(FaceCapture, 'capture'),
-  LivenessCapture: appendToTracking(LivenessCapture, 'liveness_capture'),
+  LivenessCapture: appendToTracking(LivenessCapture, 'video_facial'),
 }

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -242,16 +242,12 @@ const DocumentFrontWrapper = (props) =>
 const DocumentBackWrapper = (props) =>
   <MapConfirm {...props} method= 'document' side= 'back' />
 
-const LivenessWrapper = (props) => <FaceBaseConfirm {...props} />
-
-const FaceBaseConfirm = (props) =>
+const BaseFaceConfirm = (props) =>
   <MapConfirm {...props} method='face' />
-
-const FaceConfirmWrapper = (props) => <FaceBaseConfirm {...props} />
 
 const DocumentFrontConfirm = appendToTracking(DocumentFrontWrapper, 'front')
 const DocumentBackConfirm = appendToTracking(DocumentBackWrapper, 'back')
-const FaceConfirm = appendToTracking(FaceConfirmWrapper, 'selfie')
-const LivenessConfirm = appendToTracking(LivenessWrapper, 'video')
+const FaceConfirm = appendToTracking(BaseFaceConfirm, 'selfie')
+const LivenessConfirm = appendToTracking(BaseFaceConfirm, 'video')
 
 export { DocumentFrontConfirm, DocumentBackConfirm, FaceConfirm, LivenessConfirm}

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -249,6 +249,6 @@ const FaceConfirm = (props) =>
 
 const DocumentFrontConfirm = appendToTracking(DocumentFrontWrapper, 'front')
 const DocumentBackConfirm = appendToTracking(DocumentBackWrapper, 'back')
-const LivenessConfirm = appendToTracking(LivenessWrapper, 'video_facial')
+const LivenessConfirm = appendToTracking(LivenessWrapper, 'video')
 
 export { DocumentFrontConfirm, DocumentBackConfirm, FaceConfirm, LivenessConfirm}

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -242,10 +242,13 @@ const DocumentFrontWrapper = (props) =>
 const DocumentBackWrapper = (props) =>
   <MapConfirm {...props} method= 'document' side= 'back' />
 
+const LivenessWrapper = (props) => <FaceConfirm {...props} />
+
 const FaceConfirm = (props) =>
-  <MapConfirm {...props} method= 'face' />
+  <MapConfirm {...props} method='face' />
 
 const DocumentFrontConfirm = appendToTracking(DocumentFrontWrapper, 'front')
 const DocumentBackConfirm = appendToTracking(DocumentBackWrapper, 'back')
+const LivenessConfirm = appendToTracking(LivenessWrapper, 'video_facial')
 
-export { DocumentFrontConfirm, DocumentBackConfirm, FaceConfirm }
+export { DocumentFrontConfirm, DocumentBackConfirm, FaceConfirm, LivenessConfirm}

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -242,13 +242,16 @@ const DocumentFrontWrapper = (props) =>
 const DocumentBackWrapper = (props) =>
   <MapConfirm {...props} method= 'document' side= 'back' />
 
-const LivenessWrapper = (props) => <FaceConfirm {...props} />
+const LivenessWrapper = (props) => <FaceBaseConfirm {...props} />
 
-const FaceConfirm = (props) =>
+const FaceBaseConfirm = (props) =>
   <MapConfirm {...props} method='face' />
+
+const FaceConfirmWrapper = (props) => <FaceBaseConfirm {...props} />
 
 const DocumentFrontConfirm = appendToTracking(DocumentFrontWrapper, 'front')
 const DocumentBackConfirm = appendToTracking(DocumentBackWrapper, 'back')
+const FaceConfirm = appendToTracking(FaceConfirmWrapper, 'selfie')
 const LivenessConfirm = appendToTracking(LivenessWrapper, 'video')
 
 export { DocumentFrontConfirm, DocumentBackConfirm, FaceConfirm, LivenessConfirm}

--- a/src/components/Liveness/Intro.js
+++ b/src/components/Liveness/Intro.js
@@ -41,4 +41,4 @@ const Intro = ({ i18n, nextStep }: Props) => (
   </div>
 )
 
-export default trackComponent(Intro)
+export default trackComponent(Intro, 'intro')

--- a/src/components/Liveness/Intro.js
+++ b/src/components/Liveness/Intro.js
@@ -41,4 +41,4 @@ const Intro = ({ i18n, nextStep }: Props) => (
   </div>
 )
 
-export default trackComponent(Intro, 'intro')
+export default trackComponent(Intro, 'video_intro')

--- a/src/components/Liveness/index.js
+++ b/src/components/Liveness/index.js
@@ -7,6 +7,7 @@ import type { CameraType } from '../Camera/CameraTypes'
 import type { ChallengeType } from './Challenge'
 import { requestChallenges } from '../utils/onfidoApi'
 import { currentMilliseconds } from '../utils'
+import { sendScreen } from '../../Tracker'
 
 const serverError = { name: 'SERVER_ERROR', type: 'error' }
 
@@ -42,7 +43,7 @@ export default class Liveness extends Component<CameraType, State> {
       requestChallenges(this.props.token, this.handleResponse, this.handleError)
     )
     this.setState({...initialState})
-    
+
   }
 
   handleResponse = (response: Object) => {
@@ -57,11 +58,13 @@ export default class Liveness extends Component<CameraType, State> {
   handleChallengeSwitch = () => {
     if (this.state.startedAt) {
       this.setState({ switchSeconds: currentMilliseconds() - this.state.startedAt })
+      sendScreen(['capture_step_2'])
     }
   }
 
   handleVideoRecordingStart = () => {
     this.setState({ startedAt: currentMilliseconds() })
+    sendScreen(['capture_step_1'])
   }
 
   handleVideoRecorded = (blob: ?Blob) => {

--- a/src/components/Liveness/index.js
+++ b/src/components/Liveness/index.js
@@ -58,13 +58,13 @@ export default class Liveness extends Component<CameraType, State> {
   handleChallengeSwitch = () => {
     if (this.state.startedAt) {
       this.setState({ switchSeconds: currentMilliseconds() - this.state.startedAt })
-      sendScreen(['capture_step_2'])
+      sendScreen(['face_video_capture_step_2'])
     }
   }
 
   handleVideoRecordingStart = () => {
     this.setState({ startedAt: currentMilliseconds() })
-    sendScreen(['capture_step_1'])
+    sendScreen(['face_video_capture_step_1'])
   }
 
   handleVideoRecorded = (blob: ?Blob) => {

--- a/src/components/Router/StepComponentMap.js
+++ b/src/components/Router/StepComponentMap.js
@@ -3,7 +3,7 @@ import { h } from 'preact'
 import Welcome from '../Welcome'
 import {SelectPoADocument, SelectIdentityDocument} from '../Select'
 import {FrontDocumentCapture, BackDocumentCapture, FaceCapture, LivenessCapture} from '../Capture'
-import {DocumentFrontConfirm, DocumentBackConfirm, FaceConfirm} from '../Confirm'
+import {DocumentFrontConfirm, DocumentBackConfirm, FaceConfirm, LivenessConfirm} from '../Confirm'
 import Complete from '../Complete'
 import MobileFlow from '../crossDevice/MobileFlow'
 import CrossDeviceLink from '../crossDevice/CrossDeviceLink'
@@ -37,7 +37,7 @@ const captureStepsComponents = (documentType, mobileFlow, steps) => {
   return {
     welcome: () => [Welcome],
     face: () => shouldUseLiveness(steps) ?
-        [LivenessIntro, LivenessCapture, FaceConfirm] :
+        [LivenessIntro, LivenessCapture, LivenessConfirm] :
         [FaceCapture, FaceConfirm],
     document: () => createIdentityDocumentComponents(documentType),
     poa: () => [PoAIntro, SelectPoADocument, PoADocumentCapture, DocumentFrontConfirm],


### PR DESCRIPTION
# Problem
Currently we have no analytics for the video capture feature

# Solution
Track video screens. The events will be tracked using the following format:
`screen_{{method}}_{{variant}}_{{screen_name}}`
For example, for the confirmation screen we will trigger the following event `screen_face_selfie_confirmation` or `screen_face_video_confirmation`.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a]  Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/] Have any new strings been translated?
