### PR TITLE
Force mocha to exit

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build-test": "npm run build && npm run test:ui",
     "test:ui": "BROWSER_STACK=false ./test.sh",
     "test:ui-bs": "BROWSER_STACK=true ./test.sh",
-    "test:ui-js": "babel-node test/js/main.js --timeout 10000 --exit
+    "test:ui-js": "babel-node test/js/main.js --timeout 10000 --exit"
   },
   "main": "lib/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build-test": "npm run build && npm run test:ui",
     "test:ui": "BROWSER_STACK=false ./test.sh",
     "test:ui-bs": "BROWSER_STACK=true ./test.sh",
-    "test:ui-js": "babel-node test/js/main.js --timeout 10000 --exit"
+    "test:ui-js": "babel-node test/js/main.js mocha --exit"
   },
   "main": "lib/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build-test": "npm run build && npm run test:ui",
     "test:ui": "BROWSER_STACK=false ./test.sh",
     "test:ui-bs": "BROWSER_STACK=true ./test.sh",
-    "test:ui-js": "babel-node test/js/main.js --exit"
+    "test:ui-js": "babel-node test/js/main.js --exit --timeout 10000"
   },
   "main": "lib/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build-test": "npm run build && npm run test:ui",
     "test:ui": "BROWSER_STACK=false ./test.sh",
     "test:ui-bs": "BROWSER_STACK=true ./test.sh",
-    "test:ui-js": "babel-node test/js/main.js mocha --exit"
+    "test:ui-js": "babel-node test/js/main.js mocha --exit --timeout 10000"
   },
   "main": "lib/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build-test": "npm run build && npm run test:ui",
     "test:ui": "BROWSER_STACK=false ./test.sh",
     "test:ui-bs": "BROWSER_STACK=true ./test.sh",
-    "test:ui-js": "babel-node test/js/main.js"
+    "test:ui-js": "babel-node test/js/main.js --exit"
   },
   "main": "lib/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build-test": "npm run build && npm run test:ui",
     "test:ui": "BROWSER_STACK=false ./test.sh",
     "test:ui-bs": "BROWSER_STACK=true ./test.sh",
-    "test:ui-js": "babel-node test/js/main.js --exit --timeout 10000"
+    "test:ui-js": "babel-node test/js/main.js --timeout 10000 --exit
   },
   "main": "lib/index.js",
   "keywords": [


### PR DESCRIPTION
# Problem
https://boneskull.com/mocha-v4-nears-release/#mochawontforceexit - this causes Travis to hang -> e.g. https://travis-ci.org/onfido/onfido-sdk-ui/jobs/521775279.

# Solution
Force mocha to exit by adding `--exit` to the test command
(https://github.com/chaijs/chai-http/issues/178#issuecomment-336602457)

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
