### PR TITLE
Feature/accessibility announce errors cx 3479

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - UI: Accessibility - Announce page transition when screen changes
 - UI: Accessibility - Make capture previews readable by screen readers
 - UI: Accessibility - Announce camera alerts
+- UI: Accessibility - Announce validation errors and warnings on confirm screen
 
 ### Changed
 - Internal: Make Permission screen and Recovery screen buttons visible on small devices

--- a/src/components/CameraError/index.js
+++ b/src/components/CameraError/index.js
@@ -53,7 +53,7 @@ export default class CameraError extends Component<Props, State> {
           role="alertdialog"
           className={style.errorMessage}
           error={error}
-          focusOnRender={true}
+          focusOnMount={true}
           isDismissible={isDismissible}
           onDismiss={this.handleDismiss}
           renderInstruction={ str => parseTags(str,

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -61,7 +61,7 @@ const Previews = localised(({capture, retakeAction, confirmAction, error, method
     <div className={classNames(style.previewsContainer, theme.fullHeightContainer, {
       [style.previewsContainerIsFullScreen]: isFullScreen,
     })}>
-      { error.type ? <Error {...{error, withArrow: true}} /> :
+      { error.type ? <Error {...{error, withArrow: true, role: "alert", focusOnRender: true}} /> :
         <PageTitle title={title} subTitle={subTitle} smaller={true} className={style.title}/> }
         <CaptureViewer {...{ capture, method, isFullScreen, altTag }} />
       { !isFullScreen && <Actions {...{retakeAction, confirmAction, error}} /> }

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -60,7 +60,7 @@ const Previews = localised(({capture, retakeAction, confirmAction, error, method
     <div className={classNames(style.previewsContainer, theme.fullHeightContainer, {
       [style.previewsContainerIsFullScreen]: isFullScreen,
     })}>
-      { error.type ? <Error {...{error, withArrow: true, role: "alertdialog", focusOnRender: true}} /> :
+      { error.type ? <Error {...{error, withArrow: true, role: "alert", focusOnRender: false}} /> :
         <PageTitle title={title} subTitle={subTitle} smaller={true} className={style.title}/> }
         <CaptureViewer {...{ capture, method, isFullScreen, altTag }} />
       { !isFullScreen && <Actions {...{retakeAction, confirmAction, error}} /> }

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -60,7 +60,7 @@ const Previews = localised(({capture, retakeAction, confirmAction, error, method
     <div className={classNames(style.previewsContainer, theme.fullHeightContainer, {
       [style.previewsContainerIsFullScreen]: isFullScreen,
     })}>
-      { error.type ? <Error {...{error, withArrow: true, role: "alert", focusOnRender: false}} /> :
+      { error.type ? <Error {...{error, withArrow: true, role: "alert", focusOnMount: false}} /> :
         <PageTitle title={title} subTitle={subTitle} smaller={true} className={style.title}/> }
         <CaptureViewer {...{ capture, method, isFullScreen, altTag }} />
       { !isFullScreen && <Actions {...{retakeAction, confirmAction, error}} /> }

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -61,7 +61,7 @@ const Previews = localised(({capture, retakeAction, confirmAction, error, method
     <div className={classNames(style.previewsContainer, theme.fullHeightContainer, {
       [style.previewsContainerIsFullScreen]: isFullScreen,
     })}>
-      { error.type ? <Error {...{error, withArrow: true, role: "alert", focusOnRender: true}} /> :
+      { error.type ? <Error {...{error, withArrow: true, role: "alertdialog", focusOnRender: true}} /> :
         <PageTitle title={title} subTitle={subTitle} smaller={true} className={style.title}/> }
         <CaptureViewer {...{ capture, method, isFullScreen, altTag }} />
       { !isFullScreen && <Actions {...{retakeAction, confirmAction, error}} /> }

--- a/src/components/Error/index.js
+++ b/src/components/Error/index.js
@@ -22,7 +22,8 @@ class Error extends Component {
       renderMessage = identity,
       renderInstruction = identity,
       isDismissible,
-      onDismiss = noop
+      onDismiss = noop,
+      focusOnRender
     } = this.props
     const { message, instruction } = errors[error.name]
     const errorType = error.type === 'error' ? 'error' : 'warning'
@@ -31,6 +32,7 @@ class Error extends Component {
       <div
         role={role}
         ref={node => this.container = node}
+        focusOnRender={focusOnRender}
         tabIndex={-1}
         className={classNames(style[`container-${errorType}`], className)}
       >

--- a/src/components/Error/index.js
+++ b/src/components/Error/index.js
@@ -7,7 +7,7 @@ import { localised } from '../../locales'
 
 class Error extends Component {
   componentDidMount() {
-    if (this.props.focusOnRender && this.container) {
+    if (this.props.focusOnMount && this.container) {
       this.container.focus()
     }
   }

--- a/src/components/Error/index.js
+++ b/src/components/Error/index.js
@@ -22,8 +22,7 @@ class Error extends Component {
       renderMessage = identity,
       renderInstruction = identity,
       isDismissible,
-      onDismiss = noop,
-      focusOnRender
+      onDismiss = noop
     } = this.props
     const { message, instruction } = errors[error.name]
     const errorType = error.type === 'error' ? 'error' : 'warning'
@@ -32,7 +31,6 @@ class Error extends Component {
       <div
         role={role}
         ref={node => this.container = node}
-        focusOnRender={focusOnRender}
         tabIndex={-1}
         className={classNames(style[`container-${errorType}`], className)}
       >


### PR DESCRIPTION
# Problem
Currently, screen readers can only access camera errors. Errors and warnings on capture submission should also be announced by screen readers.

# Solution
Announce errors displayed on the confirm screen after an image has been submitted. This solution leverages the work done by @josokinas on #648 PR.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
