### PR TITLE
added onStepChange prop and bound to events

### DIFF
--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -218,6 +218,7 @@ class HistoryRouter extends Component {
   }
 
   onHistoryChange = ({state:historyState}) => {
+    this.props.options.events.emit('stepChange', historyState);
     this.setState({...historyState})
   }
 
@@ -291,8 +292,6 @@ class HistoryRouter extends Component {
       step: newStepIndex,
       flow: newFlow || currentFlow,
     }
-
-    this.props.options.events.emit('stepChange', newFlow || currentFlow)
 
     if (excludeStepFromHistory) {
       this.setState(newState)

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -291,6 +291,9 @@ class HistoryRouter extends Component {
       step: newStepIndex,
       flow: newFlow || currentFlow,
     }
+
+    this.props.options.events.emit('stepChange', newFlow || currentFlow)
+
     if (excludeStepFromHistory) {
       this.setState(newState)
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -80,6 +80,15 @@ const rebindOnComplete = (oldOptions, newOptions) => {
   bindOnComplete(newOptions)
 }
 
+const bindOnStepChange = ({onComplete}) => {
+  events.on('stepChange', onComplete)
+}
+
+const rebindOnStepChange = (oldOptions, newOptions) => {
+  events.off('stepChange', oldOptions.onStepChange)
+  bindOnStepChange(newOptions)
+}
+
 const noOp = ()=>{}
 
 const defaults = {
@@ -142,6 +151,7 @@ export const init = (opts) => {
       const oldOptions = this.options
       this.options = formatOptions({...this.options,...changedOptions});
       rebindOnComplete(oldOptions, this.options);
+      rebindOnStepChange(oldOptions, this.options);
       this.element = onfidoRender( this.options, containerEl, this.element )
       return this.options;
     },


### PR DESCRIPTION
# Problem
When utilizing the SDK, it would be nice to be able to know the step of the UI flow.

# Solution
Added a callback prop for stepChange

NOTE this is a naive solution and I have not been able to bootstrap the app with superstatic. I would like to consult with your team to see if this is an easy feature to add.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
