### PR TITLE
Added camera and microphone metadata to api payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Added
 - Public: Added Proof of address `poa` step where users can capture their proof of address documents. This is a beta feature.
+- Internal: Send camera and microphone labels to Onfido API as metadata
 
 ### Changed
 - Public: Users using the cross device flow on desktop (instead of mobile) are now blocked from continuing

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -205,7 +205,7 @@ class Confirm extends Component  {
     this.startTime = performance.now()
     sendEvent('Starting upload', {method})
     this.setState({uploadInProgress: true})
-    const {blob, documentType: type, id, variant, challengeData} = capture
+    const {blob, documentType: type, id, variant, challengeData, sdkMetadata} = capture
     this.setState({captureId: id})
 
     if (method === 'document') {
@@ -221,11 +221,12 @@ class Confirm extends Component  {
       uploadDocument(data, token, this.onApiSuccess, this.onApiError)
     }
     else if  (method === 'face') {
+      const sdk_metadata = JSON.stringify(sdkMetadata)
       if (variant === 'video') {
-        const data = { challengeData, blob, language }
+        const data = { challengeData, blob, language, sdk_metadata}
         uploadLiveVideo(data, token, this.onApiSuccess, this.onApiError)
       } else {
-        const data = { file: blob }
+        const data = { file: blob, sdk_metadata}
         uploadLivePhoto(data, token, this.onApiSuccess, this.onApiError)
       }
     }

--- a/src/components/Photo/Selfie.js
+++ b/src/components/Photo/Selfie.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import { h, Component } from 'preact'
-import { screenshot } from '../utils/camera.js'
+import { screenshot, getDeviceInfo } from '../utils/camera.js'
 import { FaceOverlay } from '../Overlay'
 import { ToggleFullScreen } from '../FullScreen'
 import Timeout from '../Timeout'
@@ -29,8 +29,13 @@ export default class Selfie extends Component<Props, State> {
 
   handleTimeout = () => this.setState({ hasBecomeInactive: true })
 
-  handleClick = () => screenshot(this.webcam,
-    (blob, base64) => this.props.onCapture({ blob, base64 }))
+  onScreenshotCapture = (blob: Blob, base64: string) => {
+    const stream = this.webcam && this.webcam.stream
+    const sdkMetadata = getDeviceInfo(stream)
+    this.props.onCapture({ blob, base64, sdkMetadata })
+  }
+
+  handleClick = () => screenshot(this.webcam, this.onScreenshotCapture)
 
   render() {
     const { trackScreen, renderFallback, inactiveError} = this.props

--- a/src/components/Photo/Selfie.js
+++ b/src/components/Photo/Selfie.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import { h, Component } from 'preact'
-import { screenshot, getDeviceInfo } from '../utils/camera.js'
+import { screenshot } from '../utils/camera.js'
 import { FaceOverlay } from '../Overlay'
 import { ToggleFullScreen } from '../FullScreen'
 import Timeout from '../Timeout'
@@ -29,9 +29,7 @@ export default class Selfie extends Component<Props, State> {
 
   handleTimeout = () => this.setState({ hasBecomeInactive: true })
 
-  onScreenshotCapture = (blob: Blob, base64: string) => {
-    const stream = this.webcam && this.webcam.stream
-    const sdkMetadata = getDeviceInfo(stream)
+  onScreenshotCapture = (blob: Blob, base64: string, sdkMetadata: Object) => {
     this.props.onCapture({ blob, base64, sdkMetadata })
   }
 

--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -83,7 +83,7 @@ class Video extends Component<Props, State> {
     const { challenges, challengesId: id } = this.props
     const webcam = this.webcam
     this.stopRecording()
-    if ( webcam && !hasRecordingTakenTooLong) {
+    if (webcam && !hasRecordingTakenTooLong) {
       const challengeData = { challenges, id, switchSeconds }
       const sdkMetadata = getDeviceInfo(webcam.stream)
       this.props.onVideoCapture({ blob: webcam.getVideoBlob(), challengeData, sdkMetadata })

--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -8,6 +8,7 @@ import Title from '../Title'
 import { ToggleFullScreen } from '../FullScreen'
 import { FaceOverlay } from '../Overlay'
 import { currentMilliseconds } from '../utils'
+import { getDeviceInfo } from '../utils/camera'
 import { sendScreen } from '../../Tracker'
 import Recording from './Recording'
 import NotRecording from './NotRecording'
@@ -80,10 +81,12 @@ class Video extends Component<Props, State> {
   handleRecordingStop = () => {
     const { switchSeconds, hasRecordingTakenTooLong } = this.state
     const { challenges, challengesId: id } = this.props
+    const webcam = this.webcam
     this.stopRecording()
-    if (this.webcam && !hasRecordingTakenTooLong) {
+    if ( webcam && !hasRecordingTakenTooLong) {
       const challengeData = { challenges, id, switchSeconds }
-      this.props.onVideoCapture({ blob: this.webcam.getVideoBlob(), challengeData })
+      const sdkMetadata = getDeviceInfo(webcam.stream)
+      this.props.onVideoCapture({ blob: webcam.getVideoBlob(), challengeData, sdkMetadata })
     }
   }
 

--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -8,7 +8,7 @@ import Title from '../Title'
 import { ToggleFullScreen } from '../FullScreen'
 import { FaceOverlay } from '../Overlay'
 import { currentMilliseconds } from '../utils'
-import { getDeviceInfo } from '../utils/camera'
+import { onVideoRecorded } from '../utils/camera'
 import { sendScreen } from '../../Tracker'
 import Recording from './Recording'
 import NotRecording from './NotRecording'
@@ -81,12 +81,9 @@ class Video extends Component<Props, State> {
   handleRecordingStop = () => {
     const { switchSeconds, hasRecordingTakenTooLong } = this.state
     const { challenges, challengesId: id } = this.props
-    const webcam = this.webcam
     this.stopRecording()
-    if (webcam && !hasRecordingTakenTooLong) {
-      const challengeData = { challenges, id, switchSeconds }
-      const sdkMetadata = getDeviceInfo(webcam.stream)
-      this.props.onVideoCapture({ blob: webcam.getVideoBlob(), challengeData, sdkMetadata })
+    if (this.webcam && !hasRecordingTakenTooLong) {
+      onVideoRecorded(this.webcam, { challenges, id, switchSeconds }, this.props.onVideoCapture)
     }
   }
 

--- a/src/components/utils/camera.js
+++ b/src/components/utils/camera.js
@@ -8,10 +8,10 @@ export const screenshot = (webcam, callback) => {
     console.error('webcam canvas is null')
     return
   }
-  const deviceInfo = getDeviceInfo(webcam.stream)
+  const sdkMetadata = getDeviceInfo(webcam.stream)
   asyncFunc(cloneCanvas, [canvas], canvas =>
     canvasToBase64Images(canvas, (lossyBase64, base64) =>
-      callback(base64toBlob(base64), lossyBase64, deviceInfo)
+      callback(base64toBlob(base64), lossyBase64, sdkMetadata)
     )
   )
 }
@@ -22,7 +22,7 @@ export const onVideoRecorded = (webcam, challengeData, callback) => {
   callback({ blob, challengeData, sdkMetadata })
 }
 
-export const getDeviceInfo = (stream) => {
+const getDeviceInfo = (stream) => {
   if (stream) {
     const videoTrack = stream.getVideoTracks()[0] || {}
     const audioTrack = stream.getAudioTracks()[0] || {}

--- a/src/components/utils/camera.js
+++ b/src/components/utils/camera.js
@@ -8,11 +8,18 @@ export const screenshot = (webcam, callback) => {
     console.error('webcam canvas is null')
     return
   }
+  const deviceInfo = getDeviceInfo(webcam.stream)
   asyncFunc(cloneCanvas, [canvas], canvas =>
     canvasToBase64Images(canvas, (lossyBase64, base64) =>
-      callback(base64toBlob(base64), lossyBase64)
+      callback(base64toBlob(base64), lossyBase64, deviceInfo)
     )
   )
+}
+
+export const onVideoRecorded = (webcam, challengeData, callback) => {
+  const blob = webcam.getVideoBlob()
+  const sdkMetadata = getDeviceInfo(webcam.stream)
+  callback({ blob, challengeData, sdkMetadata })
 }
 
 export const getDeviceInfo = (stream) => {

--- a/src/components/utils/camera.js
+++ b/src/components/utils/camera.js
@@ -14,3 +14,12 @@ export const screenshot = (webcam, callback) => {
     )
   )
 }
+
+export const getDeviceInfo = (stream) => {
+  if (stream) {
+    const videoTrack = stream.getVideoTracks()[0] || {}
+    const audioTrack = stream.getAudioTracks()[0] || {}
+    return {camera_name: videoTrack.label, microphone_name: audioTrack.label}
+  }
+  return {}
+}

--- a/src/components/utils/onfidoApi.js
+++ b/src/components/utils/onfidoApi.js
@@ -19,7 +19,7 @@ export const uploadLivePhoto = (data, token, onSuccess, onError) => {
   sendFile(endpoint, data, token, onSuccess, onError)
 }
 
-export const uploadLiveVideo = ({challengeData, blob, language, ...other}, token, onSuccess, onError) => {
+export const uploadLiveVideo = ({challengeData, blob, language, sdk_metadata}, token, onSuccess, onError) => {
   const {
     challenges: challenge,
     id: challenge_id,
@@ -31,7 +31,7 @@ export const uploadLiveVideo = ({challengeData, blob, language, ...other}, token
     challenge: JSON.stringify(challenge),
     challenge_id,
     challenge_switch_at,
-    ...other
+    sdk_metadata
   }
   const endpoint = `${process.env.ONFIDO_API_URL}/v2/live_videos`
   sendFile(endpoint, payload, token, onSuccess, onError)

--- a/src/components/utils/onfidoApi.js
+++ b/src/components/utils/onfidoApi.js
@@ -19,7 +19,7 @@ export const uploadLivePhoto = (data, token, onSuccess, onError) => {
   sendFile(endpoint, data, token, onSuccess, onError)
 }
 
-export const uploadLiveVideo = ({challengeData, blob, language}, token, onSuccess, onError) => {
+export const uploadLiveVideo = ({challengeData, blob, language, ...other}, token, onSuccess, onError) => {
   const {
     challenges: challenge,
     id: challenge_id,
@@ -30,7 +30,8 @@ export const uploadLiveVideo = ({challengeData, blob, language}, token, onSucces
     languages: JSON.stringify([{source: 'sdk', language_code: language}]),
     challenge: JSON.stringify(challenge),
     challenge_id,
-    challenge_switch_at
+    challenge_switch_at,
+    ...other
   }
   const endpoint = `${process.env.ONFIDO_API_URL}/v2/live_videos`
   sendFile(endpoint, payload, token, onSuccess, onError)


### PR DESCRIPTION
# Problem
Currently we don't collect video and audio labels.

# Solution
Send audio and video labels to Onfido API when uploading face video or selfie

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
