### PR TITLE
TEST upgrade to latest react-modal (but too big)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2657,12 +2657,6 @@
       "dev": true,
       "optional": true
     },
-    "cuint": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
-      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
-      "dev": true
-    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -2893,7 +2887,7 @@
     "dnd-core": {
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-2.5.4.tgz",
-      "integrity": "sha512-BcI782MfTm3wCxeIS5c7tAutyTwEIANtuu3W6/xkoJRwiqhRXKX3BbGlycUxxyzMsKdvvoavxgrC3EMPFNYL9A==",
+      "integrity": "sha1-DHCo3LtgnAsiLidfyun6g+WJc5c=",
       "requires": {
         "asap": "^2.0.6",
         "invariant": "^2.0.0",
@@ -2904,7 +2898,7 @@
         "redux": {
           "version": "3.7.2",
           "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-          "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+          "integrity": "sha1-BrcxIyFZAdJdBlvjQusCa8HIU3s=",
           "requires": {
             "lodash": "^4.2.1",
             "lodash-es": "^4.2.1",
@@ -4187,7 +4181,7 @@
     "fsevents": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "integrity": "sha1-EfgjGPX+e7LNIpZaEI6TBiCCFtg=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4340,7 +4334,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
@@ -4645,6 +4640,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4833,7 +4829,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -5061,6 +5058,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8096,7 +8094,7 @@
     "natives": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
-      "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
+      "integrity": "sha1-ARrM4ffL2H97prMJPWzZOSvhxXQ=",
       "dev": true
     },
     "natural-compare": {
@@ -11170,7 +11168,7 @@
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
       "dev": true,
       "requires": {
         "is-number": "^3.0.0",
@@ -11280,7 +11278,7 @@
     "react-dnd": {
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-2.5.4.tgz",
-      "integrity": "sha512-y9YmnusURc+3KPgvhYKvZ9oCucj51MSZWODyaeV0KFU0cquzA7dCD1g/OIYUKtNoZ+MXtacDngkdud2TklMSjw==",
+      "integrity": "sha1-C23F6dDfwpCfT0/nNuVTTzr9G9k=",
       "requires": {
         "disposables": "^1.0.1",
         "dnd-core": "^2.5.4",
@@ -11302,6 +11300,17 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-modal": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.6.1.tgz",
+      "integrity": "sha512-vAhnawahH1fz8A5x/X/1X20KHMe6Q0mkfU5BKPgKSVPYhMhsxtRbNHSitsoJ7/oP27xZo3naZZlwYuuzuSO1xw==",
+      "requires": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.5.10",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^3.0.0"
+      }
     },
     "react-modal-onfido": {
       "version": "1.5.2",
@@ -11354,7 +11363,7 @@
     "react-responsive-ui": {
       "version": "0.10.9",
       "resolved": "https://registry.npmjs.org/react-responsive-ui/-/react-responsive-ui-0.10.9.tgz",
-      "integrity": "sha512-BrLwQLnaCh59KYGpJ7gWr7fay8zC1cCXHh8uJ64bVcOYdyghq5JHW62Bvd8weRF9VSztKjq9cD0H1Krob9ptEw==",
+      "integrity": "sha1-IU9hT41o7xyifndcgJ503M2t31c=",
       "requires": {
         "babel-runtime": "^6.6.1",
         "classnames": "^2.2.5",
@@ -12495,7 +12504,7 @@
     "ssri": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz",
-      "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
+      "integrity": "sha1-E8GTkLYGyCHyoQ0Cs1HBcpuU2M8=",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
@@ -14253,6 +14262,14 @@
       "dev": true,
       "requires": {
         "cuint": "^0.2.2"
+      },
+      "dependencies": {
+        "cuint": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+          "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
+          "dev": true
+        }
       }
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "preact-compat": "3.16.0",
     "preact-context": "^1.0.3",
     "raven-js": "^3.26.3",
-    "react-modal-onfido": "1.5.2",
+    "react-modal": "^3.6.1",
     "react-native-listener": "1.0.1",
     "react-phone-number-input": "^0.15.2",
     "react-redux": "4.4.6",

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -17,24 +17,38 @@ class Modal extends Component {
     this.state = {isOpen: false}
   }
 
-  openModal = () => {
-    this.setState({isOpen: true})
+  onAfterOpen = () => {
+    setTimeout(()=>{
+      this.setState({reallyOpened:true})
+    },1)
   }
 
-  onRequestClose = () => {
-    this.setState({isOpen: false})
+  componentWillReceiveProps({isOpen}) {
+    if (this.props.isOpen && !isOpen){
+      this.setState({reallyOpened: false})
+    }
   }
+
+  modalClasses = (className) => ({
+    base: classNames(
+      style[className],
+      this.state.reallyOpened ? style[`${className}AfterOpen`] : false
+    ),
+    afterOpen: "",
+    beforeClose: style[`${className}BeforeClose`]
+  })
 
   render () {
     const { translate, isFullScreen } = this.props
     return (
       <ReactModal
-        isOpen={this.state.isOpen || this.props.isOpen}
-        onRequestClose={this.props.onRequestClose || this.onRequestClose}
+        isOpen={this.props.isOpen}
+        onAfterOpen={this.onAfterOpen}
+        onRequestClose={this.props.onRequestClose}
         portalClassName={style.portal}
-        overlayClassName={style.overlay}
-        bodyClassName={style.modalBody}
-        className={style.inner}
+        bodyOpenClassName={style.modalBody}
+        overlayClassName={this.modalClasses('overlay')}
+        className={this.modalClasses('inner')}
         shouldCloseOnOverlayClick={true}
         closeTimeoutMS={MODAL_ANIMATION_DURATION}
       >

--- a/src/components/Modal/style.css
+++ b/src/components/Modal/style.css
@@ -1,9 +1,7 @@
 @import (less) "../Theme/constants.css";
 
-.portal > * {
-  // When the modal is closed, overlay div has no css class
-  // This selector should be overridden by the `&--after-open` class below
-  opacity: 0;
+.portal {
+
 }
 
 .modalBody {
@@ -23,11 +21,32 @@
   background-color: rgba(0, 0, 0, 0.6);
   transition: opacity modal_animation_duration, z-index 0s modal_animation_duration;
 
-  &--after-open {
+  opacity: 0;
+
+  &AfterOpen {
     opacity: 1;
   }
-  &--before-close {
+  &BeforeClose {
     opacity: 0;
+  }
+}
+
+.portal .inner {
+  margin: auto;
+  z-index: -1;
+  opacity: 0;
+  transform: scale(0);
+  transition: opacity modal_animation_duration, transform modal_animation_duration, z-index 0s modal_animation_duration;
+
+  &BeforeClose {
+    opacity: 0;
+  }
+
+  &AfterOpen {
+    z-index: 100;
+    opacity: 1;
+    transform: scale(1);
+    transition: opacity modal_animation_duration, transform modal_animation_duration;
   }
 }
 
@@ -63,20 +82,7 @@
     box-sizing: border-box;
   }
 
-  .portal & {
-    margin: auto;
-    z-index: -1;
-    opacity: 0;
-    transform: scale(0);
-    transition: opacity modal_animation_duration, transform modal_animation_duration, z-index 0s modal_animation_duration;
-  }
 
-  .overlay--after-open & {
-    z-index: 100;
-    opacity: 1;
-    transform: scale(1);
-    transition: opacity modal_animation_duration, transform modal_animation_duration;
-  }
 }
 
 .closeButton {
@@ -114,7 +120,7 @@
 
 .closeButtonFullScreen {
   background-image: url('assets/cross-white.svg');
-  
+
   .closeButtonLabel {
     color: #fff;
   }

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -185,7 +185,7 @@ const baseConfig = {
     alias: {
       'react': 'preact-compat',
       'react-dom': 'preact-compat',
-      'react-modal': 'react-modal-onfido'
+      //'react-modal': 'react-modal-onfido'
     }
   },
 


### PR DESCRIPTION
# Problem

We are on old version (our fork) of react modal.

# Solution

Tried updating since the latest version seemed to have two functions we needed:
1. no lodash
2. custom class names

The problem is that the module is twice as big as the current one.
DO NOT MERGE

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
