### PR TITLE
Feature/close modal button cx 2468

### DIFF
--- a/src/components/Modal/assets/cross.svg
+++ b/src/components/Modal/assets/cross.svg
@@ -1,0 +1,1 @@
+<svg width="32" height="32" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><circle fill="none" cx="16" cy="16" r="16"/><g transform="rotate(45 2.121 22.192)" fill="#2C3E4F"><rect x="7" width="2" height="16" rx="1"/><rect transform="rotate(90 8 8)" x="7" width="2" height="16" rx="1"/></g></g></svg>

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -2,6 +2,7 @@ import style from './style.css'
 import ReactModal from 'react-modal'
 import { h, Component } from 'preact'
 import { getCSSMilisecsValue, wrapWithClass } from '../utils'
+import { localised } from '../../locales'
 
 const MODAL_ANIMATION_DURATION = getCSSMilisecsValue(style.modal_animation_duration)
 
@@ -41,6 +42,7 @@ class ModalStrict extends Component {
   }
 
   render () {
+    const { translate } = this.props
     return (
       <ReactModal
         isOpen={this.state.isOpen || this.props.isOpen}
@@ -56,7 +58,9 @@ class ModalStrict extends Component {
           className={style.closeButton}
           onClick={this.props.onRequestClose || this.onRequestClose}
         >
-          <span className={style.closeButtonLabel}>close</span>
+          <span className={style.closeButtonLabel}>{
+            translate('close')
+          }</span>
         </button>
         {this.props.children}
       </ReactModal>
@@ -64,9 +68,11 @@ class ModalStrict extends Component {
   }
 }
 
+const LocalisedModalStrict = localised(ModalStrict)
+
 const ModalPure = ({useModal, children, ...otherProps}) => (
   useModal ?
-    <ModalStrict {...otherProps}>{children}</ModalStrict> :
+    <LocalisedModalStrict {...otherProps}>{children}</LocalisedModalStrict> :
     <Wrapper>{children}</Wrapper>
 )
 

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -52,6 +52,12 @@ class ModalStrict extends Component {
         shouldCloseOnOverlayClick={true}
         closeTimeoutMS={MODAL_ANIMATION_DURATION}
       >
+        <button
+          className={style.closeButton}
+          onClick={this.props.onRequestClose || this.onRequestClose}
+        >
+          <span className={style.closeButtonLabel}>close</span>
+        </button>
         {this.props.children}
       </ReactModal>
     )

--- a/src/components/Modal/style.css
+++ b/src/components/Modal/style.css
@@ -78,3 +78,41 @@
     transition: opacity modal_animation_duration, transform modal_animation_duration;
   }
 }
+
+.closeButton {
+  background-color: transparent;
+  background-image: url('assets/cross.svg');
+  border-radius: 16px;
+  border: none;
+  cursor: pointer;
+  font-family: 'Open Sans', sans-serif;
+  height: 32px;
+  outline: none;
+  position: absolute;
+  right: 10px;
+  text-decoration: none;
+  top: 10px;
+  width: 32px;
+  z-index: 1;
+}
+
+.closeButtonLabel {
+  display: none;
+  position: absolute;
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  font-weight: 500;
+  font-size: 14px;
+  margin-right: 8px;
+}
+
+@media (--large) {
+  .closeButton:hover {
+    background-color: #D8DADC;
+
+    .closeButtonLabel {
+      display: block;
+    }
+  }
+}

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -171,13 +171,11 @@ class MainRouter extends Component {
   }
 
   render = (props) =>
-    <LocaleProvider language={this.props.options.language}>
-      <HistoryRouter {...props}
-        steps={props.options.steps}
-        onFlowChange={this.onFlowChange}
-        mobileConfig={this.mobileConfig()}
-      />
-    </LocaleProvider>
+    <HistoryRouter {...props}
+      steps={props.options.steps}
+      onFlowChange={this.onFlowChange}
+      mobileConfig={this.mobileConfig()}
+    />
 }
 
 class HistoryRouter extends Component {

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
 import { h, render } from 'preact'
-import { Provider } from 'react-redux'
+import { Provider as ReduxProvider } from 'react-redux'
 import EventEmitter from 'eventemitter2'
 
 import { store, actions } from './core'
 import Modal from './components/Modal'
 import Router from './components/Router'
 import Tracker from './Tracker'
+import { LocaleProvider } from './locales'
 
 const events = new EventEmitter()
 
@@ -17,9 +18,11 @@ const ModalApp = ({ options:{ useModal, isModalOpen, onModalRequestClose, button
   </Modal>
 
 const Container = ({ options }) =>
-  <Provider store={store}>
-    <ModalApp options={options}/>
-  </Provider>
+  <ReduxProvider store={store}>
+    <LocaleProvider language={options.language}>
+      <ModalApp options={options} />
+    </LocaleProvider>
+  </ReduxProvider>
 
 /**
  * Renders the Onfido component

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -356,5 +356,6 @@
   "government_letter": "Government Letter",
   "council_tax": "Council Tax Letter",
   "back": "back",
-  "cancel": "Cancel"
+  "cancel": "Cancel",
+  "close": "close"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -274,5 +274,6 @@
   "short_driving_licence": "licencia",
   "short_national_identity_card": "tarjeta",
   "back": "atrás",
-  "cancel": "Cancelar"
+  "cancel": "Cancelar",
+  "close": "cerrar"
 }


### PR DESCRIPTION
# Problem
User should be able to close the modal using an explicit button
- user should see close button for both desktop and mobile views - MODAL only
- user should be able to click the close button to close the modal
- user should see hover states on both close and back buttons
- retain current desktop behaviour of allowing
-- esc key
-- clicking on the overlay background

# Solution
- Add button to modal
- Since the new button requires translated copy, the `LocaleProvider` context was moved up in the tree. However, since cross device flows will get the language code asynchronously, a new context will be defined in the cross device router as well.


## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [x] Have any new strings been translated?
