### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ You will receive a response containing the applicant id which will be used to cr
 For security reasons, instead of using the API token directly in you client-side code, you will need to generate and include a short-lived JSON Web Token ([JWT](https://jwt.io/)) every time you initialise the SDK. To generate an SDK Token you should perform a request to the [SDK Token endpoint](https://documentation.onfido.com/#sdk-tokens) in the Onfido API:
 
 ```shell
-$ curl https://api.onfido.com/v2/sdk_token
-  -H 'Authorization: Token token=YOUR_API_TOKEN'
-  -F 'applicant_id=YOUR_APPLICANT_ID'
+$ curl https://api.onfido.com/v2/sdk_token \
+  -H 'Authorization: Token token=YOUR_API_TOKEN' \
+  -F 'applicant_id=YOUR_APPLICANT_ID' \
   -F 'referrer=REFERRER_PATTERN'
 ```
 


### PR DESCRIPTION
Fix multi-line shell console command

# Problem

Shell command fails without backslash for multiline

# Solution

Add backslash to endlines `\`

## Checklist

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
