### PR TITLE
Add open sans semibold variant to demo app

### DIFF
--- a/src/demo/index.html
+++ b/src/demo/index.html
@@ -8,7 +8,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="format-detection" content="telephone=no">
 
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,500" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600" rel="stylesheet">
     <style type="text/css">
       html, body, #demo-app, .container {
         height: 100%;


### PR DESCRIPTION
# Problem
Currently semibold is incorrectly referenced in the demo app, and the browser renders a "fake bold" version of the regular variant.

# Solution
Update link tag to point to the correct semibold variant.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
