### PR TITLE
PDF should be centered

### DIFF
--- a/src/components/Confirm/PdfPreview.js
+++ b/src/components/Confirm/PdfPreview.js
@@ -23,7 +23,7 @@ class PDFPreview extends Component {
     this.id = 'pdfContainer' + (i++)
   }
   options = {
-    width: '92%',
+    width: '100%',
     height: '290px',
     'max-height': '70vh',
     border: 0,

--- a/src/components/Confirm/style.css
+++ b/src/components/Confirm/style.css
@@ -72,7 +72,7 @@
 }
 
 .pdfImage {
-  margin: 0;
+  width: 100%;
 }
 
 .retake {


### PR DESCRIPTION
# Problem
PDF previews and PDF icon are not aligned to the center.

# Solution
Align PDF previews and PDF icon to the center

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
