### PR TITLE
Cross-device flow number repeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Added
 - Public: Added Proof of address `poa` step where users can capture their proof of address documents. This is a beta feature.
 - Internal: Send camera and microphone labels to Onfido API as metadata
+- Public: Prepopulate the user's mobile phone number, when specified through the `userDetails.smsNumber` option
 
 ### Changed
 - Internal: Users using the cross device flow on desktop (instead of mobile) are now blocked from continuing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Internal: Users using the cross device flow on desktop (instead of mobile) are now blocked from continuing
 - Internal: Removed unused development dependencies which had known vulnerabilities
 
+### Fixed
+- Public: Users entering the cross-device flow twice would have been able to request an SMS message without re-entering their mobile number correctly (the form could submit when still blank)
+
 
 ## [3.0.1] - 2018-12-19
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,12 @@ A number of options are available to allow you to customise the SDK:
   smsNumberCountryCode: 'US'
   ```
 
+- **`userDetails {Object} optional`**
+  Some user details can be specified ahead of time, so that the user doesn't need to fill them in themselves.
+
+  The following details can be used by the SDK:
+    - `smsNumber` (optional) : The user's mobile number, which can be used for sending any SMS messages to the user. An example SMS message sent by the SDK is when a user requests to use their mobile devices to take photos. This should be formatted as a string, with a country code (e.g. `"+447500123456"`)
+
 - **`steps {List} optional`**
 
   List of the different steps and their custom options. Each step can either be specified as a string (when no customisation is required) or an object (when customisation is required):

--- a/src/components/PhoneNumberInput/index.js
+++ b/src/components/PhoneNumberInput/index.js
@@ -18,7 +18,7 @@ const FlagComponent = ({ countryCode, flagsPath }) => (
   />
 );
 
-const PhoneNumberInput = ({ translate, clearErrors, actions = {}, smsNumberCountryCode}) => {
+const PhoneNumberInput = ({ translate, clearErrors, actions = {}, sms = {}, smsNumberCountryCode}) => {
 
   const onChange = (number) => {
     clearErrors()
@@ -29,6 +29,7 @@ const PhoneNumberInput = ({ translate, clearErrors, actions = {}, smsNumberCount
   return (
     <form onSubmit={(e) => e.preventDefault()}>
       <PhoneNumber placeholder={translate('cross_device.phone_number_placeholder')}
+        value={sms.number || ''}
         onChange={onChange}
         country={smsNumberCountryCode}
         inputClassName={`${style.mobileInput}`}

--- a/src/components/PhoneNumberInput/index.js
+++ b/src/components/PhoneNumberInput/index.js
@@ -1,5 +1,5 @@
 import { h } from 'preact'
-import PhoneNumber, {isValidPhoneNumber} from 'react-phone-number-input'
+import PhoneNumber from 'react-phone-number-input'
 
 import classNames from 'classnames';
 import {localised} from '../../locales'
@@ -22,8 +22,7 @@ const PhoneNumberInput = ({ translate, clearErrors, actions = {}, sms = {}, smsN
 
   const onChange = (number) => {
     clearErrors()
-    const valid = isValidPhoneNumber(number)
-    actions.setMobileNumber({number, valid})
+    actions.setMobileNumber(number)
   }
 
   return (

--- a/src/core/store/actions/globals.js
+++ b/src/core/store/actions/globals.js
@@ -1,3 +1,4 @@
+import { isValidPhoneNumber } from 'react-phone-number-input'
 import * as constants from '../../constants'
 
 export function setDocumentType(payload) {
@@ -28,7 +29,12 @@ export function setClientSuccess(payload) {
   }
 }
 
-export function setMobileNumber(payload) {
+export function setMobileNumber(number) {
+  const payload = {
+    number,
+    valid: isValidPhoneNumber(number)
+  }
+
   return {
     type: constants.SET_MOBILE_NUMBER,
     payload

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -125,6 +125,9 @@ class Demo extends Component{
         language,
         steps,
         mobileFlow: !!queryStrings.link_id,
+        userDetails: {
+          smsNumber: queryStrings.smsNumber,
+        },
         onModalRequestClose: () => {
           this.setState({isModalOpen: false})
         },

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { h, render } from 'preact'
+import { h, render, Component } from 'preact'
 import { Provider as ReduxProvider } from 'react-redux'
 import EventEmitter from 'eventemitter2'
 import countries from 'react-phone-number-input/modules/countries'
@@ -20,12 +20,35 @@ const ModalApp = ({ options:{ useModal, isModalOpen, onModalRequestClose, ...oth
     <Router options={otherOptions} {...otherProps}/>
   </Modal>
 
-const Container = ({ options }) =>
-  <ReduxProvider store={store}>
-    <LocaleProvider language={options.language}>
-      <ModalApp options={options} />
-    </LocaleProvider>
-  </ReduxProvider>
+class Container extends Component {
+  componentDidMount() {
+    this.prepareInitialStore(this.props.options)
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.prepareInitialStore(nextProps.options, this.props.options)
+  }
+
+  prepareInitialStore = (options = {}, prevOptions = {}) => {
+    const { userDetails: { smsNumber } = {} } = options
+    const { userDetails: { smsNumber: prevSmsNumber } = {} } = prevOptions
+
+    if (smsNumber && smsNumber !== prevSmsNumber)
+      actions.setMobileNumber(smsNumber)
+  }
+
+  render() {
+    const { options } = this.props
+
+    return (
+      <ReduxProvider store={store}>
+        <LocaleProvider language={options.language}>
+          <ModalApp options={options} />
+        </LocaleProvider>
+      </ReduxProvider>
+    )
+  }
+}
 
 /**
  * Renders the Onfido component


### PR DESCRIPTION
# Problem
Currently if entering the cross-device flow once, entering your mobile number, and then attempting to re-send the SMS again, you can click "submit" with your mobile number still blank.

This is because only a 1-way data binding was set up, causing the old data to not populate the phone input the second time (despite still being the active bit of data)

# Solution
I just set up a 2-way data binding, so that the input correctly reflects the data.

We could also wipe the mobile number after submitting the first time, but I decided that it was actually nice to keep the value that you previously entered (so you can check + edit your number, rather than having to type it out entirely again)

## Checklist

- [X] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
