### PR TITLE
Custom SMS number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Added
 - Public: Added Proof of address `poa` step where users can capture their proof of address documents. This is a beta feature.
 - Internal: Send camera and microphone labels to Onfido API as metadata
+- Public: Prepopulate the applicant's mobile phone number, when specified through the `applicantDetails.smsNumber` option
 
 ### Changed
 - Internal: Users using the cross device flow on desktop (instead of mobile) are now blocked from continuing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Internal: Users using the cross device flow on desktop (instead of mobile) are now blocked from continuing
 - Internal: Removed unused development dependencies which had known vulnerabilities
 
+### Fixed
+- Public: Users entering the cross-device flow twice would have been able to request an SMS message without re-entering their mobile number correctly (the form could submit when still blank)
+
 
 ## [3.0.1] - 2018-12-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Added
 - Public: Added Proof of address `poa` step where users can capture their proof of address documents. This is a beta feature.
 - Internal: Send camera and microphone labels to Onfido API as metadata
-- Public: Prepopulate the applicant's mobile phone number, when specified through the `applicantDetails.smsNumber` option
+- Public: Prepopulate the user's mobile phone number, when specified through the `userDetails.smsNumber` option
 
 ### Changed
 - Internal: Users using the cross device flow on desktop (instead of mobile) are now blocked from continuing

--- a/README.md
+++ b/README.md
@@ -284,11 +284,11 @@ A number of options are available to allow you to customise the SDK:
   smsNumberCountryCode: 'US'
   ```
 
-- **`applicantDetails {Object} optional`**
-  Some applicant details can be specified ahead of time, so that the applicant doesn't need to fill them in themselves.
+- **`userDetails {Object} optional`**
+  Some user details can be specified ahead of time, so that the user doesn't need to fill them in themselves.
 
   The following details can be used by the SDK:
-    - `smsNumber` (optional) : The applicant's mobile number, which can be used for sending any SMS messages to the user. An example SMS message sent by the SDK is when a applicant requests to use their mobile devices to take photos. This should be formatted as a string, with a country code (e.g. `"+447500123456"`)
+    - `smsNumber` (optional) : The user's mobile number, which can be used for sending any SMS messages to the user. An example SMS message sent by the SDK is when a user requests to use their mobile devices to take photos. This should be formatted as a string, with a country code (e.g. `"+447500123456"`)
 
 - **`steps {List} optional`**
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,12 @@ A number of options are available to allow you to customise the SDK:
   smsNumberCountryCode: 'US'
   ```
 
+- **`applicantDetails {Object} optional`**
+  Some applicant details can be specified ahead of time, so that the applicant doesn't need to fill them in themselves.
+
+  The following details can be used by the SDK:
+    - `smsNumber` (optional) : The applicant's mobile number, which can be used for sending any SMS messages to the user. An example SMS message sent by the SDK is when a applicant requests to use their mobile devices to take photos. This should be formatted as a string, with a country code (e.g. `"+447500123456"`)
+
 - **`steps {List} optional`**
 
   List of the different steps and their custom options. Each step can either be specified as a string (when no customisation is required) or an object (when customisation is required):

--- a/src/components/PhoneNumberInput/index.js
+++ b/src/components/PhoneNumberInput/index.js
@@ -18,7 +18,7 @@ const FlagComponent = ({ countryCode, flagsPath }) => (
   />
 );
 
