### PR TITLE
Safe woopra, fix for IE11

### DIFF
--- a/src/Tracker/safeWoopra.js
+++ b/src/Tracker/safeWoopra.js
@@ -6,7 +6,16 @@ the global window object.
 */
 
 function SafeWindow () {
-  Object.keys(window).forEach(key => {
+  /*
+  For loop is being used instead of Object.keys()
+  This is because depending on the browser,
+  certain apis are part of the prototype,
+  rather than the Window instance
+
+  IE11 is one of the browsers that needs the for loop
+  */
+  /* eslint-disable guard-for-in */
+  for (const key in window) {
     Object.defineProperty(this, key,
       { get: () => {
         const value = window[key]
@@ -16,11 +25,12 @@ function SafeWindow () {
         if (key === "window") return this
         return value
       },
-        set: value=>{ window[key] = value }
+        set: value => { window[key] = value }
       }
     )
-  })
+  }
 }
+
 SafeWindow.prototype = Window.prototype;
 
 // We create a global instance of safe window, so that imports-loader


### PR DESCRIPTION
# Problem

After merging https://github.com/onfido/onfido-sdk-ui/pull/502 IE 11 stopped working

# Solution

Moved from an iterator of Object.keys to for in. This is because some of the apis woopra uses are on the prototype of window, rather than on window itself. Therefore they were not being proxied properly.

Note: For testing IE 11 will be coming as part of Browserstack testing. See https://github.com/onfido/onfido-sdk-ui/pull/620

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [n/a] Have any new strings been translated?
