### PR TITLE
On android chrome the video height overrides buttons

### DIFF
--- a/src/components/Confirm/CaptureViewer/style.css
+++ b/src/components/Confirm/CaptureViewer/style.css
@@ -35,6 +35,7 @@
 
 .videoWrapper {
   margin-bottom: 64*@unit;
+  flex: 1;
 }
 
 .pdfWrapper {


### PR DESCRIPTION
# Problem
<img width="414" alt="Screen Shot 2019-03-18 at 11 23 26" src="https://user-images.githubusercontent.com/7127427/54529737-b0a4bc00-4978-11e9-8108-3cfd84214239.png">


# Solution
Added `flex: 1;`
<img width="416" alt="Screen Shot 2019-03-18 at 11 22 47" src="https://user-images.githubusercontent.com/7127427/54529775-ce722100-4978-11e9-97cd-277fbbf1d3b6.png">



## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [x] Have tests passed locally?
- [ ] Have any new strings been translated?
