### PR TITLE
Hide scrollbar on Edge

### DIFF
--- a/src/components/Theme/style.css
+++ b/src/components/Theme/style.css
@@ -41,6 +41,7 @@
   display: flex;
   overflow: scroll;
   -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: none;
   > * {
     flex-grow: 1;
   }


### PR DESCRIPTION
# Problem
Scroll bar is visible on Edge
![screenshot 2019-02-25 at 15 38 19](https://user-images.githubusercontent.com/7127427/53348725-83359700-3913-11e9-914a-48af436db2f2.png)

# Solution
There should be no visible scroll bar
![screenshot 2019-02-25 at 15 43 51](https://user-images.githubusercontent.com/7127427/53349142-58980e00-3914-11e9-8911-0d487b77e79d.png)


## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [x] Have tests passed locally?
- [ ] Have any new strings been translated?
