### PR TITLE
Fail Travis build on ESLint test failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean": "rimraf lib dist",
     "prepublish": "npm run clean && npm run check && npm run build",
     "check": "npm run -s lint && npm run flow",
-    "lint": "eslint {src,test}",
+    "lint": "eslint './src/**/*.js' './test/**/*.js'",
     "flow": "flow check",
     "bundle-size": "webpack-bundle-analyzer"
   },

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 
 import { h } from 'preact'
 import Webcam from 'react-webcam-onfido'
+import Challenge from '../Liveness/Challenge'
 
 import { Overlay } from '../Overlay'
 import Title from '../Title'

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -3,7 +3,6 @@ import * as React from 'react'
 
 import { h } from 'preact'
 import Webcam from 'react-webcam-onfido'
-import Challenge from '../Liveness/Challenge'
 
 import { Overlay } from '../Overlay'
 import Title from '../Title'


### PR DESCRIPTION
# Problem
Travis build does not fail when there is an eslint error

# Solution
Change script to target specific directories. Pushed broken code to see the build fail. See screenshot
<img width="855" alt="screen shot 2018-09-24 at 11 53 20" src="https://user-images.githubusercontent.com/7127427/45948585-7de4c100-bff0-11e8-9dbf-fe76b59e655d.png">


## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
