### PR TITLE
Feature/sms country code cx 2548

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ## [next-release]
 
 ### Added
-- Public: Added support for default SMS number country code. The SMS number input can be receive a default value by adding the following option when the SDK is initialized `smsNumberCountryCode`. The value should be a 2-characters ISO Country code.
+- Public: Added support for default SMS number country code. The default country for the SMS number input can be customised by passing the `smsNumberCountryCode` option when the SDK is initialised. The value should be a 2-characters long ISO Country code string. If empty, the SMS number country code will default to `GB`.
 
 ### Changed
 - Public: Remove support for `buttonId` initialization option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ## [next-release]
 
+### Added
+- Public: Added support for default SMS number country code. The SMS number input can be receive a default value by adding the following option when the SDK is initialized `smsNumberCountryCode`. The value should be a 2-characters ISO Country code.
+
 ### Changed
 - Public: Remove support for `buttonId` initialization option
 

--- a/MANUAL_REGRESSION.md
+++ b/MANUAL_REGRESSION.md
@@ -352,6 +352,28 @@ On iOS:
     - Upload selfie
     - Confirm
 
+##### 28. Custom SMS country code and flag
+(on one of the desktop browsers)
+
+0. Given there is no webcam connected to the computer
+1. Open link with additional GET parameter `?countryCode=US`
+1. Click on link to start cross-device flow
+    - user should see `Continue your verification on mobile` screen
+    - user should be able to provide mobile number from any country
+    - user should see the option to send SMS
+    - the SMS input flag should be the US flag
+
+##### 29. Custom SMS with invalid country code
+(on one of the desktop browsers)
+
+0. Given there is no webcam connected to the computer
+1. Open link with additional GET parameter `?countryCode=ABCD`
+1. Click on link to start cross-device flow
+    - user should see `Continue your verification on mobile` screen
+    - user should be able to provide mobile number from any country
+    - user should see the option to send SMS
+    - the SMS input flag should be the UK one
+
 ## Non-functional
 
 ##### 1. Check analytics tracking

--- a/README.md
+++ b/README.md
@@ -248,7 +248,12 @@ A number of options are available to allow you to customise the SDK:
   If `language` is not present the default copy will be in English.
 
 - **`smsNumberCountryCode {String} optional`**
-  The default country for the SMS number input can be customised by passing `smsNumberCountryCode`. The value should be a 2-characters long ISO Country code string. If empty, the SMS number country code will default to `GB`.
+  The default country for the SMS number input can be customised by passing the `smsNumberCountryCode` option when the SDK is initialised. The value should be a 2-characters long ISO Country code string. If empty, the SMS number country code will default to `GB`.
+
+  Example:
+  ```javascript
+  smsNumberCountryCode: 'US'
+  ```
 
 - **`steps {List} optional`**
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ A number of options are available to allow you to customise the SDK:
 
   If `language` is not present the default copy will be in English.
 
+- **`smsNumberCountryCode {String} optional`**
+  The default country for the SMS number input can be customised by passing `smsNumberCountryCode`. The value should be a 2-characters long ISO Country code string. If empty, the SMS number country code will default to `GB`.
+
 - **`steps {List} optional`**
 
   List of the different steps and their custom options. Each step can either be specified as a string (when no customisation is required) or an object (when customisation is required):

