### PR TITLE
removed the confusion of document customisation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,11 +319,13 @@ A number of options are available to allow you to customise the SDK:
   The custom options are:
   - documentTypes
   ```
-    {
+  options: {   
+     documentTypes: {
         passport: boolean,
         driving_licence: boolean,
         national_identity_card: boolean
-    }
+     }
+  }
   ```
 
   ### face ###


### PR DESCRIPTION
Always better way to show the exact configuration that needs to be added, instead of bullets (like - documentTypes)!

# Problem


# Solution


## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
