### PR TITLE
Uses different descripe scopes per check

### DIFF
--- a/test/js/specs/happy.js
+++ b/test/js/specs/happy.js
@@ -11,43 +11,46 @@ const localhostUrl = 'https://localhost:8080/'
 describe('Happy Paths', options, ({driver,$,pageObjects}) => {
   const {documentSelection, welcome, documentUpload} = pageObjects
 
-  //Welcome Screen Tests
-  const copy = welcome.copy()
 
-  it('test website title', async () => {
-    await driver.get(localhostUrl)
-    const title = driver.getTitle()
-    expect(title).to.equal('Onfido SDK Demo')
+  describe('welcome screen', function () {
+    const copy = welcome.copy()
+
+    it('test website title', async () => {
+      await driver.get(localhostUrl)
+      const title = driver.getTitle()
+      expect(title).to.equal('Onfido SDK Demo')
+    })
+
+    it('test welcome screen title', async () => {
+      const welcomeTitleText = welcome.welcomeTitle.getText()
+      expect(welcomeTitleText).to.equal(copy["title"])
+      welcome.welcomeTitle.isDisplayed()
+    })
+
+    it('test welcome screen subtitle', async () => {
+      const welcomeSubtitleText = welcome.welcomeSubtitle.getText()
+      expect(welcomeSubtitleText).to.equal(copy["description_p_1"] + "\n" + copy["description_p_2"])
+      welcome.welcomeSubtitle.isDisplayed()
+    })
+
+    it('test verify identity button', async () => {
+      const verifyIdentityBtnText = welcome.primaryBtn.getText()
+      expect(verifyIdentityBtnText).to.equal(copy["next_button"])
+      welcome.primaryBtn.isDisplayed()
+    })
+
+    it('test footer is displayed', async () => {
+      welcome.footer.isDisplayed()
+    })
   })
 
-  it('test welcome screen title', async () => {
-    const welcomeTitleText = welcome.welcomeTitle.getText()
-    expect(welcomeTitleText).to.equal(copy["title"])
-    welcome.welcomeTitle.isDisplayed()
-  })
-
-  it('test welcome screen subtitle', async () => {
-    const welcomeSubtitleText = welcome.welcomeSubtitle.getText()
-    expect(welcomeSubtitleText).to.equal(copy["description_p_1"] + "\n" + copy["description_p_2"])
-    welcome.welcomeSubtitle.isDisplayed()
-  })
-
-  it('test verify identity button', async () => {
-    const verifyIdentityBtnText = welcome.primaryBtn.getText()
-    expect(verifyIdentityBtnText).to.equal(copy["next_button"])
-    welcome.primaryBtn.isDisplayed()
-  })
-
-  it('test footer is displayed', async () => {
-    welcome.footer.isDisplayed()
-  })
-
-  //Document upload screen
-  it('should upload a file', async () => {
-    driver.get(localhostUrl)
-    welcome.getPrimaryBtn().click()
-    documentSelection.getPassport().click()
-    const input = documentUpload.getUploadInput()
-    input.sendKeys(path.join(__dirname,'../../features/helpers/resources/passport.jpg'))
+  describe('upload screen', function () {
+    it('should upload a file', async () => {
+      driver.get(localhostUrl)
+      welcome.getPrimaryBtn().click()
+      documentSelection.getPassport().click()
+      const input = documentUpload.getUploadInput()
+      input.sendKeys(path.join(__dirname, '../../features/helpers/resources/passport.jpg'))
+    })
   })
 })


### PR DESCRIPTION
# Problem
Use describe blocks for each one of checks of a page

# Solution


## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
