### PR TITLE
RETEST Connect to socket.io only with web sockets

### DIFF
--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -35,11 +35,16 @@ class CrossDeviceMobileRouter extends Component {
     const searchParams = new URLSearchParams(window.location.search)
     const roomId = window.location.pathname.substring(3) ||
       searchParams.get('link_id').substring(2)
+    const socketIo = io(process.env.DESKTOP_SYNC_URL, {
+      autoConnect: false,
+      upgrade: false, // default: true
+      transports: ['websocket'], // default: ['polling', 'websocket']
+    })
     this.state = {
       token: null,
       steps: null,
       step: null,
-      socket: io(process.env.DESKTOP_SYNC_URL, {autoConnect: false}),
+      socket: socketIo,
       roomId,
       crossDeviceError: false,
       loading: true,

--- a/src/components/crossDevice/CrossDeviceLink/index.js
+++ b/src/components/crossDevice/CrossDeviceLink/index.js
@@ -30,6 +30,7 @@ class CrossDeviceLink extends Component {
         autoConnect: false,
         upgrade: false, // default: true
         transports: ['websocket'], // default: ['polling', 'websocket']
+      })
       socket.on('connect', () => {
         const roomId = this.props.roomId || null
         socket.emit('join', {roomId})

--- a/src/components/crossDevice/CrossDeviceLink/index.js
+++ b/src/components/crossDevice/CrossDeviceLink/index.js
@@ -26,7 +26,10 @@ class CrossDeviceLink extends Component {
     super(props)
 
     if (!props.socket) {
-      const socket = io(process.env.DESKTOP_SYNC_URL, {autoConnect: false})
+      const socket = io(process.env.DESKTOP_SYNC_URL, {
+        autoConnect: false,
+        upgrade: false, // default: true
+        transports: ['websocket'], // default: ['polling', 'websocket']
       socket.on('connect', () => {
         const roomId = this.props.roomId || null
         socket.emit('join', {roomId})


### PR DESCRIPTION
# Problem

It doesn't seem that the websockets only solution in this PR (https://github.com/onfido/onfido-sdk-ui/pull/477) was ever built. So it might not have not been tested

# Solution

Fix issues and rebuild and test again.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
