### PR TITLE
Buttons/Footer hiding issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Changed
 - Internal: Changed the way that blob/base64 files and images are rendered and passed through the system
+- Internal: Changed the way that the copyright footer is rendered to stay at the bottom of the page, for older `-webkit-box-flex` browsers
 
 ### Fixed
 - Public: Users entering the cross-device flow twice would have been able to request an SMS message without re-entering their mobile number correctly (the form could submit when still blank)

--- a/src/components/Confirm/style.css
+++ b/src/components/Confirm/style.css
@@ -2,9 +2,8 @@
 
 .previewsContainer {
   width: 100%;
-  height: 100%;
-  position: absolute;
   display: flex;
+  flex: 1;
   flex-direction: column;
   justify-content: space-between;
 

--- a/src/components/Theme/style.css
+++ b/src/components/Theme/style.css
@@ -34,6 +34,12 @@
 
 .content {
   flex: 1 0 auto;
+  /* We want `flex-grow: 1` for modern browsers, but older `-webkit-box-flex`
+     browsers are really buggy with their equivalent! So we opt for a slightly
+     inferior, but less buggy experience of turning off flex-grow entirely for
+     these older browsers, specifically. */
+  -webkit-box-flex: 0;
+
   position: relative;
   display: flex;
   > * {
@@ -58,11 +64,6 @@
   .fullScreenStep & {
     /* A full screen step will be a video/stream step, with a darker background */
     background-image: url('assets/powered-by-onfido-light.svg');
-  }
-
-  /* hide the footer if view height is too small */
-  @media (max-height: 420px) {
-    z-index: -1;
   }
 }
 

--- a/src/components/Uploader/style.css
+++ b/src/components/Uploader/style.css
@@ -9,7 +9,7 @@
 }
 
 .instructionsCopy {
-  margin: 1rem 24px;
+  padding: 1rem 24px;
   font-size: 14px;
   line-height: 1.43;
 
@@ -95,4 +95,3 @@
     padding: 0;
   }
 }
-


### PR DESCRIPTION
# Problem
Currently the footer and buttons can misplay a little bit. Specifically, it looks like the issue is on older Webkit browsers, which don't support the `flex` property, but fall back on `-webkit-box-flex` etc.

The footer/buttons misplaying seems to stem from the fact that these older browsers struggle to handle flex components that are meant to grow to an `auto` basis.

Currently we flex-grow the centre content, so that the footer is always at the bottom. Unfortunately, the centre content can contain quite complex content, which doesn't play well.

# Solution
Rather than growing the centre content, we can instead grow the footer, so that the footer grows to fit the page (and has a min-height of 48px in case the content is larger than the page)

This is basically the same, just from another perspective. However, because the footer is a super simple component, it plays a lot better with older browsers.

I've tested this solution on:
 * Chrome
 * Safari
 * iPhone 5s w/ Safari 7
 * Firefox
 * Firefox v35
 * IE11

Let me know if there are any other commonly bothersome browsers I should test too

## Checklist

- [X] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [X] Have tests passed locally?
- [n/a] Have any new strings been translated?
