### PR TITLE
Fix issue with selfie and autocapture on Edge

### DIFF
--- a/src/components/Photo/DocumentAutoCapture.js
+++ b/src/components/Photo/DocumentAutoCapture.js
@@ -89,7 +89,7 @@ export default class DocumentAutoCapture extends Component<Props, State> {
     this.props.onError()
   }
 
-  createWebcamRef = async(ref) => {
+  createWebcamRef = async(ref: React.Ref<typeof Camera>) => {
     this.webcam = await ref
     if (this.webcam) {
       this.start()

--- a/src/components/Photo/DocumentAutoCapture.js
+++ b/src/components/Photo/DocumentAutoCapture.js
@@ -37,7 +37,7 @@ export default class DocumentAutoCapture extends Component<Props, State> {
     hasError: false,
   }
 
-  componentDidMount() {
+  componentDidMount () {
     this.start()
   }
 

--- a/src/components/Photo/DocumentAutoCapture.js
+++ b/src/components/Photo/DocumentAutoCapture.js
@@ -37,15 +37,17 @@ export default class DocumentAutoCapture extends Component<Props, State> {
     hasError: false,
   }
 
+  componentDidMount() {
+    this.start()
+  }
+
   componentWillUnmount () {
     this.stop()
   }
 
   screenshot = () => {
     if (this.captureIds.length < maxAttempts) {
-      const id = randomId()
-      this.captureIds.push(id)
-      screenshot(this.webcam, blob => this.handleScreenshotBlob(blob, id))
+      screenshot(this.webcam, blob => this.handleScreenshotBlob(blob))
     } else {
       console.warn('Screenshotting is slow, waiting for responses before uploading more')
     }
@@ -60,15 +62,19 @@ export default class DocumentAutoCapture extends Component<Props, State> {
     Visibility.stop(this.interval)
   }
 
-  handleScreenshotBlob = (blob: Blob, id: string) => blobToLossyBase64(blob,
-    base64 => this.handleScreenshot(blob, base64, id),
+  handleScreenshotBlob = (blob: Blob) => blobToLossyBase64(blob,
+    base64 => this.handleScreenshot(blob, base64),
     error => console.error('Error converting screenshot to base64', error),
     { maxWidth: 200 })
 
-  handleScreenshot = (blob: Blob, base64: string, id: string) => {
-    this.validate(base64, id, valid =>
-      valid ? this.props.onValidCapture({ blob, base64, id }) : null
-    )
+  handleScreenshot = (blob: Blob, base64: string) => {
+    if (base64) {
+      const id = randomId()
+      this.captureIds.push(id)
+      this.validate(base64, id, valid =>
+        valid ? this.props.onValidCapture({ blob, base64, id }) : null
+      )
+    }
   }
 
   validate = (base64: string, id: string, callback: Function) => {
@@ -89,13 +95,6 @@ export default class DocumentAutoCapture extends Component<Props, State> {
     this.props.onError()
   }
 
-  createWebcamRef = async(ref: React.Ref<typeof Camera>) => {
-    this.webcam = await ref
-    if (this.webcam) {
-      this.start()
-    }
-  }
-
   render() {
     const { hasError } = this.state
     const { trackScreen, renderFallback } = this.props
@@ -103,7 +102,7 @@ export default class DocumentAutoCapture extends Component<Props, State> {
       <div>
         <Camera
           {...this.props}
-          webcamRef={ this.createWebcamRef }
+          webcamRef={ c => this.webcam = c }
           renderError={ hasError ?
             <CameraError
               error={serverError}

--- a/src/components/Photo/DocumentAutoCapture.js
+++ b/src/components/Photo/DocumentAutoCapture.js
@@ -37,10 +37,6 @@ export default class DocumentAutoCapture extends Component<Props, State> {
     hasError: false,
   }
 
-  componentDidMount () {
-    this.start()
-  }
-
   componentWillUnmount () {
     this.stop()
   }
@@ -93,6 +89,13 @@ export default class DocumentAutoCapture extends Component<Props, State> {
     this.props.onError()
   }
 
+  createWebcamRef = async(ref) => {
+    this.webcam = await ref
+    if (this.webcam) {
+      this.start()
+    }
+  }
+
   render() {
     const { hasError } = this.state
     const { trackScreen, renderFallback } = this.props
@@ -100,7 +103,7 @@ export default class DocumentAutoCapture extends Component<Props, State> {
       <div>
         <Camera
           {...this.props}
-          webcamRef={ c => this.webcam = c }
+          webcamRef={ this.createWebcamRef }
           renderError={ hasError ?
             <CameraError
               error={serverError}

--- a/src/components/Photo/Selfie.js
+++ b/src/components/Photo/Selfie.js
@@ -55,11 +55,8 @@ export default class Selfie extends Component<Props, State> {
     }))
   }
 
-  takeSnapshot = async() => {
-    const webcam = await this.webcam
-    if (webcam) {
-      screenshot(this.webcam, this.handleSnapshot)
-    }
+  takeSnapshot = () => {
+    this.webcam && screenshot(this.webcam, this.handleSnapshot)
   }
 
   takeSelfie = () => screenshot(this.webcam, this.handleSelfie)

--- a/src/components/Photo/Selfie.js
+++ b/src/components/Photo/Selfie.js
@@ -55,8 +55,12 @@ export default class Selfie extends Component<Props, State> {
     }))
   }
 
-  takeSnapshot = () =>
-    this.webcam && screenshot(this.webcam, this.handleSnapshot)
+  takeSnapshot = async() => {
+    const webcam = await this.webcam
+    if (webcam) {
+      screenshot(this.webcam, this.handleSnapshot)
+    }
+  }
 
   takeSelfie = () => screenshot(this.webcam, this.handleSelfie)
 

--- a/src/components/Photo/Selfie.js
+++ b/src/components/Photo/Selfie.js
@@ -55,9 +55,8 @@ export default class Selfie extends Component<Props, State> {
     }))
   }
 
-  takeSnapshot = () => {
+  takeSnapshot = () =>
     this.webcam && screenshot(this.webcam, this.handleSnapshot)
-  }
 
   takeSelfie = () => screenshot(this.webcam, this.handleSelfie)
 

--- a/src/components/utils/blob.js
+++ b/src/components/utils/blob.js
@@ -26,7 +26,29 @@ const blobToCanvas = (blob, callback, errorCallback, options) => {
   }, { maxWidth, maxHeight, orientation })
 }
 
-export const canvasToBlob = (canvas, callback) => canvas.toBlob(callback, "image/png")
+const decodeBase64 = (image) => {
+  const byteString  = atob(image.split(',')[1])
+  const mimeString = image.split(',')[0].split(':')[1].split(';')[0]
+  let integerArray = new Uint8Array(byteString.length)
+  for (let i = 0; i < byteString.length; i++) {
+    integerArray[i] = byteString.charCodeAt(i)
+  }
+  return { integerArray, mimeString }
+}
+
+const base64toBlob = (image) => {
+  const base64Data = decodeBase64(image)
+  return new Blob([base64Data.integerArray], {type: base64Data.mimeString})
+}
+
+export const canvasToBlob = (canvas, callback) => {
+  if (!HTMLCanvasElement.prototype.toBlob) {
+    // Handle browsers that do not support canvas.toBlob() like Edge
+    const dataUrlImg = canvas.toDataURL()
+    return callback(base64toBlob(dataUrlImg))
+  }
+  return canvas.toBlob(callback, "image/png")
+}
 
 const toDataUrl = type => (canvas, callback) => callback(canvas.toDataURL(type))
 const browserSupportedLossyFormat = `image/${supportsWebP ? 'webp':'jpeg'}`


### PR DESCRIPTION
# Problem
This PR #545 introduced a regression in `development` branch where trying to take a selfie or to capture a document using the autocapture feature on Edge was not working. The console was showing the following error `Object doesn't support property or method 'toBlob'`.

# Solution
Handle browsers that do not support `HTMLCanvasElement.prototype.toBlob` by converting the canvas to base64 and the base64 into `Blob`. This code was previously in `development` but it was mistakenly removed as part of PR #545.

Bonus: Added `await/async` on functions that require the webcam to be available in order to prevent screenshot from firing when webcam is not available.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [x] Have tests passed locally?
- [ ] Have any new strings been translated?
