### PR TITLE
Add tests for liveness fallbacks

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -36,5 +36,5 @@ if [[ ${CI} != "true" || (${NODE_ENV} = "test" && ${TRAVIS_PULL_REQUEST} != "fal
   # run cucumber tests against localhost
   SDK_URL="https://localhost:8080/?async=false"
   echo "Running Cucumber tests on ${SDK_URL}"
-  bundle exec cucumber BROWSER=${BROWSER:-chrome} SDK_URL=${SDK_URL} USE_SECRETS=false SEED_PATH=false DEBUG=false
+  bundle exec cucumber BROWSER=${BROWSER:-chrome} SDK_URL=${SDK_URL} USE_SECRETS=false SEED_PATH=false DEBUG=false CI=${CI}
 fi

--- a/test/features/cross_device.feature
+++ b/test/features/cross_device.feature
@@ -19,7 +19,6 @@ Feature: SDK Cross device steps
     Then page_title should include translation for "cross_device.submit.title"
     When I click on primary_button ()
     Then page_title should include translation for "complete.message"
-
     Examples:
       | type | locale |
       |      |        |

--- a/test/features/page_objects/sdk.rb
+++ b/test/features/page_objects/sdk.rb
@@ -125,6 +125,6 @@ Given(/^I navigate to the SDK(?:| with "([^"]*)"?)$/) do |locale_tag|
   open_sdk(@driver, { 'language' => locale_tag, 'useWebcam' => false })
 end
 
-Given(/^I navigate to the SDK using a webcam(?:| with "([^"]*)"?)$/) do |locale_tag|
-  open_sdk(@driver, { 'useWebcam' => true, 'language' => locale_tag })
+Given(/^I navigate to the SDK using liveness(?:| with "([^"]*)"?)$/) do |locale_tag|
+  open_sdk(@driver, { 'liveness' => true, 'language' => locale_tag })
 end

--- a/test/features/sdk_flow.feature
+++ b/test/features/sdk_flow.feature
@@ -172,6 +172,49 @@ Feature: SDK File Upload Tests
       |        |
       | es     |
 
+  Scenario Outline: I should enter the liveness flow if I have a camera and liveness variant requested
+    Given I initiate the verification process using liveness with <locale>
+    And I do have a camera
+    When I click on passport ()
+    When I try to upload passport
+    Then page_title should include translation for "capture.liveness.intro.title"
+    When I click on primary_button ()
+    Then page_title should include translation for "webcam_permissions.allow_access"
+
+    Examples:
+      | locale |
+      |        |
+      | es     |
+
+  Scenario Outline: I should be taken to the cross-device flow if I do not have a camera and liveness variant requested
+    Given I initiate the verification process using liveness with <locale>
+    And I do not have a camera
+    When I click on passport ()
+    When I try to upload passport
+    Then page_title should include translation for "capture.liveness.intro.title"
+    When I click on primary_button ()
+    Then page_title should include translation for "cross_device.intro.face.title"
+
+    Examples:
+      | locale |
+      |        |
+      | es     |
+
+  Scenario Outline: I should be taken to the selfie screen if browser does not have media recording capabilities and liveness variant requested
+    Given I initiate the verification process using liveness with <locale>
+    And I do have a camera
+    And I am not using a browser with media recording capabilities
+    When I click on passport ()
+    When I try to upload passport
+    Then page_title should include translation for "webcam_permissions.allow_access"
+    When I click on primary_button ()
+    Then page_title should include translation for "capture.face.title"
+
+    Examples:
+      | locale |
+      |        |
+      | es     |
+
 #   Until monster is updated to support launching Chrome with arguments (--use-fake-ui-for-media-stream, --use-fake-device-for-media-stream)
 #   this test will fail in Travis
 #

--- a/test/features/sdk_flow.feature
+++ b/test/features/sdk_flow.feature
@@ -200,10 +200,10 @@ Feature: SDK File Upload Tests
       |        |
       | es     |
 
-  Scenario Outline: I should be taken to the selfie screen if browser does not have media recording capabilities and liveness variant requested
+  Scenario Outline: I should be taken to the selfie screen if browser does not have MediaRecorder API and liveness variant requested
     Given I initiate the verification process using liveness with <locale>
     And I do have a camera
-    And I am not using a browser with media recording capabilities
+    And I am not using a browser with MediaRecorder API
     When I click on passport ()
     When I try to upload passport
     Then page_title should include translation for "webcam_permissions.allow_access"

--- a/test/features/sdk_flow.feature
+++ b/test/features/sdk_flow.feature
@@ -172,43 +172,39 @@ Feature: SDK File Upload Tests
       |        |
       | es     |
 
-  Scenario Outline: I should enter the liveness flow if I have a camera and liveness variant requested
-    Given I initiate the verification process using liveness with <locale>
-    And I do have a camera
-    When I click on passport ()
-    When I try to upload passport
-    Then page_title should include translation for "capture.liveness.intro.title"
-    When I click on primary_button ()
-    Then page_title should include translation for "webcam_permissions.allow_access"
+ Scenario Outline: I should enter the liveness flow if I have a camera and liveness variant requested
+   Given I initiate the verification process using liveness with <locale>
+   And I do have a camera
+   When I click on passport ()
+   When I try to upload passport
+   Then page_title should include translation for "capture.liveness.intro.title"
+   When I click on primary_button ()
+   Then page_title should include translation for "webcam_permissions.allow_access"
 
-    Examples:
-      | locale |
-      |        |
-      | es     |
+   Examples:
+     | locale |
+     |        |
+     | es     |
 
-  Scenario Outline: I should be taken to the cross-device flow if I do not have a camera and liveness variant requested
-    Given I initiate the verification process using liveness with <locale>
-    And I do not have a camera
-    When I click on passport ()
-    When I try to upload passport
-    Then page_title should include translation for "capture.liveness.intro.title"
-    When I click on primary_button ()
-    Then page_title should include translation for "cross_device.intro.face.title"
+ Scenario Outline: I should be taken to the cross-device flow if I do not have a camera and liveness variant requested
+   Given I initiate the verification process using liveness with <locale>
+   And I do not have a camera
+   When I click on passport ()
+   When I try to upload passport
+   Then page_title should include translation for "capture.liveness.intro.title"
+   When I click on primary_button ()
+   Then page_title should include translation for "cross_device.intro.face.title"
 
-    Examples:
-      | locale |
-      |        |
-      | es     |
+   Examples:
+     | locale |
+     |        |
+     | es     |
 
   Scenario Outline: I should be taken to the selfie screen if browser does not have MediaRecorder API and liveness variant requested
     Given I initiate the verification process using liveness with <locale>
     And I do have a camera
     And I am not using a browser with MediaRecorder API
-    When I click on passport ()
-    When I try to upload passport
-    Then page_title should include translation for "webcam_permissions.allow_access"
-    When I click on primary_button ()
-    Then page_title should include translation for "capture.face.title"
+    Then I am taken to the selfie screen
 
     Examples:
       | locale |

--- a/test/features/step_definitions/sdk_steps.rb
+++ b/test/features/step_definitions/sdk_steps.rb
@@ -127,3 +127,15 @@ Then(/^I can (confirm|decline) privacy terms$/) do | action |
     When I click on #{action}_privacy_terms ()
   }
 end
+
+Then(/^I am taken to the selfie screen$/) do
+  # Skip this test on Travis, due to camera absence
+  next if ENV['CI'] == 'true'
+  steps %Q{
+    When I click on passport ()
+    When I try to upload passport
+    Then page_title should include translation for "webcam_permissions.allow_access"
+    When I click on primary_button ()
+    Then page_title should include translation for "capture.face.title"
+  }
+end

--- a/test/features/step_definitions/sdk_steps.rb
+++ b/test/features/step_definitions/sdk_steps.rb
@@ -23,7 +23,7 @@ Given(/^I do( not)? have a camera$/) do |has_no_camera|
   @driver.execute_script('window.navigator.mediaDevices.enumerateDevices = () => Promise.resolve([' + devices + '])')
 end
 
-Given(/^I am( not)? using a browser with media recording capabilities$/) do |has_no_camera|
+Given(/^I am not using a browser with MediaRecorder API$/) do
   @driver.execute_script('window.MediaRecorder = undefined')
 end
 

--- a/test/features/step_definitions/sdk_steps.rb
+++ b/test/features/step_definitions/sdk_steps.rb
@@ -19,7 +19,7 @@ Given(/^I initiate the verification process using liveness with(?: (.+)?)?$/) do
 end
 
 Given(/^I do( not)? have a camera$/) do |has_no_camera|
-  devices = !has_no_camera ? '{ kind: "video" }' : ''
+  devices = has_no_camera ? '' : '{ kind: "video" }'
   @driver.execute_script('window.navigator.mediaDevices.enumerateDevices = () => Promise.resolve([' + devices + '])')
 end
 

--- a/test/features/step_definitions/sdk_steps.rb
+++ b/test/features/step_definitions/sdk_steps.rb
@@ -10,12 +10,21 @@ Given(/^I initiate the verification process with(?: (.+)?)?$/) do |locale|
   }
 end
 
-Given(/^I initiate the verification process using a webcam with(?: (.+)?)?$/) do |locale|
+Given(/^I initiate the verification process using liveness with(?: (.+)?)?$/) do |locale|
   i18n.load_locale(locale)
   steps %Q{
-    Given I navigate to the SDK using a webcam with "#{locale}"
+    Given I navigate to the SDK using liveness with "#{locale}"
     Then I click on primary_button (SDK)
   }
+end
+
+Given(/^I do( not)? have a camera$/) do |has_no_camera|
+  devices = !has_no_camera ? '{ kind: "video" }' : ''
+  @driver.execute_script('window.navigator.mediaDevices.enumerateDevices = () => Promise.resolve([' + devices + '])')
+end
+
+Given(/^I am( not)? using a browser with media recording capabilities$/) do |has_no_camera|
+  @driver.execute_script('window.MediaRecorder = undefined')
 end
 
 Given(/^I verify with (passport|identity_card|drivers_license)(?: with (.+)?)?$/) do |document_type, locale|


### PR DESCRIPTION
# Problem
We need to implement tests to assert liveness fallbacks work as expected:
```
  "desktop + no webcam -> x-device" scenario should be covered
  "desktop + safari (i.e. no `MediaRecorder`) -> selfie" scenario should be covered
```

# Solution

Since we can't enable the real webcam for tests, or emulate different browsers' implementation of `MediaRecorded`, the proposed approach is to stub `enumerateDevices` and unset `MediaRecorder` during if needed, the tests.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
