### PR TITLE
Fix IE11

### DIFF
--- a/src/core/store/reducers/captures.js
+++ b/src/core/store/reducers/captures.js
@@ -6,7 +6,7 @@ const initialState = {}
 
 const stateKey = arr => cleanFalsy(arr).join('_')
 const getKeyByCaptureId = (captures = {}, captureId) =>
-  Object.keys(captures).find(key => captures[key].id === captureId)
+  Array.find(Object.keys(captures), key => captures[key].id === captureId)
 
 export function captures (state = initialState, action = {}) {
   const { payload = {}, type } = action


### PR DESCRIPTION
# Problem
I accidentally introduced an instance of `arr.find`, which IE11 does not support

# Solution
Replace `arr.find(x)` with `Array.find(arr, x)`, a prototype method that IE11 does support

## Checklist
- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [X] Have tests passed locally?
- [n/a] Have any new strings been translated?
