### PR TITLE
Pass prop back to components

### DIFF
--- a/src/components/Router/StepsRouter.js
+++ b/src/components/Router/StepsRouter.js
@@ -30,7 +30,7 @@ class StepsRouter extends Component {
         <div className={classNames(theme.content,{
           [theme.fullScreenContentWrapper]: isFullScreen
         })}>
-          <CurrentComponent {...{...options, ...globalUserOptions, ...otherProps}}
+          <CurrentComponent {...{...options, ...globalUserOptions, ...otherProps, back}}
             trackScreen={this.trackScreen} />
         </div>
         <div className={theme.footer} />


### PR DESCRIPTION
# Problem
Cancel button does not work on `Connected to your mobile` screen because the prop `back` has been removed from the components props

# Solution
Pass the prop `back` to components

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
