### PR TITLE
Tweak PoA documents

### DIFF
--- a/src/components/DocumentSelector/documentTypes.js
+++ b/src/components/DocumentSelector/documentTypes.js
@@ -40,12 +40,12 @@ export const poaDocumentOptions = {
     warning: 'utility_bill_warning',
     eStatementAccepted: true,
   },
-  benefit_letters: {
-    hint: 'benefits_letter_hint',
+  council_tax: {
     icon: 'icon-letter',
     checkAvailableInCountry: isUK,
   },
-  council_tax: {
+  benefit_letters: {
+    hint: 'benefits_letter_hint',
     icon: 'icon-letter',
     checkAvailableInCountry: isUK,
   },

--- a/src/components/ProofOfAddress/Guidance/graphic.js
+++ b/src/components/ProofOfAddress/Guidance/graphic.js
@@ -9,7 +9,7 @@ export default () => {
       <text transform="translate(0 110)" className={style.label}>Address</text>
       <text transform="translate(0 141)" className={style.label}>Issue date or</text>
       <text transform="translate(84.314 141)" className={style.label}></text>
-      <text transform="translate(0 161)" className={style.label}>Summary dates</text>
+      <text transform="translate(0 161)" className={style.label}>Summary period</text>
       <text transform="translate(0 28)" className={style.label}>Logo</text>
       <g transform="translate(119)">
         <path fill="#2C3E4F" d="M8 0h122.79c1.985.002 3.9.744 5.37 2.08l8.65 7.84c.092.084.182.171.27.26l5.57 5.56A8 8 0 0 1 153 21.4V209a8 8 0 0 1-8 8H8a8 8 0 0 1-8-8V8a8 8 0 0 1 8-8z" />

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -19,7 +19,7 @@
       "estatements_accepted": "e-statements accepted",
       "utility_bill_hint": "Gas, electricity, water, landline, or broadband",
       "utility_bill_warning": "Sorry, no mobile phone bills",
-      "benefits_letter_hint": "Government authorised household benefits eg. Jobseeker allowance, Housing benefit",
+      "benefits_letter_hint": "Government authorised household benefits eg. Jobseeker allowance, Housing benefit, Tax credits",
       "government_letter_hint": "Any government issued letter eg. Benefits entitlement, Voting letters, Tax letters, etc"
     }
   },
@@ -276,7 +276,7 @@
       "full_name": "Full Name",
       "make_sure_it_shows": "Make sure it clearly shows:",
       "current_address": "Current Address",
-      "issue_date": "Issue date or Summary dates",
+      "issue_date": "Issue date or Summary period",
       "continue": "Continue"
     }
   },


### PR DESCRIPTION
# Problem
- doc selection benefits letter copy should be "Government authorised household benefits eg. Jobseeker allowance, Housing benefit, Tax credits"
- Guidance page should see "Issue date or Summary period" instead of "Issue date or Summary dates"
- Council tax letters should appear above Benefits letters


# Solution
Update translations and document types config object



## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [n/a] Have any new strings been translated?
