### PR TITLE
Feature/improve documentation for doc step option cx 3062

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,8 +339,12 @@ A number of options are available to allow you to customise the SDK:
   ### document ###
 
   This is the document capture step. Users will be asked to select the document type and to provide images of their selected documents. They will also have a chance to check the quality of the images before confirming.
+
   The custom options are:
-  - documentTypes
+  - documentTypes (object)
+
+  The list of document types can be filtered by using the `documentTypes` option. The default value for each document type is `true`.
+
   ```
   options: {   
      documentTypes: {

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ A number of options are available to allow you to customise the SDK:
   - country (default: `GBR`)
   - documentTypes
   ```
-    {
+    options: {
         country: string,
         documentTypes: {
           bank_building_society_statement: boolean,
@@ -381,7 +381,7 @@ A number of options are available to allow you to customise the SDK:
   The custom options are:
   - requestedVariant
   ```
-    {
+    options: {
         requestedVariant: 'standard' | 'video'
     }
   ```

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ A number of options are available to allow you to customise the SDK:
   The custom options are:
   - documentTypes (object)
 
-  The list of document types can be filtered by using the `documentTypes` option. The default value for each document type is `true`.
+  The list of document types visible to the user can be filtered by using the `documentTypes` option. The default value for each document type is `true`.
 
   ```
   options: {   


### PR DESCRIPTION
# Problem
The documentation for the DocumentTypes option on the document step is lacking a description and the example code is confusing.

# Solution
* Merge customer PR who suggested the improvement
* Include description of what the `DocumentTypes` option does

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
