### PR TITLE
Stop rendering timeout if another timeout expired

### DIFF
--- a/src/components/Camera/LivenessCamera.js
+++ b/src/components/Camera/LivenessCamera.js
@@ -117,6 +117,18 @@ export default class LivenessCamera extends React.Component<Props, State> {
     }
   }
 
+  renderTimeout() {
+    const { isRecording, hasBecomeInactive, hasRecordingTakenTooLong } = this.state
+    const { hasGrantedPermission } = this.props
+    if (hasGrantedPermission && !hasBecomeInactive && !hasRecordingTakenTooLong) {
+      return isRecording ?
+        <Timeout key="recording" seconds={ 20 } onTimeout={ this.handleRecordingTimeout } /> :
+        <Timeout key="notRecording" seconds={ 12 } onTimeout={ this.handleInactivityTimeout } />
+    }
+
+    return null
+  }
+
   render = () => {
     const { i18n, challenges = [], hasGrantedPermission, hasMediaStream } = this.props
     const { isRecording, currentIndex } = this.state
@@ -127,12 +139,7 @@ export default class LivenessCamera extends React.Component<Props, State> {
     return (
       <div className={style.livenessCamera}>
         {
-          hasGrantedPermission ?
-            isRecording ?
-              <Timeout key="recording" seconds={ 20 } onTimeout={ this.handleRecordingTimeout } /> :
-              <Timeout key="notRecording" seconds={ 12 } onTimeout={ this.handleInactivityTimeout } />
-            :
-            null
+          this.renderTimeout()
         }
         <CameraPure
           {...{


### PR DESCRIPTION
# Problem
The 12-second "camera problem" warning counter should restart only after the user has clicked "redo action" after the 20-second timeout.

# Solution
Right now it only checks whether the user is recording to start the "inactivity" timeout or the "recording too long" timeout. It should also check if no timeout has already expired before starting a new one.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
