### PR TITLE
Connect to socket.io only with polling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "onfido-sdk-ui",
+  "version": "2.8.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "socket.io-sticky-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/socket.io-sticky-headers/-/socket.io-sticky-headers-1.1.0.tgz",
+      "integrity": "sha1-QIl5wx4F98sYRkl6BveRUFa4kIY=",
+      "requires": {
+        "debug": "^2.6.3"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "redux": "3.5.2",
     "reselect": "2.5.1",
     "socket.io-client": "^2.0.4",
+    "socket.io-sticky-headers": "^1.1.0",
     "speed-measure-webpack-plugin": "^1.0.0-beta-1",
     "supports-webp": "1.0.3",
     "url-search-params": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "redux": "3.5.2",
     "reselect": "2.5.1",
     "socket.io-client": "^2.0.4",
-    "socket.io-sticky-headers": "^1.1.0",
     "speed-measure-webpack-plugin": "^1.0.0-beta-1",
     "supports-webp": "1.0.3",
     "url-search-params": "^0.10.0",

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -5,9 +5,6 @@ import io from 'socket.io-client'
 import createHistory from 'history/createBrowserHistory'
 import URLSearchParams from 'url-search-params'
 
-import stickyHeader from 'socket.io-sticky-headers'
-stickyHeader(require('socket.io-client/node_modules/engine.io-client/lib/transports/polling-xhr'), 'My-Session-Id', true)
-
 import { componentsList } from './StepComponentMap'
 import StepsRouter from './StepsRouter'
 import { themeWrap } from '../Theme'
@@ -41,12 +38,8 @@ class CrossDeviceMobileRouter extends Component {
     const socketIo = io(process.env.DESKTOP_SYNC_URL, {
       autoConnect: false,
       upgrade: false, // default: true
-      transports: ['polling'], // default: ['polling', 'websocket']
-      reconnection: false,
-      'force new connection': true
+      transports: ['websocket'], // default: ['polling', 'websocket']
     })
-    stickyHeader.setSocket(socketIo)
-
     this.state = {
       token: null,
       steps: null,

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -5,6 +5,9 @@ import io from 'socket.io-client'
 import createHistory from 'history/createBrowserHistory'
 import URLSearchParams from 'url-search-params'
 
+import stickyHeader from 'socket.io-sticky-headers'
+stickyHeader(require('socket.io-client/node_modules/engine.io-client/lib/transports/polling-xhr'), 'My-Session-Id', true)
+
 import { componentsList } from './StepComponentMap'
 import StepsRouter from './StepsRouter'
 import { themeWrap } from '../Theme'
@@ -35,16 +38,21 @@ class CrossDeviceMobileRouter extends Component {
     const searchParams = new URLSearchParams(window.location.search)
     const roomId = window.location.pathname.substring(3) ||
       searchParams.get('link_id').substring(2)
+    const socketIo = io(process.env.DESKTOP_SYNC_URL, {
+      autoConnect: false,
+      upgrade: false, // default: true
+      transports: ['polling'], // default: ['polling', 'websocket']
+      reconnection: false,
+      'force new connection': true
+    })
+    stickyHeader.setSocket(socketIo)
+
     this.state = {
       token: null,
       steps: null,
       step: null,
       i18n: initializeI18n(),
-      socket: io(process.env.DESKTOP_SYNC_URL, {
-        autoConnect: false,
-        upgrade: false, // default: true
-        transports: ['polling'], // default: ['polling', 'websocket']
-      }),
+      socket: socketIo,
       roomId,
       crossDeviceError: false,
       loading: true,

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -40,7 +40,11 @@ class CrossDeviceMobileRouter extends Component {
       steps: null,
       step: null,
       i18n: initializeI18n(),
-      socket: io(process.env.DESKTOP_SYNC_URL, {autoConnect: false}),
+      socket: io(process.env.DESKTOP_SYNC_URL, {
+        autoConnect: false,
+        upgrade: false, // default: true
+        transports: ['polling'], // default: ['polling', 'websocket']
+      }),
       roomId,
       crossDeviceError: false,
       loading: true,

--- a/src/components/crossDevice/CrossDeviceLink/index.js
+++ b/src/components/crossDevice/CrossDeviceLink/index.js
@@ -25,7 +25,11 @@ class CrossDeviceLink extends Component {
     super(props)
 
     if (!props.socket) {
-      const socket = io(process.env.DESKTOP_SYNC_URL, {autoConnect: false})
+      const socket = io(process.env.DESKTOP_SYNC_URL, {
+        autoConnect: false,
+        upgrade: false, // default: true
+        transports: ['polling'], // default: ['polling', 'websocket']
+      })
       socket.on('connect', () => {
         const roomId = this.props.roomId || null
         socket.emit('join', {roomId})

--- a/src/components/crossDevice/CrossDeviceLink/index.js
+++ b/src/components/crossDevice/CrossDeviceLink/index.js
@@ -2,6 +2,9 @@ import { h, Component} from 'preact'
 import classNames from 'classnames'
 import io from 'socket.io-client'
 
+import stickyHeader from 'socket.io-sticky-headers'
+stickyHeader(require('socket.io-client/node_modules/engine.io-client/lib/transports/polling-xhr'), 'My-Session-Id', true)
+
 import theme from '../../Theme/style.css'
 import style from './style.css'
 import { performHttpReq } from '../../utils/http'
@@ -29,7 +32,10 @@ class CrossDeviceLink extends Component {
         autoConnect: false,
         upgrade: false, // default: true
         transports: ['polling'], // default: ['polling', 'websocket']
+        reconnection: false,
+        'force new connection': true
       })
+      stickyHeader.setSocket(socket)
       socket.on('connect', () => {
         const roomId = this.props.roomId || null
         socket.emit('join', {roomId})

--- a/src/components/crossDevice/CrossDeviceLink/index.js
+++ b/src/components/crossDevice/CrossDeviceLink/index.js
@@ -2,9 +2,6 @@ import { h, Component} from 'preact'
 import classNames from 'classnames'
 import io from 'socket.io-client'
 
-import stickyHeader from 'socket.io-sticky-headers'
-stickyHeader(require('socket.io-client/node_modules/engine.io-client/lib/transports/polling-xhr'), 'My-Session-Id', true)
-
 import theme from '../../Theme/style.css'
 import style from './style.css'
 import { performHttpReq } from '../../utils/http'
@@ -31,11 +28,7 @@ class CrossDeviceLink extends Component {
       const socket = io(process.env.DESKTOP_SYNC_URL, {
         autoConnect: false,
         upgrade: false, // default: true
-        transports: ['polling'], // default: ['polling', 'websocket']
-        reconnection: false,
-        'force new connection': true
-      })
-      stickyHeader.setSocket(socket)
+        transports: ['websocket'], // default: ['polling', 'websocket']
       socket.on('connect', () => {
         const roomId = this.props.roomId || null
         socket.emit('join', {roomId})


### PR DESCRIPTION
# Problem

We're experiencing session stickiness problems.

# Solution

We want to test connecting over polling (no upgrade to websockets) in order to check if we can mitigate the issue.
