### PR TITLE
Move chai to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3029,7 +3029,8 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -4029,6 +4030,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -4042,6 +4044,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
           "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+          "dev": true,
           "requires": {
             "type-detect": "^4.0.0"
           }
@@ -4049,7 +4052,8 @@
         "type-detect": {
           "version": "4.0.8",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+          "dev": true
         }
       }
     },
@@ -4073,7 +4077,8 @@
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "check-types": {
       "version": "7.3.0",
@@ -8708,7 +8713,8 @@
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "get-stream": {
       "version": "4.1.0",
@@ -13050,7 +13056,8 @@
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "pause-stream": {
       "version": "0.0.11",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "babel-plugin-auto-await": "^0.4.2",
     "babel-upgrade": "0.0.23",
     "browserstack-local": "^1.3.7",
+    "chai": "^4.2.0",
     "css-loader": "^2.1.0",
     "eslint": "^5.15.3",
     "eslint-plugin-flowtype": "^3.4.2",
@@ -84,6 +85,7 @@
     "less-loader": "^4.0.4",
     "mini-css-extract-plugin": "^0.5.0",
     "mocha": "^6.0.2",
+    "object-loops": "0.8.0",
     "postcss-base64": "^0.4.1",
     "postcss-custom-media": "^5.0.1",
     "postcss-loader": "^2.0.6",
@@ -100,13 +102,11 @@
     "webpack-bundle-analyzer": "^2.11.1",
     "webpack-cli": "^3.3.1",
     "webpack-dev-server": "^3.3.1",
-    "webpack-visualizer-plugin": "^0.1.11",
-    "object-loops": "0.8.0"
+    "webpack-visualizer-plugin": "^0.1.11"
   },
   "dependencies": {
     "@babel/runtime-corejs3": "^7.4.3",
     "blueimp-load-image": "2.12.2",
-    "chai": "^4.2.0",
     "classnames": "2.2.5",
     "enumerate-devices": "^1.1.0",
     "eventemitter2": "2.1.3",


### PR DESCRIPTION
# Problem
Chai is located in non-dev dependencies.

# Solution
npm install chai --save-dev

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
