### PR TITLE
Fixed Spanish translations

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -243,7 +243,7 @@
       "header": "Need to use your mobile to take photos?",
       "submessage": "Securely continue verification on your mobile"
     },
-    "tips": "Tips"
+    "tips": "Important"
   },
   "privacy": {
     "title": "You'll have to upload a photo of your identity document",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -193,7 +193,7 @@
     "click_allow": "Haga clic en Permitir en la ventana emergente que aparecerá a continuación",
     "allow": "Permitir",
     "why": "¿Por qué necesita hacer esto?",
-    "if_denied": "Si niega accesso a la cámara, no podrá tomar fotos para completar el proceso de verificación",
+    "if_denied": "Si niega acceso a la cámara, no podrá tomar fotos para completar el proceso de verificación",
     "enable_webcam": "Activar cámara",
     "access_denied": "Acceso a la cámara no permitido",
     "recover_access": "Recupere acceso a la cámara para continuar la verificación facial",
@@ -222,7 +222,7 @@
     },
     "no_face": {
       "message": "Cara no encontrada",
-      "instruction": "Su cara debe de estar en la selfie"
+      "instruction": "Su cara tiene que salir en la selfie"
     },
     "multiple_faces": {
       "message": "Múltiples caras encontradas",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -176,7 +176,7 @@
       "header": "¿Necesita usar su móvil para tomar fotos?",
       "submessage": "Continúe la verificación de forma segura en su dispositivo móvil"
     },
-    "tips": "Tips"
+    "tips": "Importante"
   },
   "privacy": {
     "title": "Tendrá que subir una foto de su documento de identidad",


### PR DESCRIPTION
# Problem
Some Spanish sentences include grammatical errors or are incorrect.


# Solution
Fix grammar and syntax errors

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [x] Have any new strings been translated?
