### PR TITLE
[Bugfix] Add button "type"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Fixed
 - Public: Handle non JSON error responses and return a `Connection Lost` error to the user
 - UI: Make sure "full screen" mode is off when navigating away from enlarged preview
+- UI: Make sure all buttons have a type of a "button" set
 
 ## [5.0.0] - 2019-04-01
 

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -4,9 +4,10 @@ import style from './style.css'
 
 const Button = ({ className, textClassName, variants = [], disabled, children, onClick }) => (
   <button
-    className={classNames(className, style.button, ...variants.map(v => style['button-' + v]))}
-    onClick={onClick}
+    type="button"
     disabled={disabled}
+    onClick={onClick}
+    className={classNames(className, style.button, ...variants.map(v => style['button-' + v]))}
   >
     <span className={classNames(textClassName, style['button-text'])}>
       {children}

--- a/src/components/CameraError/index.js
+++ b/src/components/CameraError/index.js
@@ -58,7 +58,11 @@ export default class CameraError extends Component<Props, State> {
           onDismiss={this.handleDismiss}
           renderInstruction={ str => parseTags(str,
             ({text}) =>
-            <button onClick={this.handleFallbackClick} className={style.fallbackLink}>
+            <button
+              type="button"
+              onClick={this.handleFallbackClick}
+              className={style.fallbackLink}
+            >
               {renderFallback(text)}
             </button>
           )}

--- a/src/components/CameraPermissions/Primer/index.js
+++ b/src/components/CameraPermissions/Primer/index.js
@@ -1,7 +1,6 @@
 import { h } from 'preact'
 import PageTitle from 'components/PageTitle'
 import theme from 'components/Theme/style.css'
-import {preventDefaultOnClick} from 'components/utils'
 import Button from 'components/Button'
 import { trackComponent } from 'Tracker'
 import style from './style.css'
@@ -19,7 +18,7 @@ const Permissions = ({onNext, translate}) => (
       </div>
       <Button
         variants={["centered", "primary"]}
-        onClick={preventDefaultOnClick(onNext)}
+        onClick={onNext}
       >
         {translate('webcam_permissions.enable_webcam')}
       </Button>

--- a/src/components/CameraPermissions/Recover/index.js
+++ b/src/components/CameraPermissions/Recover/index.js
@@ -2,7 +2,6 @@ import { h } from 'preact'
 import PageTitle from 'components/PageTitle'
 import theme from 'components/Theme/style.css'
 import style from './style.css'
-import {preventDefaultOnClick} from 'components/utils'
 import Button from 'components/Button'
 import { trackComponent } from 'Tracker'
 import { localised } from '../../../locales'
@@ -32,7 +31,7 @@ const Recover = ({translate}) => (
       <Button
         className={style.button}
         variants={["primary"]}
-        onClick={preventDefaultOnClick(() => window.location.reload())}
+        onClick={() => window.location.reload()}
       >
         {translate('webcam_permissions.refresh')}
       </Button>

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -5,7 +5,6 @@ import theme from '../Theme/style.css'
 import classNames from 'classnames'
 import { isOfMimeType } from '~utils/blob'
 import { cleanFalsy } from '~utils/array'
-import { preventDefaultOnClick } from '~utils/index'
 import { uploadDocument, uploadLivePhoto, uploadLiveVideo } from '~utils/onfidoApi'
 import CaptureViewer from './CaptureViewer'
 import { poaDocumentTypes } from '../DocumentSelector/documentTypes'
@@ -30,7 +29,7 @@ const ConfirmAction = localised(({confirmAction, translate, error}) =>
   <Button
     className={style["btn-primary"]}
     variants={["primary"]}
-    onClick={preventDefaultOnClick(confirmAction)}>
+    onClick={confirmAction}>
     { error.type === 'warn' ? translate('confirm.continue') : translate('confirm.confirm') }
   </Button>
 )

--- a/src/components/DocumentSelector/index.js
+++ b/src/components/DocumentSelector/index.js
@@ -41,41 +41,37 @@ class DocumentSelector extends Component<Props & WithDefaultOptions> {
     return options.length ? options : defaultDocOptions
   }
 
-  handleSelect = (e, value: string) => {
-    e.stopPropagation()
+  handleSelect = (value: string) => {
     const { setDocumentType, nextStep } = this.props
     setDocumentType(value)
     nextStep()
   }
 
-  renderOption = (option: DocumentOptionsType) => {
-    const handleClick = e => this.handleSelect(e, option.value)
-
-    return (
-      <button
-        className={style.option}
-        onClick={handleClick}
-      >
-        <div className={`${style.icon} ${style[option.icon]}`} />
-        <div className={style.content}>
-          <div className={style.optionMain}>
-            <p className={style.label}>{option.label}</p>
-            {option.hint &&
-              <div className={style.hint}>{option.hint}</div>
-            }
-            {option.warning &&
-              <div className={style.warning}>{option.warning}</div>
-            }
-          </div>
-          {option.eStatementAccepted &&
-            <div className={style.tag}>{
-              this.props.translate('document_selector.proof_of_address.estatements_accepted')
-            }</div>
+  renderOption = (option: DocumentOptionsType) => (
+    <button
+      type="button"
+      onClick={() => this.handleSelect(option.value)}
+      className={style.option}
+    >
+      <div className={`${style.icon} ${style[option.icon]}`} />
+      <div className={style.content}>
+        <div className={style.optionMain}>
+          <p className={style.label}>{option.label}</p>
+          {option.hint &&
+            <div className={style.hint}>{option.hint}</div>
+          }
+          {option.warning &&
+            <div className={style.warning}>{option.warning}</div>
           }
         </div>
-      </button>
-    );
-  }
+        {option.eStatementAccepted &&
+          <div className={style.tag}>{
+            this.props.translate('document_selector.proof_of_address.estatements_accepted')
+          }</div>
+        }
+      </div>
+    </button>
+  )
 
   render() {
     const documentOptions = this.getOptions()

--- a/src/components/Error/index.js
+++ b/src/components/Error/index.js
@@ -42,7 +42,13 @@ class Error extends Component {
         <p className={style.instruction}>
           <span className={style['instruction-text']}>{renderInstruction(translate(instruction))}</span>
         </p>
-        { isDismissible && <button type="button" aria-label={translate('accessibility.dismiss_alert')} className={style.dismiss} onClick={onDismiss} /> }
+        { isDismissible &&
+            <button
+              type="button"
+              aria-label={translate('accessibility.dismiss_alert')}
+              onClick={onDismiss}
+              className={style.dismiss}
+            /> }
       </div>
     )
   }

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -27,11 +27,12 @@ class Modal extends Component {
         appElement={document.body}
       >
         <button
+          type="button"
           aria-label={translate('accessibility.close_sdk_screen')}
+          onClick={this.props.onRequestClose}
           className={classNames(style.closeButton, {
             [style.closeButtonFullScreen]: isFullScreen,
           })}
-          onClick={this.props.onRequestClose}
         >
           <span className={style.closeButtonLabel} aria-hidden="true">
             {translate('close')}

--- a/src/components/NavigationBar/index.js
+++ b/src/components/NavigationBar/index.js
@@ -5,7 +5,7 @@ import { compose } from '../utils/func'
 import { setNavigationDisabled } from '../../core/store/actions/globals'
 import { withFullScreenState } from '../FullScreen'
 import style from './style.css'
-import {preventDefaultOnClick, isDesktop} from '../utils'
+import {isDesktop} from '~utils/index'
 import {localised} from '../../locales'
 
 export const withNavigationDisabledState = connect(({ globals: { isNavigationDisabled }}) => ({ isNavigationDisabled }))
@@ -19,12 +19,13 @@ const NavigationBar = ({back, translate, disabled, isFullScreen, className}) =>
     [style.fullScreenNav]: isFullScreen
   })}>
     <button
+      type="button"
       aria-label={translate('back')}
+      onClick={back}
       className={classNames(style.back, {
         [style.disabled]: disabled,
         [style.backHoverDesktop]: isDesktop
       })}
-      onClick={preventDefaultOnClick(back)}
     >
         <span className={style.iconBack} />
         <span className={style.label} aria-hidden="true">

--- a/src/components/Photo/Selfie.js
+++ b/src/components/Photo/Selfie.js
@@ -104,10 +104,11 @@ export default class Selfie extends Component<Props, State> {
         <FaceOverlay />
         <div className={style.actions}>
           <button
+            type="button"
             aria-label={translate('accessibility.shutter')}
-            className={style.btn}
             disabled={hasCameraError}
             onClick={this.takeSelfie}
+            className={style.btn}
           />
         </div>
       </Camera>

--- a/src/components/PrivacyStatement/index.js
+++ b/src/components/PrivacyStatement/index.js
@@ -4,7 +4,6 @@ import theme from '../Theme/style.css'
 import style from './style.css'
 import PageTitle from '../PageTitle'
 import Button from '../Button'
-import {preventDefaultOnClick} from '../utils'
 import {sendScreen} from '../../Tracker'
 import {localised} from '../../locales'
 
@@ -39,7 +38,7 @@ class PrivacyStatement extends Component {
             </div>
             <div className={style.actions}>
               <Button
-                onClick={preventDefaultOnClick(back)}
+                onClick={back}
                 className={style.decline}
               >
                 {translate('privacy.decline')}
@@ -47,7 +46,7 @@ class PrivacyStatement extends Component {
               <Button
                 className={style.primary}
                 variant={["primary"]}
-                onClick={preventDefaultOnClick(actions.acceptTerms)}
+                onClick={actions.acceptTerms}
               >
                 {translate('privacy.continue')}
               </Button>

--- a/src/components/ProofOfAddress/Guidance/index.js
+++ b/src/components/ProofOfAddress/Guidance/index.js
@@ -4,7 +4,6 @@ import style from './style.css'
 import PageTitle from '../../PageTitle'
 import Button from '../../Button'
 import {trackComponent} from '../../../Tracker'
-import {preventDefaultOnClick} from '../../utils'
 import {localised} from '../../../locales'
 import Graphic from './graphic';
 
@@ -30,7 +29,7 @@ const Guidance = ({translate, parseTranslatedTags, documentType, nextStep}) => {
       <div className={theme.thickWrapper}>
         <Button
           variants={["primary", "centered"]}
-          onClick={preventDefaultOnClick(nextStep)}
+          onClick={nextStep}
         >
           {translate('proof_of_address.guidance.continue')}
         </Button>

--- a/src/components/ProofOfAddress/PoAIntro/index.js
+++ b/src/components/ProofOfAddress/PoAIntro/index.js
@@ -4,7 +4,6 @@ import style from './style.css'
 import PageTitle from '../../PageTitle'
 import Button from '../../Button'
 import {trackComponent} from '../../../Tracker'
-import {preventDefaultOnClick} from '../../utils'
 import {localised} from '../../../locales'
 
 const PoAIntro = ({country, translate, parseTranslatedTags, nextStep}) => (
@@ -29,7 +28,7 @@ const PoAIntro = ({country, translate, parseTranslatedTags, nextStep}) => (
     <div className={theme.thickWrapper}>
       <Button
         variants={["primary", "centered"]}
-        onClick={preventDefaultOnClick(nextStep)}
+        onClick={nextStep}
       >
         {translate('proof_of_address.intro.start')}
       </Button>

--- a/src/components/Video/Intro.js
+++ b/src/components/Video/Intro.js
@@ -6,7 +6,6 @@ import style from './style.css'
 import theme from '../Theme/style.css'
 import PageTitle from '../PageTitle'
 import Button from '../Button'
-import {preventDefaultOnClick} from '../utils'
 import {localised} from '../../locales'
 import type { LocalisedType } from '../../locales'
 import { trackComponent } from '../../Tracker'
@@ -39,7 +38,7 @@ const Intro = ({ translate, parseTranslatedTags, nextStep }: Props) => (
     <div className={theme.thickWrapper}>
       <Button
         variants={['primary', 'centered']}
-        onClick={preventDefaultOnClick(nextStep)}
+        onClick={nextStep}
       >
         {translate('capture.liveness.intro.continue')}
       </Button>

--- a/src/components/Video/NotRecording.js
+++ b/src/components/Video/NotRecording.js
@@ -22,10 +22,11 @@ const NotRecording = ({ translate, onStart, hasError, disableInteraction, onTime
         { translate('capture.liveness.press_record') }
       </div>
       <button
+        type="button"
         aria-label={translate('accessibility.start_recording')}
-        className={classNames(style.btn, style.startRecording)}
         disabled={disableInteraction}
         onClick={onStart}
+        className={classNames(style.btn, style.startRecording)}
       />
     </div>
   </div>

--- a/src/components/Video/Recording.js
+++ b/src/components/Video/Recording.js
@@ -47,10 +47,11 @@ const Recording = ({ onTimeout, onStop, onNext, currentChallenge, isLastChalleng
             {translate('capture.liveness.challenges.next')}
           </Button> :
           <button
+            type="button"
             aria-label={translate('accessibility.finish_recording')}
-            className={classNames(style.btn, style.stopRecording)}
             disabled={disableInteraction}
             onClick={onStop}
+            className={classNames(style.btn, style.stopRecording)}
           />
       }
     </div>

--- a/src/components/Welcome/index.js
+++ b/src/components/Welcome/index.js
@@ -2,7 +2,6 @@ import { h } from 'preact'
 import PageTitle from '../PageTitle'
 import theme from '../Theme/style.css'
 import style from './style.css'
-import {preventDefaultOnClick} from '../utils'
 import Button from '../Button'
 import { trackComponent } from '../../Tracker'
 import {localised} from '../../locales'
@@ -20,7 +19,7 @@ const Welcome = ({title, descriptions, nextStep, translate}) => {
         <div className={style.text}>
           {welcomeDescriptions.map(description => <p>{description}</p>)}
         </div>
-        <Button onClick={preventDefaultOnClick(nextStep)} variants={['centered', 'primary']}>
+        <Button onClick={nextStep} variants={['centered', 'primary']}>
           {translate('welcome.next_button')}
         </Button>
       </div>

--- a/src/components/crossDevice/CrossDeviceLink/index.js
+++ b/src/components/crossDevice/CrossDeviceLink/index.js
@@ -112,7 +112,6 @@ class CrossDeviceLinkUI extends Component {
   linkCopiedTimeoutId = null
 
   copyToClipboard = (e) => {
-    e.preventDefault()
     this.linkText.select()
     document.execCommand('copy')
     e.target.focus()
@@ -228,7 +227,13 @@ class CrossDeviceLinkUI extends Component {
                 <textarea className={style.linkText} value={mobileUrl} ref={(element) => this.linkText = element}/>
                 { document.queryCommandSupported('copy') &&
                   <div className={style.actionContainer}>
-                    <button className={style.copyToClipboard} onClick={this.copyToClipboard}>{linkCopy}</button>
+                    <button
+                      type="button"
+                      onClick={this.copyToClipboard}
+                      className={style.copyToClipboard}
+                    >
+                      {linkCopy}
+                    </button>
                   </div>
                 }
               </div>

--- a/src/components/crossDevice/CrossDeviceSubmit/index.js
+++ b/src/components/crossDevice/CrossDeviceSubmit/index.js
@@ -1,7 +1,6 @@
 import { h, Component } from 'preact'
 import { connect } from 'react-redux'
 import { trackComponent } from '../../../Tracker'
-import {preventDefaultOnClick} from '../../utils'
 import PageTitle from '../../PageTitle'
 import Button from '../../Button'
 import theme from '../../Theme/style.css'
@@ -31,7 +30,7 @@ class CrossDeviceSubmit extends Component {
   }
 
   render () {
-    const { translate } = this.props
+    const { translate, nextStep } = this.props
     const documentCopy = this.hasMultipleDocuments() ? translate('cross_device.submit.multiple_docs_uploaded') : translate('cross_device.submit.one_doc_uploaded')
     return (
       <div>
@@ -57,7 +56,7 @@ class CrossDeviceSubmit extends Component {
           <div>
             <Button
               variants={["primary", "centered"]}
-              onClick={preventDefaultOnClick(this.props.nextStep)}
+              onClick={nextStep}
             >
               {translate('cross_device.submit.action')}
             </Button>

--- a/src/components/crossDevice/Intro/index.js
+++ b/src/components/crossDevice/Intro/index.js
@@ -5,7 +5,6 @@ import style from './style.css'
 import PageTitle from '../../PageTitle'
 import Button from '../../Button'
 import { trackComponent } from '../../../Tracker'
-import {preventDefaultOnClick} from '../../utils'
 import {componentsList} from '../../Router/StepComponentMap'
 import { localised } from '../../../locales'
 
@@ -43,7 +42,7 @@ const Intro = ({translate, nextStep, mobileConfig}) => {
       <div className={theme.thickWrapper}>
         <Button
           variants={["primary", "centered"]}
-          onClick={preventDefaultOnClick(nextStep)}
+          onClick={nextStep}
         >
           {translate(`cross_device.intro.${ isFace ? 'face' : 'document' }.action`)}
         </Button>

--- a/src/components/crossDevice/MobileConnected/index.js
+++ b/src/components/crossDevice/MobileConnected/index.js
@@ -4,7 +4,7 @@ import theme from '../../Theme/style.css'
 import style from './style.css'
 import PageTitle from '../../PageTitle'
 import { trackComponent } from '../../../Tracker'
-import {preventDefaultOnClick} from '../../utils'
+import {preventDefaultOnClick} from '~utils/index'
 import { localised } from '../../../locales'
 
 const MobileConnected = ({translate, back}) => {

--- a/src/components/crossDevice/MobileNotificationSent/index.js
+++ b/src/components/crossDevice/MobileNotificationSent/index.js
@@ -4,7 +4,7 @@ import theme from '../../Theme/style.css'
 import style from './style.css'
 import PageTitle from '../../PageTitle'
 import { trackComponent } from '../../../Tracker'
-import {preventDefaultOnClick} from '../../utils'
+import {preventDefaultOnClick} from '~utils/index'
 import { localised } from '../../../locales'
 
 const MobileNotificationSent = ({sms, translate, previousStep}) =>

--- a/src/components/crossDevice/SwitchDevice/index.js
+++ b/src/components/crossDevice/SwitchDevice/index.js
@@ -1,5 +1,5 @@
 import { h } from 'preact'
-import {preventDefaultOnClick} from '../../utils'
+import {preventDefaultOnClick} from '~utils/index'
 import style from './style.css'
 import { localised } from '../../../locales'
 

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -153,7 +153,8 @@ class Demo extends Component{
       { useModal &&
         <button
           id="button"
-          onClick={ () => this.setState({isModalOpen: true})}>
+          type="button"
+          onClick={ () => this.setState({isModalOpen: true}) }>
             Verify identity
         </button>
       }


### PR DESCRIPTION
# Problem
Currently buttons do not have types set, that defaults to "submit". This causes some trouble as described on https://github.com/onfido/onfido-sdk-ui/issues/647.

# Solution
Button type added as "button" everywhere, also:
- props sorted
- onClick events for buttons now do not prevent default behaviour

Please unless if anyone has a good reason **why** the default behaviour was prevented in the first place?

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [`n/a`] Have new automated tests been implemented?
- [`n/a`] Have new manual tests been written down?
- [x] Have tests passed locally?
- [`n/a`] Have any new strings been translated?
