### PR TITLE
Update manual regression test case for document upload in PDF format.

### DIFF
--- a/MANUAL_REGRESSION.md
+++ b/MANUAL_REGRESSION.md
@@ -187,6 +187,7 @@ Go through the flow looking for layout/usability inconsistencies between browser
 6. All the other strings should be in Spanish
 
 ##### 15. Upload a document in PDF format
+*Feature is available on desktop browsers only.*
 (on Firefox, Safari, IE11 and Microsoft Edge browsers)
 
 1. Go through the flow to document capture


### PR DESCRIPTION
# Problem
We want to be sure that testers test this feature on desktop browsers only as this is no longer available on any of the mobile browsers. 

# Solution
Update manual regression for document upload 

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [`n/a` ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [`n/a` ] Have new automated tests been implemented?
- [`n/a` ] Have new manual tests been written down?
- [`n/a` ] Have tests passed locally?
- [`n/a` ] Have any new strings been translated?
