### PR TITLE
Only allow recording when media stream available

### DIFF
--- a/src/components/Camera/CameraTypes.js
+++ b/src/components/Camera/CameraTypes.js
@@ -50,6 +50,7 @@ type CameraType = {
   onVideoRecorded: (?Blob, ?ChallengeData) => void,
   trackScreen: Function,
   hasError?: boolean,
+  hasMediaStream?: boolean,
   useFullScreen: boolean => void,
   liveness: ?boolean,
   hasGrantedPermission?: boolean,
@@ -58,6 +59,7 @@ type CameraType = {
 
 type CameraStateType = {
   hasError: boolean,
+  hasMediaStream: boolean,
   hasGrantedPermission: ?boolean,
   hasSeenPermissionsPrimer: boolean,
   cameraError: Object,

--- a/src/components/Camera/LivenessCamera.js
+++ b/src/components/Camera/LivenessCamera.js
@@ -63,8 +63,10 @@ export default class LivenessCamera extends React.Component<Props, State> {
   }
 
   handleRecordingStart = () => {
-    this.startRecording()
-    this.props.onVideoRecordingStart()
+    if (this.props.hasMediaStream) {
+      this.startRecording()
+      this.props.onVideoRecordingStart()
+    }
   }
 
   handleRecordingStop = () => {
@@ -115,7 +117,7 @@ export default class LivenessCamera extends React.Component<Props, State> {
   }
 
   render = () => {
-    const { i18n, challenges = [], hasGrantedPermission } = this.props
+    const { i18n, challenges = [], hasGrantedPermission, hasMediaStream } = this.props
     const { isRecording, currentIndex } = this.state
     const currentChallenge = challenges[currentIndex] || {}
     const isLastChallenge = currentIndex === challenges.length - 1

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -138,6 +138,7 @@ export default class Camera extends React.Component<CameraType, CameraStateType>
 
   state: CameraStateType = {
     hasError: false,
+    hasMediaStream: false,
     hasGrantedPermission: undefined,
     hasSeenPermissionsPrimer: false,
     cameraError: {},
@@ -181,6 +182,7 @@ export default class Camera extends React.Component<CameraType, CameraStateType>
       onUserMedia: this.handleUserMedia,
       onFailure: this.handleWebcamFailure,
       hasError: this.state.hasError,
+      hasMediaStream: this.state.hasMediaStream,
       cameraError: this.state.cameraError,
       hasGrantedPermission: this.state.hasGrantedPermission,
     }
@@ -192,7 +194,7 @@ export default class Camera extends React.Component<CameraType, CameraStateType>
   }
 
   handleUserMedia = () => {
-    this.setState({ hasGrantedPermission: true })
+    this.setState({ hasGrantedPermission: true, hasMediaStream: true })
   }
 
   handleWebcamFailure = (error: Error) => {


### PR DESCRIPTION
# Problem

Trying to start recording a video when media stream is not available throws an exception. 

![image](https://user-images.githubusercontent.com/1504258/45435955-f757e780-b6b1-11e8-8922-c2b6859da87d.png)

https://jsfiddle.net/4xqtt6fL/1579/show

# Solution

Wait until media stream is available to allow recording a video

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
