### PR TITLE
Fix FF layout issues

### DIFF
--- a/src/components/Theme/style.css
+++ b/src/components/Theme/style.css
@@ -54,6 +54,10 @@
   background-position: 50% 50%;
   background-repeat: no-repeat;
   z-index: 1;
+  /* hide the footer if view height is too small */
+  @media (max-height: 420px) {
+    z-index: -1;
+  }
 }
 
 .thickWrapper {
@@ -66,6 +70,7 @@
 .imageWrapper {
   display: flex;
   height: 300px;
+  min-height: 100px;
   margin: auto 3rem;
   @media (--small-viewport) {
     margin: 0rem @small-text-margin;


### PR DESCRIPTION
# Problem
On the confirmation screen on Firefox, user cannot interact with buttons when the screen is too small because the footer overrides the buttons

# Solution
* Give `imageWrapper` a `min-height` to prevent content overflowing on FF and prevent it from disappearing when the screen is vertically resized.
* If the device height is lower that 420px hide footer behind content

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
