### PR TITLE
Fix footer button issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Changed
 - Internal: Changed the way that blob/base64 files and images are rendered and passed through the system
 - Internal: Changed CSS units to be consistently `em` (but still tied to `px` at our root, until we can fix our media queries)
-- Internal: Changed the way that the copyright footer is rendered to stay at the bottom of the page, for older `-webkit-box-flex` browsers
 - Public: More meaningful error message for upload fallback disabled on face step
 - Internal: Map colours and use less variables instead of hard-coding colour values
 - Internal: Rebranding of primary colors.
+- UI: Fixed issue with footer overlapping content, prevent buttons from disappearing below viewport, prevent images from overlapping buttons.
 
 ### Fixed
 - Public: Users entering the cross-device flow twice would have been able to request an SMS message without re-entering their mobile number correctly (the form could submit when still blank)

--- a/src/components/Confirm/CaptureViewer/style.css
+++ b/src/components/Confirm/CaptureViewer/style.css
@@ -17,7 +17,7 @@
 .videoWrapper {
   display: flex;
   position: relative;
-  height: 270px;
+  height: 53.35%;
   min-height: 90px;
   margin: 0 3rem 2rem;
 

--- a/src/components/Confirm/CaptureViewer/style.css
+++ b/src/components/Confirm/CaptureViewer/style.css
@@ -30,8 +30,12 @@
   position: static;
 }
 
+.pdfWrapper {
+  overflow: scroll;
+}
+
 .videoWrapper {
-  height: 306px;
+  height: 60.71%;
   margin-bottom: 4rem;
 }
 

