### PR TITLE
Update test guidelines file

### DIFF
--- a/test/TESTING_GUIDELINES.md
+++ b/test/TESTING_GUIDELINES.md
@@ -14,8 +14,8 @@ Guide to Cucumber acceptance tests for JS SDK.
     - make sure `gem` is installed alongside with Ruby
 2. Google Chrome (latest version)
 3. Chromedriver (WebDriver for Chrome)
-    - `brew install chromedriver`
-    - **Note:** if you have chromedriver already installed, make sure it's the latest version: `brew upgrade chromedriver`
+    - `brew cask install chromedriver`
+    - **Note:** if you have chromedriver already installed, make sure it's the latest version: `brew cask upgrade chromedriver`
 4. Firefox (latest version)
 5. Geckdriver (WebDriver for Firefox)
     - `brew install geckodriver`


### PR DESCRIPTION
# Problem
Because of the instructions in the test guidelines file were outdated users wouldn't be able to install chromedriver file and would receive an error. 

> Error: No available formula with the name "chromedriver"
>It was migrated from homebrew/core to homebrew/cask.

# Solution
Update test guidelines file with correct command 

`brew cask upgrade chromedriver`

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
