### PR TITLE
Update references from Bitbucket to Gitlab for monster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - chmod ugo+x ./test.sh
   - ./test.sh
 addons:
-  ssh_known_hosts: bitbucket.org
+  ssh_known_hosts: gitlab.eu-west-1.mgmt.onfido.xyz
 after_success:
   - python node_modules/travis-weigh-in/weigh_in.py dist/onfido.min.js
   - chmod ugo+x ./deploy.sh

--- a/test/Gemfile
+++ b/test/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-gem 'monster', :git => 'git@bitbucket.org:onfido/monster.git', :tag => '0.8.26'
+gem 'monster', :git => 'git@gitlab.eu-west-1.mgmt.onfido.xyz:onfido/quality/monster.git', :tag => '0.8.26'
 gem 'cucumber', :git => 'https://github.com/cucumber/cucumber-ruby.git', :ref => '085be64'
 gem 'cucumber-api', :git => 'https://github.com/cristian-m-vasile/cucumber-api.git'
 gem 'rake'

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git@bitbucket.org:onfido/monster.git
+  remote: git@gitlab.eu-west-1.mgmt.onfido.xyz:onfido/quality/monster.git
   revision: 388bc2ac3c030ad1ed2d11cae3786baf98a7de31
   tag: 0.8.26
   specs:
@@ -24,9 +24,9 @@ GIT
 
 GIT
   remote: https://github.com/cristian-m-vasile/cucumber-api.git
-  revision: a7cdef1c1271148b48ca97bf8402cd33d538c159
+  revision: 9ae5c70fedc0ad2ca3491a64e9e210231abe9c58
   specs:
-    cucumber-api (0.6.2)
+    cucumber-api (0.6.3)
       json-schema (~> 2.5)
       jsonpath (~> 0.5)
       rest-client (~> 1.8)
@@ -48,38 +48,39 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    aws-eventstream (1.0.1)
-    aws-partitions (1.142.0)
-    aws-sdk-core (3.46.2)
-      aws-eventstream (~> 1.0)
+    aws-eventstream (1.0.3)
+    aws-partitions (1.166.0)
+    aws-sdk-core (3.53.1)
+      aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
-      aws-sigv4 (~> 1.0)
+      aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.13.0)
-      aws-sdk-core (~> 3, >= 3.39.0)
-      aws-sigv4 (~> 1.0)
+    aws-sdk-kms (1.21.0)
+      aws-sdk-core (~> 3, >= 3.53.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-s3 (1.21.0)
       aws-sdk-core (~> 3, >= 3.26.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
-    aws-sigv4 (1.0.3)
-    backports (3.10.3)
+    aws-sigv4 (1.1.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
+    backports (3.15.0)
     browserstack-local (1.3.0)
     builder (3.2.3)
-    byebug (11.0.0)
+    byebug (11.0.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
     coderay (1.1.2)
-    concurrent-ruby (1.1.4)
+    concurrent-ruby (1.1.5)
     cucumber-core (2.0.0)
       backports (~> 3.6)
       gherkin (~> 4.0)
     cucumber-wire (0.0.1)
     diff-lcs (1.3)
-    domain_name (0.5.20170404)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     faker (1.9.3)
       i18n (>= 0.7)
@@ -96,7 +97,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
     json (2.2.0)
-    json-schema (2.8.0)
+    json-schema (2.8.1)
       addressable (>= 2.4)
     jsonpath (0.7.2)
       multi_json
@@ -109,10 +110,10 @@ GEM
     multi_json (1.13.1)
     multi_test (0.1.2)
     netrc (0.11.0)
-    nokogiri (1.10.1)
+    nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     oauth (0.5.4)
-    parallel (1.14.0)
+    parallel (1.17.0)
     parallel_tests (2.24.0)
       parallel
     pry (0.12.2)
@@ -121,7 +122,7 @@ GEM
     pry-byebug (3.7.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    public_suffix (3.0.1)
+    public_suffix (3.0.3)
     rake (12.3.2)
     report_builder (1.8)
       json (>= 1.8.1)
@@ -131,7 +132,7 @@ GEM
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     retries (0.0.5)
-    rspec-expectations (3.8.2)
+    rspec-expectations (3.8.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
@@ -141,7 +142,7 @@ GEM
       rubyzip (~> 1.2)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.4)
+    unf_ext (0.0.7.6)
 
 PLATFORMS
   ruby

--- a/test/TESTING_GUIDELINES.md
+++ b/test/TESTING_GUIDELINES.md
@@ -2,7 +2,7 @@
 
 Guide to Cucumber acceptance tests for JS SDK.
 
-**Note:** Currently tests can be run only by Onfido people who have access to `monster` repository on Onfido's Bitbucket.
+**Note:** Currently tests can be run only by Onfido people who have access to `monster` repository on Onfido's Gitlab.
 
 ## Setup
 
@@ -23,7 +23,7 @@ Guide to Cucumber acceptance tests for JS SDK.
 6. Bundler
     - `gem install bundler`
 7. Other
-    - Make sure you have at least READ access to `monster` repository on Onfido's Bitbucket (it will work only for Onfidoers)
+    - Make sure you have at least READ access to `monster` repository on Onfido's Gitlab (it will work only for Onfidoers)
 
 ### Test environment
 

--- a/test/TESTING_GUIDELINES.md
+++ b/test/TESTING_GUIDELINES.md
@@ -56,7 +56,7 @@ If there's a need to introduce a change in `monster` gem, follow the steps:
 - create a branch out of master on `monster` gem
 - bump version in `monster/lib/monster/version.rb` according to your changes
 - for development purposes change `monster` gem dependency line in `test/Gemfile` of this project:
-  - if changes on monster branch: `gem 'monster', :git => 'git@bitbucket.org:onfido/monster.git', :branch => 'your-branch-on-monster'`
+  - if changes on monster branch: `gem 'monster', :git => 'git@gitlab.eu-west-1.mgmt.onfido.xyz:onfido/quality/monster.git', :branch => 'your-branch-on-monster'`
   - if changes on local changes: `gem 'monster', :path => 'your/local/path/to/monster'`
 - run `bundle update monster` in `test/` directory
 - once solution tested, issue PR with your monster branch to `master` and assign 2 QAs
@@ -64,7 +64,7 @@ If there's a need to introduce a change in `monster` gem, follow the steps:
   - `git tag <version>` version
 - merge your `monster` branch to `master`
 - back in this project, update `monster` gem dependency line in `test/Gemfile` to reflect latest changes in monster by tag:
-  -  `gem 'monster', :git => 'git@bitbucket.org:onfido/monster.git', :tag => '<version_from_your_branch>'`
+  -  `gem 'monster', :git => 'git@gitlab.eu-west-1.mgmt.onfido.xyz:onfido/quality/monster.git', :tag => '<version_from_your_branch>'`
 - run `bundle update monster` in `test/` directory to apply the changes (`Gemfile.lock` should be updated)
 
 ### Test structure


### PR DESCRIPTION
# Problem
Due to the migration from Bitbucket to Gitlab we need to update the references for monster so that we can still run Ruby tests.

# Solution
Replace references for monster repo from Bitbucket to Gitlab.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
