### PR TITLE
Change copy for forbidden client error

### DIFF
--- a/src/components/Capture/Face.js
+++ b/src/components/Capture/Face.js
@@ -87,7 +87,7 @@ class Face extends Component {
           instructions={ translate('capture.face.instructions') }
           />
       :
-        <GenericError />
+        <GenericError error={{name: 'GENERIC_CLIENT_ERROR'}}/>
 
   }
 }

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -117,8 +117,7 @@ class CrossDeviceMobileRouter extends Component {
     actions.acceptTerms()
   }
 
-  setError = (error) => {
-    const name = error ? error : 'GENERIC_CLIENT_ERROR'
+  setError = (name='GENERIC_CLIENT_ERROR') => {
     this.setState({crossDeviceError: { name }, loading: false})
   }
 

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -123,7 +123,7 @@ class CrossDeviceMobileRouter extends Component {
   }
 
   onDisconnect = () => {
-    this.pingTimeoutId = setTimeout(this.setError(), 3000)
+    this.pingTimeoutId = setTimeout(this.setError, 3000)
     this.sendMessage('disconnect ping')
   }
 

--- a/src/components/crossDevice/GenericError/index.js
+++ b/src/components/crossDevice/GenericError/index.js
@@ -3,17 +3,20 @@ import { h, Component } from 'preact'
 import Title from '../../Title'
 import theme from '../../Theme/style.css'
 import style from './style.css'
+import errors from '../../strings/errors'
+import { lowerCase } from '../../utils/string'
 import { sendScreen } from '../../../Tracker'
 import { localised } from '../../../locales'
 
 class GenericError extends Component {
   componentDidMount() {
-    sendScreen(['generic_client_error'])
+    sendScreen([`${lowerCase(this.props.error.name)}`])
   }
-  render ({translate}) {
+  render ({translate, error}) {
+    const { message, instruction } = errors[error.name]
     return (
       <div>
-        <Title title={translate('errors.generic_client_error.message')} subTitle={translate('errors.generic_client_error.instruction')} />
+        <Title title={translate(message)} subTitle={translate(instruction)} />
         <div className={theme.thickWrapper}>
           <span className={`${theme.icon}  ${style.icon}`} />
         </div>

--- a/src/components/strings/errors.js
+++ b/src/components/strings/errors.js
@@ -14,4 +14,6 @@ export default {
   'CAMERA_INACTIVE': { message: 'errors.camera_inactive.message', instruction: 'errors.camera_inactive.instruction'},
   'CAMERA_INACTIVE_NO_FALLBACK': { message: 'errors.camera_inactive.message', instruction: 'errors.camera_inactive_no_fallback.instruction'},
   'LIVENESS_TIMEOUT': { message: 'errors.liveness_timeout.message', instruction: 'errors.liveness_timeout.instruction'},
+  'GENERIC_CLIENT_ERROR': { message: 'errors.generic_client_error.message', instruction: 'errors.generic_client_error.instruction' },
+  'FORBIDDEN_CLIENT_ERROR': {message: 'errors.forbidden_client_error.message', instruction: 'errors.forbidden_client_error.instruction'}
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -339,6 +339,10 @@
       "message": "Something's gone wrong",
       "instruction": "You’ll need to restart your verification on your computer"
     },
+    "forbidden_client_error": {
+      "message": "Something's gone wrong",
+      "instruction": "You must open this link on a mobile device"
+    },
     "camera_not_working": {
       "message": "Your camera isn’t working",
       "instruction": "It may be disconnected or not functional. <fallback>Use your mobile</fallback> to continue verification."

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -254,6 +254,10 @@
       "message": "Algo salió mal",
       "instruction": "Deberá reiniciar su verificación en su computadora"
     },
+    "forbidden_client_error": {
+      "message": "Algo salió mal",
+      "instruction": "Debe abrir este enlace en un dispositivo móvil."
+    },
     "camera_not_working": {
       "message": "Su cámara no esta funcionando",
       "instruction": "Puede estar desconectada o no funcionando. <fallback>Use su móvil</fallback> para continuar la verificación"


### PR DESCRIPTION
# Problem
Currently if the cross device link is opened on a desktop an error with the following copy will be displayed `Something's gone wrong. You’ll need to restart your verification on your computer`

# Solution
Return device specific error message. The copy for a link opened on a desktop browser will be:
`You must open this link on a mobile device`.
In this PR, I also make sure that a generic client error is returned if a live photo or video cannot be captured and upload is disabled.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [x] Have any new strings been translated?
