### PR TITLE
Remove buttonId option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,16 +117,9 @@ Example app which uses the npm style of import.
 
 ### 5. Adding basic HTML markup
 
-There are just two elements required in your HTML:
-
-1. A button that triggers the modal to open
-2. An empty element for the modal interface to mount itself on
+There is only one element required in your HTML, an empty element for the modal interface to mount itself on:
 
 ```html
-<!-- Somewhere on your page you need a button or link that triggers
-the verification modal to open -->
-<button id='onfido-button' disabled>Verify identity</button>
-
 <!-- At the bottom of your page, you need an empty element where the
 verification component will be mounted. -->
 <div id='onfido-mount'></div>
@@ -171,7 +164,6 @@ Congratulations! You have successfully started the flow. Carry on reading the ne
   ```js
   Onfido.init({
     token: 'your-jwt-token',
-    buttonId: 'onfido-button',
     containerId: 'onfido-mount',
     onComplete: function(data) {
       console.log("everything is complete")
@@ -219,10 +211,6 @@ A number of options are available to allow you to customise the SDK:
   In case `useModal` is set to `true`, this defines whether the modal is open or closed.
   To change the state of the modal after calling `init()` you need to later use `setOptions()` to modify it.
   The default value is `false`.
-
-- **`buttonId {String} optional`**
-
-  In case `useModal` is set to `true`, the button with this ID, when clicked, will open the verification modal. This defaults to `onfido-button`, although is not necessary to have a button at all.
 
 - **`containerId {String} optional`**
 

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -14,24 +14,6 @@ class ModalStrict extends Component {
     this.state = {isOpen: false}
   }
 
-  componentDidMount() {
-    const { buttonId } = this.props
-    console.log(buttonId)
-    const button = document.getElementById(buttonId)
-    if (!button){
-      console.warn(`The button with id #${buttonId} cannot be found`)
-      return
-    }
-    button.addEventListener('click', this.openModal)
-    button.disabled = false
-    this.setState({button})
-  }
-
-  componentWillUnmount() {
-    const { button } = this.state
-    if (button) button.removeEventListener('click', this.openModal)
-  }
-
   openModal = () => {
     this.setState({isOpen: true})
   }

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,8 @@ const events = new EventEmitter()
 
 Tracker.setUp()
 
-const ModalApp = ({ options:{ useModal, isModalOpen, onModalRequestClose, buttonId, ...otherOptions}, ...otherProps}) =>
-  <Modal {...{useModal, buttonId}} isOpen={isModalOpen} onRequestClose={onModalRequestClose}>
+const ModalApp = ({ options:{ useModal, isModalOpen, onModalRequestClose, ...otherOptions}, ...otherProps}) =>
+  <Modal useModal={useModal} isOpen={isModalOpen} onRequestClose={onModalRequestClose}>
     <Router options={otherOptions} {...otherProps}/>
   </Modal>
 
@@ -48,7 +48,6 @@ const noOp = ()=>{}
 
 const defaults = {
   token: 'some token',
-  buttonId: 'onfido-button',
   containerId: 'onfido-mount',
   onComplete: noOp
 }


### PR DESCRIPTION
# Problem
Remove "button to trigger modal" support

Feature broken, please remove
* Remove support for button that triggers modal
** buttonId as an option should be removed
* Remove reference to it in Readme

# Solution
- Remove references to `buttonId` in codeabase
- Remove from documentation

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [n/a] Have any new strings been translated?
