### PR TITLE
Added documentation for uploadFallback disabled option for face step

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,13 +377,23 @@ A number of options are available to allow you to customise the SDK:
 
   ### face ###
 
-  This is the face capture step. Users will be asked to capture their face in the form of a photo or a video. They will also have a chance to check the quality of the photos or video before confirming. A preferred variant can be requested for this step, by passing the option `requestedVariant: 'standard' | 'video'`. If empty, it will default to `standard` and a photo will be captured. If the `requestedVariant` is `video`, we will try to fulfil this request depending on camera availability and device/browser support. In case a video cannot be taken the face step will fallback to the `standard` option. At the end of the flow, the `onComplete` callback will return the `variant` used to capture face and this can be used to initiate the facial_similarity check.
+  This is the face capture step. Users will be asked to capture their face in the form of a photo or a video. They will also have a chance to check the quality of the photos or video before confirming.
 
   The custom options are:
-  - requestedVariant
+  - requestedVariant (string)
+   A preferred variant can be requested for this step, by passing the option `requestedVariant: 'standard' | 'video'`. If empty, it will default to `standard` and a photo will be captured. If the `requestedVariant` is `video`, we will try to fulfil this request depending on camera availability and device/browser support. In case a video cannot be taken the face step will fallback to the `standard` option. At the end of the flow, the `onComplete` callback will return the `variant` used to capture face and this can be used to initiate the facial_similarity check.
+
+  - uploadFallback (boolean)
+  By default, the SDK will try to take a live photo/video of the user. When this is not possible - because of lack of browser support or on mobile devices with no camera - the user will be presented with an upload fallback, where they will be able to select a selfie from their phone gallery.
+  The upload fallback for the the face step can be disabled by passing the option `uploadFallback: false`.
+
+  Warning: if the user is on a desktop with no camera or the camera is not functional, they will be forced to continue the flow on their mobile device. If the mobile does not have a camera or there is no camera browser support, _and_ the `uploadFallback` is set to `false`, the user **won't be able to complete the flow**.
+
+
   ```
     options: {
         requestedVariant: 'standard' | 'video'
+        uploadFallback: false
     }
   ```
 


### PR DESCRIPTION
# Problem
Currently, the feature that allows for disabling the upload fallback is not public.

# Solution
Add documentation for uploadFallback option on face step

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
