### PR TITLE
Feature/cx 3583 better focus management

### DIFF
--- a/src/components/EnlargedPreview/index.js
+++ b/src/components/EnlargedPreview/index.js
@@ -78,7 +78,7 @@ class EnlargedPreview extends Component<Props, State> {
           ref={node => this.previewContainer = node}
           tabIndex={-1}
           aria-label={altTag}
-          aria-live={isExpanded ? "assertive" : "polite"}
+          aria-live={isExpanded ? "assertive" : ""}
           aria-expanded={isExpanded.toString()}
           role='img'
         >

--- a/src/components/PageTitle/index.js
+++ b/src/components/PageTitle/index.js
@@ -1,23 +1,33 @@
-import { h } from 'preact'
+import { h, Component} from 'preact'
 import { withFullScreenState } from '../FullScreen'
 import style from './style.css'
 import classNames from 'classnames'
 
-const PageTitle = ({title, subTitle, smaller, isFullScreen, className}) =>
-  <div className={classNames(
-      style.titleWrapper,
-      {
-        [style.smaller]: smaller && !isFullScreen,
-        [style.fullScreen]: isFullScreen
-      },
-      className
-    )}>
-    <div className={style.title}>
-      <span className={style.titleSpan} role="heading" aria-level="1"
-        aria-live="assertive" tabindex="-1" autoFocus
-      >{title}</span>
-    </div>
-    { subTitle && <div>{subTitle}</div> }
-  </div>
+class PageTitle extends Component {
+  componentDidMount() {
+    this.container.focus()
+  }
+
+  render() {
+    const { title, subTitle, smaller, isFullScreen, className } = this.props
+    return (
+      <div className={classNames(
+          style.titleWrapper,
+          {
+            [style.smaller]: smaller && !isFullScreen,
+            [style.fullScreen]: isFullScreen
+          },
+          className
+        )}>
+        <div className={style.title}>
+          <span className={style.titleSpan} role="heading" aria-level="1"
+            aria-live="assertive" tabindex="-1" ref={node => this.container = node}
+          >{title}</span>
+        </div>
+        { subTitle && <div>{subTitle}</div> }
+      </div>
+    )
+  }
+}
 
 export default withFullScreenState(PageTitle)

--- a/src/components/Router/StepsRouter.js
+++ b/src/components/Router/StepsRouter.js
@@ -7,13 +7,6 @@ import theme from '../Theme/style.css'
 import { withFullScreenState } from '../FullScreen'
 
 class StepsRouter extends Component {
-  componentDidUpdate(prevProps) {
-    // Re-focus to container when step changes in order for accessible tabbing
-    if (this.container && prevProps.step !== this.props.step) {
-      this.container.focus()
-    }
-  }
-
   trackScreen = (screenNameHierarchy, properties = {}) => {
     const { step } = this.currentComponent()
     sendScreen(
@@ -32,8 +25,6 @@ class StepsRouter extends Component {
     return (
       //TODO: Wrap CurrentComponent in themeWrap HOC
       <div
-        ref={node => this.container = node}
-        tabIndex={-1}
         className={classNames(theme.step, {
           [theme.fullScreenStep]: isFullScreen
         })}


### PR DESCRIPTION
# Problem
When navigating across different screens, we need to reset the focus to ensure a good user experience for accessibility users. This problem was addressed in this PR https://github.com/onfido/onfido-sdk-ui/pull/642 but unfortunately, the change introduced a new issue only reproducible on certain screens. 
The issue can be seen on the confirmation screen. When navigating to the confirmation screen the screen reader, instead of announcing the H1, it reads the whole screen content. This is not an ideal user experience as it can be confusing for the user, as well as time consuming and inconsistent.

# Solution

When navigating to confirmation screen (or to any other screen with this issue) the screen readers should only announce the page change by reading the H1, not the whole SDK content.
In general, the initial screen reader and tab starting focus should aligned, and that should be the title element on each screen.
I achieved this by replacing `autoFocus=true` with the `focus()` call over the component reference.
I also removed the focus at SDK container level.

Bonus:
Replaced `aria-live="polite"` with a conditional empty string for cases when the element does not need to be announced.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
