### PR TITLE
Only display label on hover for desktop devices, not tap ones

### DIFF
--- a/src/components/NavigationBar/index.js
+++ b/src/components/NavigationBar/index.js
@@ -3,14 +3,14 @@ import classNames from 'classnames'
 import { compose } from '../utils/func'
 import { withFullScreenState } from '../FullScreen'
 import style from './style.css'
-import {preventDefaultOnClick} from '../utils'
+import {preventDefaultOnClick, isDesktop} from '../utils'
 import {localised} from '../../locales'
 
 const NavigationBar = ({back, translate, disabled, isFullScreen, className}) =>
   <div className={classNames(className, style.navigation, {
     [style.fullScreenNav]: isFullScreen
   })}>
-    <button href='#' className={classNames(style.back, {[style.disabled]: disabled})}
+    <button href='#' className={classNames(style.back, {[style.disabled]: disabled, [style.backHoverDesktop]: isDesktop})}
       onClick={preventDefaultOnClick(back)}>
         <span className={style.iconBack} />
         <span className={style.label}>

--- a/src/components/NavigationBar/style.css
+++ b/src/components/NavigationBar/style.css
@@ -63,7 +63,8 @@
   margin-left: 8px;
 }
 
-.back:hover {
+
+.backHoverDesktop:hover {
   .label {
     display: inline-block;
 
@@ -71,7 +72,9 @@
       display: none;
     }
   }
+}
 
+.back:hover {
   .iconBack {
     background-color: #D8DADC;
   }


### PR DESCRIPTION
# Problem
On iPad and some mobile devices, when you click on the back button, you need to click twice to trigger the action. This is a known issue related with displaying elements on hover.
On a browser with a cursor pointer, you'll see the pseudo element reveal itself on :hover. On some devices tapping the link will just reveal the pseudo element. It requires a second tap to actually go to the link.
Source https://css-tricks.com/annoying-mobile-double-tap-link-issue/

# Solution
The article above suggests using the following media query `@media (pointer: fine) { ... }`. The problem is that if a browser does not support this feature (ie Firefox and IE11), you end up with no label being shown. 
My solution involves adding a class if is desktop and this will solve the issue and work on all browsers.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