--- a/src/components/Confirm/style.css
+++ b/src/components/Confirm/style.css
@@ -38,6 +38,7 @@
 
 .error {
   display: block;
+  margin-bottom: 8px;
   @media (--small-viewport) {
     font-size: 11px;
   }

--- a/src/components/Confirm/style.css
+++ b/src/components/Confirm/style.css
@@ -34,7 +34,6 @@
 
 .actions{
   padding: 0;
-  margin-bottom: 8px;
 }
 
 .error {

--- a/src/components/Confirm/style.css
+++ b/src/components/Confirm/style.css
@@ -34,6 +34,7 @@
 
 .actions{
   padding: 0;
+  margin-bottom: 8px;
 }
 
 .error {

--- a/src/components/Confirm/style.css
+++ b/src/components/Confirm/style.css
@@ -2,6 +2,7 @@
 
 .previewsContainer {
   width: 100%;
+  height: 100%;
   display: flex;
   flex: 1;
   flex-direction: column;

--- a/src/components/Error/style.css
+++ b/src/components/Error/style.css
@@ -8,7 +8,7 @@
   padding: 8px 16px 12px 16px;
   position: relative;
   @media (--small-viewport) {
-    margin: 0 16px;
+    margin: 0 16px 8px;
   }
 }
 

--- a/src/components/NavigationBar/style.css
+++ b/src/components/NavigationBar/style.css
@@ -1,16 +1,15 @@
 @import (less) "../Theme/constants.css";
 
-@navigation-all-padding: @navigation-padding-lg @navigation-padding-lg 0;
-
 .navigation {
+  @navigation-all-padding: @navigation-padding-top @navigation-padding-sides 0;
   height: @navigation-height;
   padding: @navigation-all-padding;
   text-align: left;
   box-sizing: content-box;
   @media (--small-viewport) {
+    @navigation-all-padding: @navigation-padding-top-sm-screen @navigation-padding-sides-sm-screen 0;
     height: @navigation-height-sm-screen;
-    padding-left: @navigation-padding-xs;
-    padding-top: @navigation-padding-sm;
+    padding: @navigation-all-padding;
   }
 }
 

--- a/src/components/NavigationBar/style.css
+++ b/src/components/NavigationBar/style.css
@@ -1,12 +1,16 @@
 @import (less) "../Theme/constants.css";
 
+@navigation-all-padding: @navigation-padding @navigation-padding 0;
+
 .navigation {
+  height: @navigation-height;
+  padding: @navigation-all-padding;
   text-align: left;
   box-sizing: content-box;
   @media (--small-viewport) {
-    height: 38*@unit;
-    padding-left: 8*@unit;
-    padding-top: 10*@unit;
+    height: @navigation-height-sm-screen;
+    padding-left: @navigation-padding-xs;
+    padding-top: @navigation-padding-sm;
   }
 }
 

--- a/src/components/NavigationBar/style.css
+++ b/src/components/NavigationBar/style.css
@@ -1,8 +1,6 @@
 @import (less) "../Theme/constants.css";
 
 .navigation {
-  height: 32*@unit;
-  padding: 16*@unit 16*@unit 0;
   text-align: left;
   box-sizing: content-box;
   @media (--small-viewport) {

--- a/src/components/NavigationBar/style.css
+++ b/src/components/NavigationBar/style.css
@@ -1,6 +1,6 @@
 @import (less) "../Theme/constants.css";
 
-@navigation-all-padding: @navigation-padding @navigation-padding 0;
+@navigation-all-padding: @navigation-padding-lg @navigation-padding-lg 0;
 
 .navigation {
   height: @navigation-height;

--- a/src/components/Theme/constants.css
+++ b/src/components/Theme/constants.css
@@ -17,14 +17,19 @@
 
 @large-text-margin: 40*@unit;
 @small-text-margin: 24*@unit;
+@padding-lg: 16*@unit;
+@padding-sm: 10*@unit;
+@padding-xs: 8*@unit;
 
 @footer-height: 32*@unit;
 @footer-margin: 16*@unit;
 @navigation-height: 32*@unit;
 @navigation-height-sm-screen: 38*@unit;
-@navigation-padding-lg: 16*@unit;
-@navigation-padding-sm: 10*@unit;
-@navigation-padding-xs: 8*@unit;
+@navigation-padding-top: @padding-lg;
+@navigation-padding-sides: @padding-lg;
+@navigation-padding-top-sm-screen: @padding-sm;
+@navigation-padding-sides-sm-screen: @padding-xs;
+
 
 @color-primary-500: #353FF4;
 

--- a/src/components/Theme/constants.css
+++ b/src/components/Theme/constants.css
@@ -18,6 +18,14 @@
 @large-text-margin: 40*@unit;
 @small-text-margin: 24*@unit;
 
+@footer-height: 32*@unit;
+@footer-margin: 16*@unit;
+@navigation-height: 32*@unit;
+@navigation-height-sm-screen: 38*@unit;
+@navigation-padding-lg: 16*@unit;
+@navigation-padding-sm: 10*@unit;
+@navigation-padding-xs: 8*@unit;
+
 @color-primary-500: #353FF4;
 
 /* Solid colors */

--- a/src/components/Theme/style.css
+++ b/src/components/Theme/style.css
@@ -40,6 +40,7 @@
   position: relative;
   display: flex;
   overflow: scroll;
+  -webkit-overflow-scrolling: touch;
   > * {
     flex-grow: 1;
   }

--- a/src/components/Theme/style.css
+++ b/src/components/Theme/style.css
@@ -32,8 +32,8 @@
   flex: 0 0 auto;
 }
 
-@non-content-height: calc(@footer-height + @footer-margin + @navigation-height + @navigation-padding);
-@non-content-height-sm: calc(@footer-height + @footer-margin + @navigation-height-sm-screen + @navigation-padding-sm)
+@non-content-height: calc(@footer-height + @footer-margin + @navigation-height + @navigation-padding-lg);
+@non-content-height-sm: calc(@footer-height + @footer-margin + @navigation-height-sm-screen + @navigation-padding-sm);
 .content {
   /* Content height is 100% - non content height (total height of footer + total height of navbar)  */
   height: calc(100% - @non-content-height);

--- a/src/components/Theme/style.css
+++ b/src/components/Theme/style.css
@@ -1,4 +1,11 @@
 @import (less) "./constants.css";
+@footer-height: 32*@unit;
+@footer-margin: 16*@unit;
+@navbar-height: 32*@unit;
+@navbar-padding: 16*@unit;
+@navbar-all-padding: @navbar-padding @navbar-padding 0;
+@non-content-height: calc(@footer-height + @footer-margin + @navbar-height + @navbar-padding);
+
 
 .step {
   width: 100%;
@@ -29,12 +36,14 @@
 }
 
 .navigationBar{
+  height: @navbar-height;
+  padding: @navbar-all-padding;
   flex: 0 0 auto;
 }
 
 .content {
-  /* Content height is 100% - 96px (height of footer + height of navbar)  */
-  height: calc(100% - 96px);
+  /* Content height is 100% - non content height (total height of footer + total height of navbar)  */
+  height: calc(100% - @non-content-height);
   flex: 1 0 auto;
   position: relative;
   display: flex;
@@ -50,7 +59,7 @@
 
 .footer {
   width: 100%;
-  height: 32*@unit;
+  height: @footer-height;
   margin-top: 16*@unit;
   flex: 0 0 auto;
 

--- a/src/components/Theme/style.css
+++ b/src/components/Theme/style.css
@@ -33,13 +33,9 @@
 }
 
 .content {
+  /* Content height is 100% - 96px (height of footer + height of navbar)  */
+  height: calc(100% - 96px);
   flex: 1 0 auto;
-  /* We want `flex-grow: 1` for modern browsers, but older `-webkit-box-flex`
-     browsers are really buggy with their equivalent! So we opt for a slightly
-     inferior, but less buggy experience of turning off flex-grow entirely for
-     these older browsers, specifically. */
-  -webkit-box-flex: 0;
-
   position: relative;
   display: flex;
   > * {
@@ -66,6 +62,11 @@
   .fullScreenStep & {
     /* A full screen step will be a video/stream step, with a darker background */
     background-image: url('assets/powered-by-onfido-light.svg');
+  }
+
+  /* hide the footer if view height is too small */
+  @media (max-height: 420px) {
+    z-index: -1;
   }
 }
 

--- a/src/components/Theme/style.css
+++ b/src/components/Theme/style.css
@@ -38,6 +38,7 @@
   flex: 1 0 auto;
   position: relative;
   display: flex;
+  overflow: scroll;
   > * {
     flex-grow: 1;
   }
@@ -62,11 +63,6 @@
   .fullScreenStep & {
     /* A full screen step will be a video/stream step, with a darker background */
     background-image: url('assets/powered-by-onfido-light.svg');
-  }
-
-  /* hide the footer if view height is too small */
-  @media (max-height: 420px) {
-    z-index: -1;
   }
 }
 

--- a/src/components/Theme/style.css
+++ b/src/components/Theme/style.css
@@ -32,10 +32,9 @@
   flex: 0 0 auto;
 }
 
-@non-content-height: calc(@footer-height + @footer-margin + @navigation-height + @navigation-padding-lg);
-@non-content-height-sm: calc(@footer-height + @footer-margin + @navigation-height-sm-screen + @navigation-padding-sm);
 .content {
   /* Content height is 100% - non content height (total height of footer + total height of navbar)  */
+  @non-content-height: calc(@footer-height + @footer-margin + @navigation-height + @navigation-padding-top);
   height: calc(100% - @non-content-height);
   flex: 1 0 auto;
   position: relative;
@@ -45,7 +44,8 @@
     flex-grow: 1;
   }
   @media (--small-viewport) {
-    height: calc(100% - @non-content-height-sm);
+    @non-content-height: calc(@footer-height + @footer-margin + @navigation-height-sm-screen + @navigation-padding-top-sm-screen);
+    height: calc(100% - @non-content-height);
   }
 }
 

--- a/src/components/Theme/style.css
+++ b/src/components/Theme/style.css
@@ -1,11 +1,4 @@
 @import (less) "./constants.css";
-@footer-height: 32*@unit;
-@footer-margin: 16*@unit;
-@navbar-height: 32*@unit;
-@navbar-padding: 16*@unit;
-@navbar-all-padding: @navbar-padding @navbar-padding 0;
-@non-content-height: calc(@footer-height + @footer-margin + @navbar-height + @navbar-padding);
-
 
 .step {
   width: 100%;
@@ -36,11 +29,11 @@
 }
 
 .navigationBar{
-  height: @navbar-height;
-  padding: @navbar-all-padding;
   flex: 0 0 auto;
 }
 
+@non-content-height: calc(@footer-height + @footer-margin + @navigation-height + @navigation-padding);
+@non-content-height-sm: calc(@footer-height + @footer-margin + @navigation-height-sm-screen + @navigation-padding-sm)
 .content {
   /* Content height is 100% - non content height (total height of footer + total height of navbar)  */
   height: calc(100% - @non-content-height);
@@ -50,6 +43,9 @@
   overflow: scroll;
   > * {
     flex-grow: 1;
+  }
+  @media (--small-viewport) {
+    height: calc(100% - @non-content-height-sm);
   }
 }
 


### PR DESCRIPTION
# Problem
This [PR](https://github.com/onfido/onfido-sdk-ui/pull/559/) was supposed to fix the following issue
<img width="363" alt="screen shot 2019-02-12 at 18 25 52" src="https://user-images.githubusercontent.com/7127427/52660419-897d4980-2ef7-11e9-8064-fd3061890b3f.png">
It caused the following issues:
**Footer and buttons pushed below the viewport**
<img width="298" alt="screen shot 2019-02-12 at 18 28 12" src="https://user-images.githubusercontent.com/7127427/52660603-f1339480-2ef7-11e9-9c43-fda363c81abd.png">

**Footer and CTA do not stick at the bottom on older devices** 


<img width="332" alt="screen shot 2019-02-12 at 18 59 51" src="https://user-images.githubusercontent.com/7127427/52660883-9484a980-2ef8-11e9-911f-10331298b322.png">

# Solution
Having a fix height for the `.imageWrapper` is not ideal because old devices have got smaller screen sizes and in some cases do not fully support flexbox. 
In this PR, I used relative height for the imageWrapper using `%` units. In order to make it work, I set the parent `.previewsContainer` height to 100%, and its parent`.content` to have a calculated div of 100% - 96px (which is the height of the navbar + the height of the footer). It's not beautiful but it works everywhere.

Also, I've decided to bring back the HACK removed in the previous PR, which hides the footer if the window is shrunk below a certain height.

## Possible improvements:
-  ~~Assign navbar height and footer height to a variable and pass it to the calc()~~ Done

<img width="323" alt="screen shot 2019-02-12 at 18 45 03" src="https://user-images.githubusercontent.com/7127427/52660946-c138c100-2ef8-11e9-911d-0cef48f49c87.png">


## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [x] Have tests passed locally?
- [ ] Have any new strings been translated?
