### PR TITLE
Fix bundler issue on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
   directories:
     - "node_modules"
 before_install:
+  - gem install bundler -v '< 2'
   - openssl aes-256-cbc -K $encrypted_1688a3f2e0a8_key -iv $encrypted_1688a3f2e0a8_iv -in test/monster_rsa.enc -out ~/.ssh/monster_rsa -d
   - chmod ugo+x ./test/scripts/setup_test_environment.sh
   - sudo ./test/scripts/setup_test_environment.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
   directories:
     - "node_modules"
 before_install:
+  - rvm install 2.3.4
   - openssl aes-256-cbc -K $encrypted_1688a3f2e0a8_key -iv $encrypted_1688a3f2e0a8_iv -in test/monster_rsa.enc -out ~/.ssh/monster_rsa -d
   - chmod ugo+x ./test/scripts/setup_test_environment.sh
   - sudo ./test/scripts/setup_test_environment.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ cache:
   directories:
     - "node_modules"
 before_install:
-  - rvm install 2.6.0
   - openssl aes-256-cbc -K $encrypted_1688a3f2e0a8_key -iv $encrypted_1688a3f2e0a8_iv -in test/monster_rsa.enc -out ~/.ssh/monster_rsa -d
   - chmod ugo+x ./test/scripts/setup_test_environment.sh
   - sudo ./test/scripts/setup_test_environment.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
   directories:
     - "node_modules"
 before_install:
-  - gem install bundler -v '< 2'
+  - rvm install 2.6.0
   - openssl aes-256-cbc -K $encrypted_1688a3f2e0a8_key -iv $encrypted_1688a3f2e0a8_iv -in test/monster_rsa.enc -out ~/.ssh/monster_rsa -d
   - chmod ugo+x ./test/scripts/setup_test_environment.sh
   - sudo ./test/scripts/setup_test_environment.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ cache:
   directories:
     - "node_modules"
 before_install:
-  - rvm install 2.3.4
   - openssl aes-256-cbc -K $encrypted_1688a3f2e0a8_key -iv $encrypted_1688a3f2e0a8_iv -in test/monster_rsa.enc -out ~/.ssh/monster_rsa -d
   - chmod ugo+x ./test/scripts/setup_test_environment.sh
   - sudo ./test/scripts/setup_test_environment.sh