--- a/src/components/PhoneNumberInput/index.js
+++ b/src/components/PhoneNumberInput/index.js
@@ -42,7 +42,7 @@ const PhoneNumberInput = ({ translate, clearErrors, actions = {}, smsNumberCount
   }
 
   return (
-    <form onSubmit={(e) => e.preventDefault()} onError={(e) => console.log('shit happens', e)}>
+    <form onSubmit={(e) => e.preventDefault()}>
       <PhoneNumber placeholder={translate('cross_device.phone_number_placeholder')}
         onChange={onChange}
         country={countryCode()}

--- a/src/components/PhoneNumberInput/index.js
+++ b/src/components/PhoneNumberInput/index.js
@@ -1,7 +1,12 @@
 import { h } from 'preact'
 import PhoneNumber, {isValidPhoneNumber} from 'react-phone-number-input'
+import countries from 'react-phone-number-input/modules/countries'
+
 import classNames from 'classnames';
 import {localised} from '../../locales'
+import {lowerCase, upperCase} from '../utils/string'
+import {includes} from '../utils/array'
+
 
 import 'react-phone-number-input/rrui.css'
 import 'react-phone-number-input/style.css'
@@ -16,7 +21,7 @@ const FlagComponent = ({ countryCode, flagsPath }) => (
   />
 );
 
-const PhoneNumberInput = ({ translate, clearErrors, actions = {}}) => {
+const PhoneNumberInput = ({ translate, clearErrors, actions = {}, smsNumberCountryCode}) => {
 
   const onChange = (number) => {
     clearErrors()
@@ -24,11 +29,23 @@ const PhoneNumberInput = ({ translate, clearErrors, actions = {}}) => {
     actions.setMobileNumber({number, valid})
   }
 
+  const validCountryCode = () => {
+    const isCountryCodeInCountriesList = includes(countries.flat(), lowerCase(smsNumberCountryCode))
+    const isValid = smsNumberCountryCode.length === 2 && isCountryCodeInCountriesList
+    if (!isValid) { console.warn("Invalid ISO Country Code") }
+    return isValid
+  }
+
+  const countryCode = () => {
+    if (!smsNumberCountryCode) return 'GB'
+    return validCountryCode() ? upperCase(smsNumberCountryCode) : 'GB'
+  }
+
   return (
-    <form onSubmit={(e) => e.preventDefault()}>
+    <form onSubmit={(e) => e.preventDefault()} onError={(e) => console.log('shit happens', e)}>
       <PhoneNumber placeholder={translate('cross_device.phone_number_placeholder')}
         onChange={onChange}
-        country="GB"
+        country={countryCode()}
         inputClassName={`${style.mobileInput}`}
         className={`${style.phoneNumberContainer}`}
         flagComponent={ FlagComponent }

--- a/src/components/PhoneNumberInput/index.js
+++ b/src/components/PhoneNumberInput/index.js
@@ -1,11 +1,8 @@
 import { h } from 'preact'
 import PhoneNumber, {isValidPhoneNumber} from 'react-phone-number-input'
-import countries from 'react-phone-number-input/modules/countries'
 
 import classNames from 'classnames';
 import {localised} from '../../locales'
-import {lowerCase, upperCase} from '../utils/string'
-import {includes} from '../utils/array'
 
 
 import 'react-phone-number-input/rrui.css'
@@ -29,23 +26,11 @@ const PhoneNumberInput = ({ translate, clearErrors, actions = {}, smsNumberCount
     actions.setMobileNumber({number, valid})
   }
 
-  const validCountryCode = () => {
-    const isCountryCodeInCountriesList = includes(countries.flat(), lowerCase(smsNumberCountryCode))
-    const isValid = smsNumberCountryCode.length === 2 && isCountryCodeInCountriesList
-    if (!isValid) { console.warn("Invalid ISO Country Code") }
-    return isValid
-  }
-
-  const countryCode = () => {
-    if (!smsNumberCountryCode) return 'GB'
-    return validCountryCode() ? upperCase(smsNumberCountryCode) : 'GB'
-  }
-
   return (
     <form onSubmit={(e) => e.preventDefault()}>
       <PhoneNumber placeholder={translate('cross_device.phone_number_placeholder')}
         onChange={onChange}
-        country={countryCode()}
+        country={smsNumberCountryCode}
         inputClassName={`${style.mobileInput}`}
         className={`${style.phoneNumberContainer}`}
         flagComponent={ FlagComponent }

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -48,6 +48,8 @@ const language = queryStrings.language === "customTranslations" ? {
   phrases: {'welcome.title': 'Ouvrez votre nouveau compte bancaire'}
 } : queryStrings.language
 
+const smsNumberCountryCode = queryStrings.countryCode ? { smsNumberCountryCode: queryStrings.countryCode } : {}
+
 const getToken = function(onSuccess) {
   const url = process.env.JWT_FACTORY
   const request = new XMLHttpRequest()
@@ -120,7 +122,8 @@ class Demo extends Component{
     onModalRequestClose: () => {
       this.setState({isModalOpen: false})
     },
-    ...clientSdkOptions
+    ...clientSdkOptions,
+    ...smsNumberCountryCode
   })
 
   render () {

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -122,8 +122,8 @@ class Demo extends Component{
     onModalRequestClose: () => {
       this.setState({isModalOpen: false})
     },
+    ...smsNumberCountryCode,
     ...clientSdkOptions,
-    ...smsNumberCountryCode
   })
 
   render () {

--- a/src/index.js
+++ b/src/index.js
@@ -77,10 +77,11 @@ const deprecationWarnings = ({steps}) => {
 }
 
 const isSMSCountryCodeValid = (smsNumberCountryCode) => {
-  const isCountryCodeInCountriesList = includes(countries.flat(), lowerCase(smsNumberCountryCode))
-  const isValid = smsNumberCountryCode.length === 2 && isCountryCodeInCountriesList
-  if (!isValid) { console.warn("`smsNumberCountryCode` must be a valid two-characters ISO Country Code") }
-  return isValid
+  const isCodeValid = includes(countries.map(([code]) => code), lowerCase(smsNumberCountryCode))
+  if (!isCodeValid) {
+    console.warn("`smsNumberCountryCode` must be a valid two-characters ISO Country Code. 'GB' will be used instead.")
+  }
+  return isCodeValid
 }
 
 const validateSmsCountryCode = (smsNumberCountryCode) => {

--- a/src/index.js
+++ b/src/index.js
@@ -72,11 +72,18 @@ const deprecationWarnings = ({steps}) => {
   }
 }
 
+const validateSmsCountryCode = ({smsNumberCountryCode}) => {
+  if (smsNumberCountryCode && smsNumberCountryCode.length !== 2) {
+    console.warn("`smsNumberCountryCode` must be a two-characters ISO Country Code")
+  }
+}
+
 Onfido.init = (opts) => {
   console.log("onfido_sdk_version", process.env.SDK_VERSION)
   Tracker.install()
   const options = formatOptions({ ...defaults, ...opts, events })
   deprecationWarnings(options)
+  validateSmsCountryCode(options)
 
   bindOnComplete(options)
 


### PR DESCRIPTION
# Problem
Currently, the SMS country defaults to `GB`. We want to allow integrators to customise the sms country with a default value.

![screen shot 2018-10-16 at 17 28 53 1](https://user-images.githubusercontent.com/7127427/47032361-1b539080-d16a-11e8-9d0c-c918aed7db8a.png)

# Solution
  The default country for the SMS number input can be customised by passing the `smsNumberCountryCode` option when the SDK is initialised. The value should be a 2-characters long ISO Country code string. If empty, the SMS number country code will default to `GB`.

  Example:
  ```javascript
  smsNumberCountryCode: 'US'
  ```
Warnings will be returned in the console if the value of smsNumberCountryCode is a string longer than 2 characters or if the string is not included in the default country list.

This feature can be tested in the demo app with the following query string `?countryCode=US`. The value should be a valid 2-characters ISO country code

![screen shot 2018-10-16 at 17 37 33](https://user-images.githubusercontent.com/7127427/47032504-6ec5de80-d16a-11e8-9fbe-0a13dad3faa7.png)


## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
