### PR TITLE
Feature/cross device mobile only cx 2797

### DIFF
--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -44,6 +44,9 @@ class CrossDeviceMobileRouter extends Component {
       crossDeviceError: false,
       loading: true,
     }
+    if (isDesktop) {
+      return this.setState({crossDeviceError: true, loading: false})
+    }
     this.state.socket.on('config', this.setConfig(props.actions))
     this.state.socket.on('connect', () => {
       this.state.socket.emit('join', {roomId: this.state.roomId})

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -18,6 +18,8 @@ import { LocaleProvider } from '../../locales'
 
 const history = createHistory()
 
+const restrictedXDevice = process.env.RESTRICTED_XDEVICE_FEATURE_ENABLED
+
 const Router = (props) =>{
   const RouterComponent = props.options.mobileFlow ? CrossDeviceMobileRouter : MainRouter
   return <RouterComponent {...props} allowCrossDeviceFlow={!props.options.mobileFlow && isDesktop}/>
@@ -44,7 +46,7 @@ class CrossDeviceMobileRouter extends Component {
       crossDeviceError: false,
       loading: true,
     }
-    if (isDesktop) {
+    if (restrictedXDevice && isDesktop) {
       return this.setState({crossDeviceError: true, loading: false})
     }
     this.state.socket.on('config', this.setConfig(props.actions))

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -105,11 +105,13 @@ const PROD_CONFIG = {
   'MOBILE_URL' : 'https://id.onfido.com',
   'SMS_DELIVERY_URL': 'https://telephony.onfido.com',
   'PUBLIC_PATH' : `https://assets.onfido.com/web-sdk-releases/${packageJson.version}/`,
+  'RESTRICTED_XDEVICE_FEATURE_ENABLED': true,
   WOOPRA_DOMAIN
 }
 
 const TEST_CONFIG = { ...PROD_CONFIG,
   PUBLIC_PATH: '/', 'MOBILE_URL' : '/',
+  'RESTRICTED_XDEVICE_FEATURE_ENABLED': false,
   'WOOPRA_DOMAIN': WOOPRA_DEV_DOMAIN
 }
 
@@ -123,6 +125,7 @@ const STAGING_CONFIG = {
   'MOBILE_URL' : '/',
   'SMS_DELIVERY_URL' : 'https://telephony-dev.onfido.com',
   'PUBLIC_PATH' : '/',
+  'RESTRICTED_XDEVICE_FEATURE_ENABLED': true,
   'WOOPRA_DOMAIN': WOOPRA_DEV_DOMAIN
 }
 


### PR DESCRIPTION
# Problem
Cross device link should only be opened on mobile browsers


# Solution
Only allow cross device link to be opened on mobile browsers. If desktop is detected, it won't be possible to open the mobile link.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