-const PhoneNumberInput = ({ translate, clearErrors, actions = {}, smsNumberCountryCode}) => {
+const PhoneNumberInput = ({ translate, clearErrors, actions = {}, sms = {}, smsNumberCountryCode}) => {
 
   const onChange = (number) => {
     clearErrors()
@@ -29,6 +29,7 @@ const PhoneNumberInput = ({ translate, clearErrors, actions = {}, smsNumberCount
   return (
     <form onSubmit={(e) => e.preventDefault()}>
       <PhoneNumber placeholder={translate('cross_device.phone_number_placeholder')}
+        value={sms.number || ''}
         onChange={onChange}
         country={smsNumberCountryCode}
         inputClassName={`${style.mobileInput}`}

--- a/src/components/PhoneNumberInput/index.js
+++ b/src/components/PhoneNumberInput/index.js
@@ -1,5 +1,5 @@
 import { h } from 'preact'
-import PhoneNumber, {isValidPhoneNumber} from 'react-phone-number-input'
+import PhoneNumber from 'react-phone-number-input'
 
 import classNames from 'classnames';
 import {localised} from '../../locales'
@@ -22,8 +22,7 @@ const PhoneNumberInput = ({ translate, clearErrors, actions = {}, sms = {}, smsN
 
   const onChange = (number) => {
     clearErrors()
-    const valid = isValidPhoneNumber(number)
-    actions.setMobileNumber({number, valid})
+    actions.setMobileNumber(number)
   }
 
   return (

--- a/src/core/store/actions/globals.js
+++ b/src/core/store/actions/globals.js
@@ -1,3 +1,4 @@
+import { isValidPhoneNumber } from 'react-phone-number-input'
 import * as constants from '../../constants'
 
 export function setDocumentType(payload) {
@@ -28,7 +29,12 @@ export function setClientSuccess(payload) {
   }
 }
 
-export function setMobileNumber(payload) {
+export function setMobileNumber(number) {
+  const payload = {
+    number,
+    valid: isValidPhoneNumber(number)
+  }
+
   return {
     type: constants.SET_MOBILE_NUMBER,
     payload

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -125,7 +125,7 @@ class Demo extends Component{
         language,
         steps,
         mobileFlow: !!queryStrings.link_id,
-        applicantDetails: {
+        userDetails: {
           smsNumber: queryStrings.smsNumber,
         },
         onModalRequestClose: () => {

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -125,6 +125,9 @@ class Demo extends Component{
         language,
         steps,
         mobileFlow: !!queryStrings.link_id,
+        applicantDetails: {
+          smsNumber: queryStrings.smsNumber,
+        },
         onModalRequestClose: () => {
           this.setState({isModalOpen: false})
         },

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { h, render } from 'preact'
+import { h, render, Component } from 'preact'
 import { Provider as ReduxProvider } from 'react-redux'
 import EventEmitter from 'eventemitter2'
 import countries from 'react-phone-number-input/modules/countries'
@@ -20,12 +20,30 @@ const ModalApp = ({ options:{ useModal, isModalOpen, onModalRequestClose, ...oth
     <Router options={otherOptions} {...otherProps}/>
   </Modal>
 
-const Container = ({ options }) =>
-  <ReduxProvider store={store}>
-    <LocaleProvider language={options.language}>
-      <ModalApp options={options} />
-    </LocaleProvider>
-  </ReduxProvider>
+class Container extends Component {
+  componentDidMount() {
+    this.prepareInitialStore()
+  }
+
+  prepareInitialStore = () => {
+    const { options: { applicantDetails = {} } = {} } = this.props
+
+    if (applicantDetails.smsNumber)
+      actions.setMobileNumber(applicantDetails.smsNumber)
+  }
+
+  render() {
+    const { options } = this.props
+
+    return (
+      <ReduxProvider store={store}>
+        <LocaleProvider language={options.language}>
+          <ModalApp options={options} />
+        </LocaleProvider>
+      </ReduxProvider>
+    )
+  }
+}
 
 /**
  * Renders the Onfido component

--- a/src/index.js
+++ b/src/index.js
@@ -22,14 +22,19 @@ const ModalApp = ({ options:{ useModal, isModalOpen, onModalRequestClose, ...oth
 
 class Container extends Component {
   componentDidMount() {
-    this.prepareInitialStore()
+    this.prepareInitialStore(this.props.options)
   }
 
-  prepareInitialStore = () => {
-    const { options: { applicantDetails = {} } = {} } = this.props
+  componentWillReceiveProps(nextProps) {
+    this.prepareInitialStore(nextProps.options, this.props.options)
+  }
 
-    if (applicantDetails.smsNumber)
-      actions.setMobileNumber(applicantDetails.smsNumber)
+  prepareInitialStore = (options = {}, prevOptions = {}) => {
+    const { applicantDetails: { smsNumber } = {} } = options
+    const { applicantDetails: { smsNumber: prevSmsNumber } = {} } = prevOptions
+
+    if (smsNumber && smsNumber !== prevSmsNumber)
+      actions.setMobileNumber(smsNumber)
   }
 
   render() {

--- a/src/index.js
+++ b/src/index.js
@@ -30,8 +30,8 @@ class Container extends Component {
   }
 
   prepareInitialStore = (options = {}, prevOptions = {}) => {
-    const { applicantDetails: { smsNumber } = {} } = options
-    const { applicantDetails: { smsNumber: prevSmsNumber } = {} } = prevOptions
+    const { userDetails: { smsNumber } = {} } = options
+    const { userDetails: { smsNumber: prevSmsNumber } = {} } = prevOptions
 
     if (smsNumber && smsNumber !== prevSmsNumber)
       actions.setMobileNumber(smsNumber)


### PR DESCRIPTION
# Problem
Currently there's no way for clients to specify an SMS number ahead of time

# Solution
Allow clients to specify the applicant's mobile number, using the `applicantDetails.smsNumber` option

## Checklist

- [X] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