--- a/test/scripts/setup_test_environment.sh
+++ b/test/scripts/setup_test_environment.sh
@@ -8,5 +8,6 @@ if [[ ${CI} == "true" && (${NODE_ENV} = "test" && ${TRAVIS_PULL_REQUEST} != "fal
   sudo ./test/scripts/install_chromedriver_travis.sh
 
   chmod 600 ~/.ssh/monster_rsa
+  sudo apt-get install ruby-full
   gem install bundler
 fi

--- a/test/scripts/setup_test_environment.sh
+++ b/test/scripts/setup_test_environment.sh
@@ -13,6 +13,7 @@ if [[ ${CI} == "true" && (${NODE_ENV} = "test" && ${TRAVIS_PULL_REQUEST} != "fal
   # prepare environment for rvm installation
   sudo apt-get update
   sudo apt-get install -y curl gnupg build-essential
+  sudo usermod -a -G rvm `whoami`
 
   # Install rvm
   sudo gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3

--- a/test/scripts/setup_test_environment.sh
+++ b/test/scripts/setup_test_environment.sh
@@ -8,5 +8,6 @@ if [[ ${CI} == "true" && (${NODE_ENV} = "test" && ${TRAVIS_PULL_REQUEST} != "fal
   sudo ./test/scripts/install_chromedriver_travis.sh
 
   chmod 600 ~/.ssh/monster_rsa
+  rvm install 2.3.4
   gem install bundler
 fi

--- a/test/scripts/setup_test_environment.sh
+++ b/test/scripts/setup_test_environment.sh
@@ -9,5 +9,5 @@ if [[ ${CI} == "true" && (${NODE_ENV} = "test" && ${TRAVIS_PULL_REQUEST} != "fal
 
   chmod 600 ~/.ssh/monster_rsa
   sudo apt-get install ruby-full
-  gem install bundler
+  gem install bundler -v '< 2'
 fi

--- a/test/scripts/setup_test_environment.sh
+++ b/test/scripts/setup_test_environment.sh
@@ -8,6 +8,16 @@ if [[ ${CI} == "true" && (${NODE_ENV} = "test" && ${TRAVIS_PULL_REQUEST} != "fal
   sudo ./test/scripts/install_chromedriver_travis.sh
 
   chmod 600 ~/.ssh/monster_rsa
-  sudo apt-get install ruby-full
-  gem install bundler -v '< 2'
+
+  # Install rvm
+  sudo gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+  curl -sSL https://get.rvm.io | sudo bash -s stable
+  source ~/.rvm/scripts/rvm
+
+  # Install Ruby
+  rvm install ruby
+  rvm --default use ruby
+
+  # Install bundler
+  gem install bundler
 fi

--- a/test/scripts/setup_test_environment.sh
+++ b/test/scripts/setup_test_environment.sh
@@ -9,6 +9,11 @@ if [[ ${CI} == "true" && (${NODE_ENV} = "test" && ${TRAVIS_PULL_REQUEST} != "fal
 
   chmod 600 ~/.ssh/monster_rsa
 
+
+  # prepare environment for rvm installation
+  sudo apt-get update
+  sudo apt-get install -y curl gnupg build-essential
+
   # Install rvm
   sudo gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
   curl -sSL https://get.rvm.io | sudo bash -s stable

--- a/test/scripts/setup_test_environment.sh
+++ b/test/scripts/setup_test_environment.sh
@@ -8,6 +8,6 @@ if [[ ${CI} == "true" && (${NODE_ENV} = "test" && ${TRAVIS_PULL_REQUEST} != "fal
   sudo ./test/scripts/install_chromedriver_travis.sh
 
   chmod 600 ~/.ssh/monster_rsa
-  sudo apt-get install ruby-full
+  sudo apt-get install ruby
   gem install bundler -v '< 2'
 fi

--- a/test/scripts/setup_test_environment.sh
+++ b/test/scripts/setup_test_environment.sh
@@ -8,22 +8,6 @@ if [[ ${CI} == "true" && (${NODE_ENV} = "test" && ${TRAVIS_PULL_REQUEST} != "fal
   sudo ./test/scripts/install_chromedriver_travis.sh
 
   chmod 600 ~/.ssh/monster_rsa
-
-
-  # prepare environment for rvm installation
-  sudo apt-get update
-  sudo apt-get install -y curl gnupg build-essential
-  sudo usermod -a -G rvm `whoami`
-
-  # Install rvm
-  sudo gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
-  curl -sSL https://get.rvm.io | sudo bash -s stable
-  source ~/.rvm/scripts/rvm
-
-  # Install Ruby
-  rvm install ruby
-  rvm --default use ruby
-
-  # Install bundler
-  gem install bundler
+  sudo apt-get install ruby-full
+  gem install bundler -v '< 2'
 fi

--- a/test/scripts/setup_test_environment.sh
+++ b/test/scripts/setup_test_environment.sh
@@ -8,6 +8,5 @@ if [[ ${CI} == "true" && (${NODE_ENV} = "test" && ${TRAVIS_PULL_REQUEST} != "fal
   sudo ./test/scripts/install_chromedriver_travis.sh
 
   chmod 600 ~/.ssh/monster_rsa
-  sudo apt-get install ruby-full
   gem install bundler -v '< 2'
 fi

--- a/test/scripts/setup_test_environment.sh
+++ b/test/scripts/setup_test_environment.sh
@@ -8,6 +8,6 @@ if [[ ${CI} == "true" && (${NODE_ENV} = "test" && ${TRAVIS_PULL_REQUEST} != "fal
   sudo ./test/scripts/install_chromedriver_travis.sh
 
   chmod 600 ~/.ssh/monster_rsa
-  sudo apt-get install ruby
+  sudo apt-get install ruby-full
   gem install bundler -v '< 2'
 fi

--- a/test/scripts/setup_test_environment.sh
+++ b/test/scripts/setup_test_environment.sh
@@ -8,6 +8,5 @@ if [[ ${CI} == "true" && (${NODE_ENV} = "test" && ${TRAVIS_PULL_REQUEST} != "fal
   sudo ./test/scripts/install_chromedriver_travis.sh
 
   chmod 600 ~/.ssh/monster_rsa
-  rvm install 2.3.4
   gem install bundler
 fi


### PR DESCRIPTION
# Problem
The latest version of bundler released yesterday does not support ruby versions < 2.3.0

# Solution
Install a stable version of Ruby for Linux to avoid relaying solely on the pre-installed versions in the travis environment
Use bundler version < 2

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
