### PR TITLE
Woopra stop tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Fixed
 - Public: Users entering the cross-device flow twice would have been able to request an SMS message without re-entering their mobile number correctly (the form could submit when still blank)
-
+- Internal: Fix a bug that potentially allowed 3rd party tracking scripts to (in some very specific conditions) continue to send Onfido tracking events, after calling `.tearDown()`
 
 ## [3.0.1] - 2018-12-19
 

--- a/src/Tracker/index.js
+++ b/src/Tracker/index.js
@@ -5,6 +5,8 @@ require('imports-loader?this=>window!wpt/wpt.min.js')
 import mapObject from 'object-loops/map'
 import {includes,isOnfidoHostname} from '~utils/string'
 
+let shouldSendEvents = false
+
 const client = window.location.hostname
 const sdk_version = process.env.SDK_VERSION
 
@@ -61,10 +63,13 @@ const setUp = () => {
 
 const uninstall = () => {
   RavenTracker.uninstall()
+  woopra.dispose()
+  shouldSendEvents = false
 }
 
 const install = () => {
   RavenTracker.install()
+  shouldSendEvents = true
 }
 
 const formatProperties = properties => {
@@ -74,8 +79,10 @@ const formatProperties = properties => {
   )
 }
 
-const sendEvent = (eventName, properties) =>
-  woopra.track(eventName, formatProperties(properties))
+const sendEvent = (eventName, properties) => {
+  if (shouldSendEvents)
+    woopra.track(eventName, formatProperties(properties))
+}
 
 const screeNameHierarchyFormat = (screeNameHierarchy) =>
   `screen_${cleanFalsy(screeNameHierarchy).join('_')}`

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -90,6 +90,8 @@ class SDK extends Component{
   initSDK = (options)=> {
     const onfidoSdk = Onfido.init(options)
     this.setState({onfidoSdk})
+
+    window.onfidoSdkHandle = onfidoSdk
   }
 
   shouldComponentUpdate () {


### PR DESCRIPTION
# Problem
In some very specific conditions, it is possible for some 3rd party tracking scripts (namely, Woopra) to continue to send Onfido tracking events, after calling `.tearDown()`

# Solution
Ensure that [`woopra.dispose()`](https://github.com/onfido/js-client-tracker/blob/master/wpt.js#L1620) is called on tear down, and add a manual boolean `shouldSendEvents` to manually stop attempting event-sending, after tear-down.

## Checklist

- [X] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
