### PR TITLE
Refactored to hold the selfie data within the capture object

### DIFF
--- a/src/components/Capture/Face.js
+++ b/src/components/Capture/Face.js
@@ -41,7 +41,7 @@ class Face extends Component {
   handleVideoCapture = payload => this.handleCapture({ ...payload, variant: 'video' })
 
   handleUpload = file => fileToLossyBase64Image(file,
-    base64 => this.handleCapture({ selfie: { blob: file, base64 }}),
+    base64 => this.handleCapture({ blob: file, base64 }),
     () => {})
 
   handleError = () => this.props.actions.deleteCapture()

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -122,9 +122,6 @@ const Previews = localised(({capture, retakeAction, confirmAction, error, method
     translate(`confirm.face.${capture.variant}.message`) :
     translate(`confirm.${documentType}.message`)
 
-  const previewableCapture = method === 'face' && capture.variant === 'standard' ?
-    capture.selfie : capture
-
   return (
     <div className={classNames(style.previewsContainer, {
       [style.previewsContainerIsFullScreen]: isFullScreen,
@@ -134,7 +131,7 @@ const Previews = localised(({capture, retakeAction, confirmAction, error, method
         <div className={classNames(theme.imageWrapper, {
           [style.videoWrapper]: capture.variant === 'video',
         })}>
-          <CaptureViewer {...{ method, isFullScreen }} capture={previewableCapture} />
+          <CaptureViewer {...{ capture, method, isFullScreen }} />
         </div>
       <Actions {...{retakeAction, confirmAction, error}} />
     </div>
@@ -227,7 +224,7 @@ class Confirm extends Component {
     }
   }
 
-  handleSelfieUpload = ({snapshot, selfie }, token) => {
+  handleSelfieUpload = ({snapshot, ...selfie }, token) => {
     // if snapshot is present, it needs to be uploaded together with the user initiated selfie
     if (snapshot) {
       chainMultiframeUpload(snapshot, selfie, token,

--- a/src/components/Photo/Selfie.js
+++ b/src/components/Photo/Selfie.js
@@ -43,7 +43,7 @@ export default class Selfie extends Component<Props, State> {
        to have a snapshot, even if it's not an ideal one */
     const snapshot = this.state.snapshotBuffer[0] || this.state.snapshotBuffer[1]
     const captureData = this.props.useMultipleSelfieCapture ?
-      { snapshot, ...selfie } : selfie 
+      { snapshot, ...selfie } : selfie
     this.props.onCapture(captureData)
   }
 

--- a/src/components/Photo/Selfie.js
+++ b/src/components/Photo/Selfie.js
@@ -43,7 +43,7 @@ export default class Selfie extends Component<Props, State> {
        to have a snapshot, even if it's not an ideal one */
     const snapshot = this.state.snapshotBuffer[0] || this.state.snapshotBuffer[1]
     const captureData = this.props.useMultipleSelfieCapture ?
-      { snapshot, selfie } : { selfie }
+      { snapshot, ...selfie } : selfie 
     this.props.onCapture(captureData)
   }
 


### PR DESCRIPTION
# Problem
On cross device, after submitting document and face capture and reaching the "Uploads successful" screen, when navigating to the previous screen, the SDK was not able to display the previously uploaded image and it was returning an error. 
We noticed that the capture binary was returned as an ArrayBuffer by the redux store, even if it was stored correctly as a Blob or File. I think this might be a bug in Redux because it happened in Chrome, FF and Safari.

# Solution
We don't know what's causing the redux store or the browser to return an ArrayBuffer instead of a Blob/File. I've noticed that the bug only appears when the Blob or File is nested within the `capture` object. For example, this breaks:
`{selfie: {blob: Blob || File}}`
This works:
`{blob: Blob || File}`

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
