### PR TITLE
Fix/highest css specificity custom input cx 2570

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/). Breaking chan
 This project adheres to the Node [default version scheme](https://docs.npmjs.com/misc/semver).
 
 ## [Next version]
+### Fixed
+- Public: Fixed issue where the user is prompted to submit the same document capture twice and fixed broken custom input UI by adding higher CSS specificity
+
+## TODO: replace this with title of release 4.0.0, currently in progress
 
 ### Added
 - Public: Prepopulate the user's mobile phone number, when specified through the `userDetails.smsNumber` option

--- a/src/components/CustomFileInput/index.js
+++ b/src/components/CustomFileInput/index.js
@@ -45,6 +45,9 @@ export default class CustomFileInput extends Component<Props> {
           type="file"
           className={style.input}
           ref={ ref => this.input = ref }
+          // This input should always be hidden.
+          // Highest specificity added to prevent the host app from overriding this style by mistake 
+          style={{display: 'none'}}
           onChange={this.handleChange}
           {...other}
         />

--- a/src/components/CustomFileInput/index.js
+++ b/src/components/CustomFileInput/index.js
@@ -46,7 +46,7 @@ export default class CustomFileInput extends Component<Props> {
           className={style.input}
           ref={ ref => this.input = ref }
           // This input should always be hidden.
-          // Highest specificity added to prevent the host app from overriding this style by mistake 
+          // Highest specificity added to prevent the host app from overriding this style by mistake
           style={{display: 'none'}}
           onChange={this.handleChange}
           {...other}

--- a/src/components/CustomFileInput/index.js
+++ b/src/components/CustomFileInput/index.js
@@ -45,9 +45,6 @@ export default class CustomFileInput extends Component<Props> {
           type="file"
           className={style.input}
           ref={ ref => this.input = ref }
-          // This input should always be hidden.
-          // Highest specificity added to prevent the host app from overriding this style by mistake
-          style={{display: 'none'}}
           onChange={this.handleChange}
           {...other}
         />

--- a/src/components/CustomFileInput/style.css
+++ b/src/components/CustomFileInput/style.css
@@ -6,6 +6,9 @@
 .input {
   bottom: 0;
   left: 0;
+  /* This input should always be hidden.
+  Highest specificity added to prevent the host app from overriding this style by mistake */
+  display: none !important;
   position: absolute;
   right: 0;
   top: 0;

--- a/src/components/CustomFileInput/style.css
+++ b/src/components/CustomFileInput/style.css
@@ -6,7 +6,6 @@
 .input {
   bottom: 0;
   left: 0;
-  display: none;
   position: absolute;
   right: 0;
   top: 0;


### PR DESCRIPTION
# Problem
Some clients have reported that they are prompted to submit a document image twice and that the input style is broken. See image below
<img width="344" alt="Screen Shot 2019-03-13 at 17 44 33" src="https://user-images.githubusercontent.com/7127427/54301901-c2bcde00-45b7-11e9-9197-044bab37c17b.png">

# Solution
The issue is due to the fact that sometimes the style of the input are overridden by the host app. My first solution was to add inline styles but if the client host app uses `input { display:  block !important; }` our custom input will inherit the style of the host app, and it will break. Therefore, the best solution for this particular case is to use `!important` to make it less likely for the input style to break.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [x] Have tests passed locally?
- [ ] Have any new strings been translated?
