### PR TITLE
[Bugfix] Correct new version CHANGELOG types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ##[Next version]
 
 ### Added
-- Public: Accessibility - Make H1 readable by screen readers
-- Public: Accessibility - Make buttons/links readable by screen readers, allow tabbing to them
-- Public: Accessibility - Announce page transition when screen changes
+- Public: UI - Make H1 readable by screen readers
+- Public: UI - Make buttons/links readable by screen readers, allow tabbing to them
+- Public: UI - Announce page transition when screen changes
 
 ### Changed
 - Internal: Make Permission screen and Recovery screen buttons visible on small devices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ##[Next version]
 
 ### Added
-- Public: UI - Make H1 readable by screen readers
-- Public: UI - Make buttons/links readable by screen readers, allow tabbing to them
-- Public: UI - Announce page transition when screen changes
+- UI: Accessibility - Make H1 readable by screen readers
+- UI: Accessibility - Make buttons/links readable by screen readers, allow tabbing to them
+- UI: Accessibility - Announce page transition when screen changes
 
 ### Changed
 - Internal: Make Permission screen and Recovery screen buttons visible on small devices


### PR DESCRIPTION
# Problem
As noted by @rfreitas we've been added wrong type of CHANGELOG for the new release in regards to accessibility UI changes.

# Solution
Change type from "Public" to "UI".

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [`n/a`] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [`n/a`] Have new automated tests been implemented?
- [`n/a`] Have new manual tests been written down?
- [`n/a`] Have tests passed locally?
- [`n/a`] Have any new strings been translated?
