### PR TITLE
Copy change for better selfie fallback transition

### DIFF
--- a/src/locales/mobilePhrases/en.json
+++ b/src/locales/mobilePhrases/en.json
@@ -27,10 +27,10 @@
   },
   "errors": {
     "camera_not_working": {
-      "instruction": "Try the <fallback>basic camera mode</fallback> instead"
+      "instruction": "Take a selfie using the <fallback>basic camera mode</fallback> instead"
     },
     "camera_inactive": {
-      "instruction": "Try the <fallback>basic camera mode</fallback> instead"
+      "instruction": "Take a selfie using the <fallback>basic camera mode</fallback> instead"
     }
   }
 }

--- a/src/locales/mobilePhrases/es.json
+++ b/src/locales/mobilePhrases/es.json
@@ -27,10 +27,10 @@
   },
   "errors": {
     "camera_not_working": {
-      "instruction": "Puede estar desconectada o no funcionando. Pruebe el <fallback>modo de cámara básica</fallback> en su lugar"
+      "instruction": "Tome una selfie usando el <fallback>modo de cámara básica</fallback> en su lugar"
     },
     "camera_inactive": {
-      "instruction": "Pruebe el <fallback>modo de cámara básica</fallback> en su lugar"
+      "instruction": "Tome una selfie usando el <fallback>modo de cámara básica</fallback> en su lugar"
     }
   }
 }


### PR DESCRIPTION
# Problem
Camera errors that result in selfie fallback are not descriptive enough in terms of what action will be required from the user.

# Solution
Change the copy to "Take a selfie using the basic camera mode instead".

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [x] Have any new strings been translated?
