### PR TITLE
Feature/disable doc upload#cx 3018

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Added
 - Public: Prepopulate the user's mobile phone number, when specified through the `userDetails.smsNumber` option
 - Public: Send through details (such as `id`s) of the uploaded files, in the `onComplete` event
-- Public: Upload fallback for the `face` step can be disabled by using the option `{ uploadFallback: false }`. The default value is `true`.
+- Public: Added `forceCrossDevice` option to `document` step. The feature forces users to use their mobile to capture the document image. It defaults to `false`. Not available on the Proof of Address flow.
 - Internal: Add an internal-only warning for internal-users of the cross-device flow (a warning entirely stripped in production)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ A number of options are available to allow you to customise the SDK:
   }
   ```
   - forceCrossDevice (boolean - default: `false`)
-  When set to `true`, users will be forced to use their mobile devices to capture the document image. They will be able to do so via the built-in SMS feature.
+  When set to `true`, desktop users will be forced to use their mobile devices to capture the document image. They will be able to do so via the built-in SMS feature. Use this option if you want to prevent file upload from desktops.
 
   ```
     options: {

--- a/README.md
+++ b/README.md
@@ -352,6 +352,14 @@ A number of options are available to allow you to customise the SDK:
      }
   }
   ```
+  - forceCrossDevice (boolean - default: `false`)
+  When set to `true`, users will be forced to use their mobile devices to capture the document image. They will be able to do so via the built-in SMS feature.
+
+  ```
+    options: {
+      forceCrossDevice: true
+    }
+  ```
 
   ### poa ###
 

--- a/src/components/Capture/Document.js
+++ b/src/components/Capture/Document.js
@@ -16,6 +16,7 @@ import style from './style.css'
 class Document extends Component {
   static defaultProps = {
     side: 'front',
+    forceCrossDevice: false
   }
 
   handleCapture = payload => {

--- a/src/components/Capture/index.js
+++ b/src/components/Capture/index.js
@@ -11,4 +11,4 @@ export const FrontDocumentCapture = appendToTracking(withOptions(Document), 'fro
 export const BackDocumentCapture = appendToTracking(withOptions(Document, { side: 'back' }), 'back_capture')
 export const SelfieCapture = appendToTracking(withOptions(Face, { requestedVariant: 'standard' }), 'selfie_capture')
 export const VideoCapture = appendToTracking(withOptions(Face, { requestedVariant: 'video' }), 'video_capture')
-export const PoADocumentCapture = appendToTracking(Document, 'poa')
+export const PoADocumentCapture = appendToTracking(withOptions(Document, { forceCrossDevice: false }), 'poa')

--- a/src/components/Capture/withCrossDeviceWhenNoCamera.js
+++ b/src/components/Capture/withCrossDeviceWhenNoCamera.js
@@ -8,7 +8,7 @@ export default WrappedComponent =>
     }
 
     componentWillUpdate(nextProps) {
-      const propsWeCareAbout = ["useWebcam", "hasCamera", "allowCrossDeviceFlow"]
+      const propsWeCareAbout = ["useWebcam", "hasCamera", "allowCrossDeviceFlow", "forceCrossDevice"]
       const propsHaveChanged = propsWeCareAbout
         .some(propKey => nextProps[propKey] !== this.props[propKey])
 
@@ -18,10 +18,10 @@ export default WrappedComponent =>
     }
 
     attemptForwardToCrossDevice = (props = this.props) => {
-      const { useWebcam, hasCamera, allowCrossDeviceFlow, changeFlowTo } = props
-      const shouldAttempt = useWebcam && allowCrossDeviceFlow
+      const { useWebcam, hasCamera, forceCrossDevice, allowCrossDeviceFlow, changeFlowTo } = props
+      const shouldUseCamera = useWebcam && hasCamera === false
 
-      if (shouldAttempt && hasCamera === false) {
+      if (allowCrossDeviceFlow && (shouldUseCamera || forceCrossDevice)) {
         changeFlowTo('crossDeviceSteps', 0, true)
       }
     }

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -35,7 +35,8 @@ const steps = [
     type:'document',
     options: {
       useWebcam: queryStrings.useWebcam === "true",
-      documentTypes: {}
+      documentTypes: {},
+      forceCrossDevice: queryStrings.forceCrossDevice === "true"
     }
   },
   {

--- a/test/features/page_objects/sdk.rb
+++ b/test/features/page_objects/sdk.rb
@@ -128,3 +128,7 @@ end
 Given(/^I navigate to the SDK using liveness(?:| with "([^"]*)"?)$/) do |locale_tag|
   open_sdk(@driver, { 'liveness' => true, 'language' => locale_tag })
 end
+
+Given(/^I navigate to the SDK with forceCrossDevice feature enabled/) do
+  open_sdk(@driver, { 'forceCrossDevice' => true, 'useWebcam' => false })
+end

--- a/test/features/sdk_flow.feature
+++ b/test/features/sdk_flow.feature
@@ -237,8 +237,3 @@ Feature: SDK File Upload Tests
       Then I should see 3 document_select_buttons ()
       When I click on passport ()
       Then page_title should include translation for "cross_device.intro.document.title"
-
-      Examples:
-        | locale |
-        |        |
-        | es     |

--- a/test/features/sdk_flow.feature
+++ b/test/features/sdk_flow.feature
@@ -229,3 +229,16 @@ Feature: SDK File Upload Tests
         | type | locale |
         |      |        |
         | pdf  | es     |
+
+
+    Scenario Outline: I should be taken to the cross-device flow if forceCrossDevice option is enabled
+      Given I navigate to the SDK with forceCrossDevice feature enabled
+      When I click on primary_button ()
+      Then I should see 3 document_select_buttons ()
+      When I click on passport ()
+      Then page_title should include translation for "cross_device.intro.document.title"
+
+      Examples:
+        | locale |
+        |        |
+        | es     |


### PR DESCRIPTION
# Problem
In some cases, clients might want to prevent users from uploading a pre-captured image of their documents. They want to be able to force their user to use the cross device flow where they will be to take a photo of the document using their mobile devices.

# Solution
Added a configuration parameter on the document step called `forceCrossDevice`. It defaults to `false`. When set to `true`, after a user has selected a document type, they will see the cross device intro screen.
The configuration should not affect the Proof of Address flow. The mobile experience remains the same.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [x] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [x] Have tests passed locally?
- [ ] Have any new strings been translated?
