### PR TITLE
Feature/no guidance screen retake cx 2455

### DIFF
--- a/src/components/ProofOfAddress/index.js
+++ b/src/components/ProofOfAddress/index.js
@@ -1,36 +1,3 @@
-// @flow
-import * as React from 'react'
-import { h, Component } from 'preact'
-import { FrontDocumentCapture } from '../Capture'
-import Guidance from './Guidance'
-import { trackComponent } from '../../Tracker'
+export { FrontDocumentCapture as PoACapture } from '../Capture'
+export { default as PoAGuidance } from './Guidance'
 export { default as PoAIntro } from './PoAIntro'
-
-type Props = {
-  documentType: string,
-  i18n: Object,
-  trackScreen: Function,
-}
-
-type State = {
-  hasSeenGuidanceScreen: boolean,
-}
-
-class PoACapture extends Component<Props, State> {
-  state = {
-    hasSeenGuidanceScreen: false,
-  }
-
-  handleIntroNext = () => {
-    this.setState({ hasSeenGuidanceScreen: true })
-  }
-
-  render() {
-    const { i18n, documentType, trackScreen } = this.props
-    return this.state.hasSeenGuidanceScreen ?
-      <FrontDocumentCapture {...this.props} /> :
-      <Guidance {...{i18n, trackScreen, documentType, nextStep: this.handleIntroNext}} />
-  }
-}
-
-export default trackComponent(PoACapture)

--- a/src/components/Router/StepComponentMap.js
+++ b/src/components/Router/StepComponentMap.js
@@ -10,7 +10,7 @@ import CrossDeviceLink from '../crossDevice/CrossDeviceLink'
 import ClientSuccess from '../crossDevice/ClientSuccess'
 import CrossDeviceIntro from '../crossDevice/Intro'
 import LivenessIntro from '../Liveness/Intro'
-import PoADocumentCapture, { PoAIntro } from '../ProofOfAddress'
+import { PoACapture, PoAIntro, PoAGuidance } from '../ProofOfAddress'
 
 export const componentsList = ({flow, documentType, steps, mobileFlow}) => {
   const captureSteps = mobileFlow ? clientCaptureSteps(steps) : steps
@@ -40,7 +40,7 @@ const captureStepsComponents = (documentType, mobileFlow, steps) => {
         [LivenessIntro, LivenessCapture, LivenessConfirm] :
         [FaceCapture, FaceConfirm],
     document: () => createIdentityDocumentComponents(documentType),
-    poa: () => [PoAIntro, SelectPoADocument, PoADocumentCapture, DocumentFrontConfirm],
+    poa: () => [PoAIntro, SelectPoADocument, PoAGuidance, PoACapture, DocumentFrontConfirm],
     complete: () => complete
   }
 }


### PR DESCRIPTION
# Problem
user should not be presented with the guidance screen when retaking photo/upload for PoA
- user should not see the guidance screen again when retaking photos - they should just see the capture screen instead
- they should see the guidance screen if they click back though
- clicking back from the capture screen, user should also see the guidance screen instead of doc selection

# Solution
Use StepsRouter instead of internal state

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
