### PR TITLE
Fix Safari PDF rendering

### DIFF
--- a/src/demo/index.ejs
+++ b/src/demo/index.ejs
@@ -12,7 +12,7 @@
       default-src 'self' https://assets.onfido.com;
       script-src 'self' https://www.woopra.com https://assets.onfido.com;
       style-src 'self' 'unsafe-inline' https://assets.onfido.com;
-      connect-src *.onfido.com wss://*.onfido.com https://www.woopra.com;
+      connect-src blob: *.onfido.com wss://*.onfido.com https://www.woopra.com;
       img-src 'self' data: blob: https://lipis.github.io/flag-icon-css/;
       media-src blob:;
       object-src 'self' blob:;


### PR DESCRIPTION
# Problem
Currently Safari isn't rendering PDF previews when non-local. It turns out that this is because our CSP was blocking it, as on Safari we render the PDF using a blob, which we don't allow for `connect-src`.

So this problem should only have actually been affecting our demo app.

# Solution
I've just added `blob:` to the CSP for `connect-src`. [Mozilla advise against allowing `data:`, but not `blob:`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src#Sources).

## Checklist
- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
