### PR TITLE
Fix small typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ A number of options are available to allow you to customise the SDK:
   The SDK can also be displayed in a custom language by passing an object containing the locale tag and the custom phrases.
   The object should include the following keys:
     - `locale`: A locale tag. This is **required** when providing phrases for an unsupported language.
-      You can also use this to partially customise the strings of a supported language (ie. Spanish), by passing a supported language locale tag (ie. `es`). For missing keys, a warning and an array containing the missing keys will be returned on the console. The values for the missing keys will be displayed in the language specified within the locale tag if supported, otherwise they will be displayed in English.
+      You can also use this to partially customise the strings of a supported language (e.g. Spanish), by passing a supported language locale tag (e.g. `es`). For missing keys, a warning and an array containing the missing keys will be returned on the console. The values for the missing keys will be displayed in the language specified within the locale tag if supported, otherwise they will be displayed in English.
       The locale tag is also used to override the language of the SMS body for the cross device feature. This feature is owned by Onfido and is currently only supporting English and Spanish.
 
     - `phrases` (required) : An object containing the keys you want to override and the new values. The keys can be found in [`/src/locales/en.json`](/src/locales/en.json). They can be passed as a nested object or as a string using the dot notation for nested values. See the examples below.

--- a/README.md
+++ b/README.md
@@ -193,13 +193,13 @@ Congratulations! You have successfully started the flow. Carry on reading the ne
 - **`onModalRequestClose {Function} optional`**
 
   Callback that fires when the user attempts to close the modal.
-  It is your responsability to decide then to close the modal or not
+  It is your responsibility to decide then to close the modal or not
    by changing the property `isModalOpen`.
 
 
 ## Removing SDK
 
-If you are embedding the SDK inside a single page app, you can call the `tearDown` function to remove the SDK complelety from the current webpage. It will reset state and you can safely re-initialise the SDK inside the same webpage later on.
+If you are embedding the SDK inside a single page app, you can call the `tearDown` function to remove the SDK completely from the current webpage. It will reset state and you can safely re-initialise the SDK inside the same webpage later on.
 
 ```javascript
 onfidoOut = Onfido.init({...})
@@ -260,7 +260,7 @@ A number of options are available to allow you to customise the SDK:
 
 - **`language {String || Object} optional`**
   The SDK language can be customised by passing a String or an Object. At the moment, we support and maintain translations for English (default) and Spanish, using respectively the following locale tags: `en`, `es`.
-  To leverege one of these two languages, the `language` option should be passed as a string containing a supported language tag.
+  To leverage one of these two languages, the `language` option should be passed as a string containing a supported language tag.
 
   Example:
   ```javascript
@@ -445,7 +445,7 @@ The new options will be shallowly merged with the previous one. So one can pass 
 
 This SDK’s aim is to help with the document capture process. It does not actually perform the full document/face checks against our [API](https://documentation.onfido.com/).
 
-In order to perform a full document/face check, you need to call our [API](https://documentation.onfido.com/) to create a check for the applicant on your backend
+In order to perform a full document/face check, you need to call our [API](https://documentation.onfido.com/) to create a check for the applicant on your backend.
 
 ### 1. Creating a check
 


### PR DESCRIPTION
# Problem

Small typos in the README

# Solution

Fix typos

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [Y] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [N/A] Have new automated tests been implemented?
- [N/A] Have new manual tests been written down?
- [N/A] Have tests passed locally?
- [N/A] Have any new strings been translated?
