### PR TITLE
Only use overflow scroll for non fullscreen content

### DIFF
--- a/src/components/Router/StepsRouter.js
+++ b/src/components/Router/StepsRouter.js
@@ -28,7 +28,8 @@ class StepsRouter extends Component {
       <div className={classNames(theme.step,{[theme.fullScreenStep]: isFullScreen})}>
         <NavigationBar back={back} disabled={disableNavigation} className={theme.navigationBar}/>
         <div className={classNames(theme.content,{
-          [theme.fullScreenContentWrapper]: isFullScreen
+          [theme.fullScreenContentWrapper]: isFullScreen,
+          [theme.scrollableContent]: !isFullScreen
         })}>
           <CurrentComponent {...{...options, ...globalUserOptions, ...otherProps, back}}
             trackScreen={this.trackScreen} />

--- a/src/components/Theme/style.css
+++ b/src/components/Theme/style.css
@@ -39,7 +39,6 @@
   flex: 1 0 auto;
   position: relative;
   display: flex;
-  overflow: scroll;
   -webkit-overflow-scrolling: touch;
   -ms-overflow-style: none;
   > * {
@@ -49,6 +48,10 @@
     @non-content-height: @footer-height + @footer-margin + @navigation-height-sm-screen + @navigation-padding-top-sm-screen;
     height: calc(100% - @non-content-height);
   }
+}
+
+.scrollableContent {
+  overflow: scroll;
 }
 
 .fullScreenContentWrapper {


### PR DESCRIPTION
# Problem
On iPhone SE, when you enlarge an image, the image is not full screen. See screenshot below, example of a black image:
![Screen Shot 2019-03-07 at 09 37 57](https://user-images.githubusercontent.com/7127427/54194003-24dfeb00-44b3-11e9-9919-bc685c991728.png)

# Solution
Only use `overflow: scroll` for non fullscreen content. Result below:
<img width="424" alt="Screen Shot 2019-03-12 at 10 46 23" src="https://user-images.githubusercontent.com/7127427/54194413-1cd47b00-44b4-11e9-9bc0-b4af4bd28451.png">

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?

