### PR TITLE
Send language code to api for lvideos

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,10 @@ A number of options are available to allow you to customise the SDK:
 
   The SDK can also be displayed in a custom language by passing an object containing the locale tag and the custom phrases.
   The object should include the following keys:
-    - `locale` (optional) : A locale tag. In order to partially customise the strings of a supported language (ie. Spanish), you will need to pass the locale tag. For missing keys, a warning and an array containing the missing keys will be returned on the console. The values for the missing keys will be displayed in the language specified within the locale tag if supported, otherwise they will be displayed in English. The locale tag is also used to override the language of the SMS body for the cross device feature. This feature is owned by Onfido and is currently only supporting English and Spanish.
+    - `locale`: A locale tag. This is *required* when providing phrases for an unsupported language.
+      In order to partially customise the strings of a supported language (ie. Spanish), you will need to pass the locale tag (ie. `es`). For missing keys, a warning and an array containing the missing keys will be returned on the console. The values for the missing keys will be displayed in the language specified within the locale tag if supported, otherwise they will be displayed in English.
+      The locale tag is also used to override the language of the SMS body for the cross device feature. This feature is owned by Onfido and is currently only supporting English and Spanish.
+
     - `phrases` (required) : An object containing the keys you want to override and the new values. The keys can be found in [`/src/locales/en.json`](/src/locales/en.json). They can be passed as a nested object or as a string using the dot notation for nested values. See the examples below.
     - `mobilePhrases` (optional) : An object containing the keys you want to override and the new values. The values specified within this object are only visible on mobile devices. Please refer to [`src/locales/mobilePhrases/en.json`](src/locales/mobilePhrases/en.json).
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ A number of options are available to allow you to customise the SDK:
 
   The SDK can also be displayed in a custom language by passing an object containing the locale tag and the custom phrases.
   The object should include the following keys:
-    - `locale`: A locale tag. This is *required* when providing phrases for an unsupported language.
+    - `locale`: A locale tag. This is **required** when providing phrases for an unsupported language.
       In order to partially customise the strings of a supported language (ie. Spanish), you will need to pass the locale tag (ie. `es`). For missing keys, a warning and an array containing the missing keys will be returned on the console. The values for the missing keys will be displayed in the language specified within the locale tag if supported, otherwise they will be displayed in English.
       The locale tag is also used to override the language of the SMS body for the cross device feature. This feature is owned by Onfido and is currently only supporting English and Spanish.
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ A number of options are available to allow you to customise the SDK:
   The SDK can also be displayed in a custom language by passing an object containing the locale tag and the custom phrases.
   The object should include the following keys:
     - `locale`: A locale tag. This is **required** when providing phrases for an unsupported language.
-      In order to partially customise the strings of a supported language (ie. Spanish), you will need to pass the locale tag (ie. `es`). For missing keys, a warning and an array containing the missing keys will be returned on the console. The values for the missing keys will be displayed in the language specified within the locale tag if supported, otherwise they will be displayed in English.
+      You can also use this to partially customise the strings of a supported language (ie. Spanish), by passing a supported language locale tag (ie. `es`). For missing keys, a warning and an array containing the missing keys will be returned on the console. The values for the missing keys will be displayed in the language specified within the locale tag if supported, otherwise they will be displayed in English.
       The locale tag is also used to override the language of the SMS body for the cross device feature. This feature is owned by Onfido and is currently only supporting English and Spanish.
 
     - `phrases` (required) : An object containing the keys you want to override and the new values. The keys can be found in [`/src/locales/en.json`](/src/locales/en.json). They can be passed as a nested object or as a string using the dot notation for nested values. See the examples below.

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -194,7 +194,7 @@ class Confirm extends Component  {
     }
     else if  (method === 'face') {
       if (variant === 'video') {
-        const data = { challengeData, blob }
+        const data = { challengeData, blob, language: this.props.i18n.currentLocale }
         uploadLiveVideo(data, token, this.onApiSuccess, this.onApiError)
       } else {
         const data = { file: blob }

--- a/src/components/utils/onfidoApi.js
+++ b/src/components/utils/onfidoApi.js
@@ -27,7 +27,7 @@ export const uploadLiveVideo = ({challengeData, blob, language}, token, onSucces
   } = challengeData
   const payload = {
     file: blob,
-    languages: [{source: 'sdk', language_code: language}],
+    languages: JSON.stringify([{source: 'sdk', language_code: language}]),
     challenge: JSON.stringify(challenge),
     challenge_id,
     challenge_switch_at

--- a/src/components/utils/onfidoApi.js
+++ b/src/components/utils/onfidoApi.js
@@ -19,13 +19,19 @@ export const uploadLivePhoto = (data, token, onSuccess, onError) => {
   sendFile(endpoint, data, token, onSuccess, onError)
 }
 
-export const uploadLiveVideo = (data, token, onSuccess, onError) => {
+export const uploadLiveVideo = ({challengeData, blob, language}, token, onSuccess, onError) => {
   const {
     challenges: challenge,
     id: challenge_id,
     switchSeconds: challenge_switch_at
-  } = data.challengeData
-  const payload = { file: data.blob, challenge: JSON.stringify(challenge), challenge_id, challenge_switch_at }
+  } = challengeData
+  const payload = {
+    file: blob,
+    languages: [{source: 'sdk', language_code: language}],
+    challenge: JSON.stringify(challenge),
+    challenge_id,
+    challenge_switch_at
+  }
   const endpoint = `${process.env.ONFIDO_API_URL}/v2/live_videos`
   sendFile(endpoint, payload, token, onSuccess, onError)
 }


### PR DESCRIPTION
# Problem
The backend needs to receive the language code to identify the language spoken by the user during the video.

# Solution
Add `languages: [{source: 'sdk', language_code: language}]` to the payload, where `language_code` is the current local and `source` is the language source (ie. on mobile SDKs the language can come from the phone or from the sdk itself). In our case, `source` will always be `'sdk'` as we don't do language detection from the browser.


## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a]Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
