### PR TITLE
Update version and date in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ## [Next version]
 
-## [5.2.0] - 2019-05-29
+## [5.2.1] - 2019-05-30
 
 ### Added
 - UI: Accessibility - Announce validation error on cross device SMS link screen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -412,7 +412,8 @@ Install with `npm install onfido-sdk-ui@0.12.0-rc.1`
 
 
 [next-version]:
-[5.2.0]: https://github.com/onfido/onfido-sdk-ui/compare/5.1.0...5.2.1
+https://github.com/onfido/onfido-sdk-ui/compare/5.2.1...development
+[5.2.1]: https://github.com/onfido/onfido-sdk-ui/compare/5.1.0...5.2.1
 [5.1.0]: https://github.com/onfido/onfido-sdk-ui/compare/5.0.1...5.1.0
 [5.0.1]: https://github.com/onfido/onfido-sdk-ui/compare/5.0.0...5.0.1
 [5.0.0]: https://github.com/onfido/onfido-sdk-ui/compare/4.0.0...5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -414,8 +414,7 @@ Install with `npm install onfido-sdk-ui@0.12.0-rc.1`
 [next-version]:
 https://github.com/onfido/onfido-sdk-ui/compare/5.2.1...development
 [5.2.1]: https://github.com/onfido/onfido-sdk-ui/compare/5.1.0...5.2.1
-[5.1.0]: https://github.com/onfido/onfido-sdk-ui/compare/5.0.1...5.1.0
-[5.0.1]: https://github.com/onfido/onfido-sdk-ui/compare/5.0.0...5.0.1
+[5.1.0]: https://github.com/onfido/onfido-sdk-ui/compare/5.0.0...5.1.0
 [5.0.0]: https://github.com/onfido/onfido-sdk-ui/compare/4.0.0...5.0.0
 [4.0.0]: https://github.com/onfido/onfido-sdk-ui/compare/3.1.0...4.0.0
 [3.1.0]: https://github.com/onfido/onfido-sdk-ui/compare/3.0.1...3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -412,7 +412,7 @@ Install with `npm install onfido-sdk-ui@0.12.0-rc.1`
 
 
 [next-version]:
-[5.2.0-rc.1]: https://github.com/onfido/onfido-sdk-ui/compare/5.1.0...5.2.0
+[5.2.0]: https://github.com/onfido/onfido-sdk-ui/compare/5.1.0...5.2.1
 [5.1.0]: https://github.com/onfido/onfido-sdk-ui/compare/5.0.1...5.1.0
 [5.0.1]: https://github.com/onfido/onfido-sdk-ui/compare/5.0.0...5.0.1
 [5.0.0]: https://github.com/onfido/onfido-sdk-ui/compare/4.0.0...5.0.0


### PR DESCRIPTION
# Problem
During the release 5.2.1 we forgot to change the version in Changelog from 5.2.0.

# Solution
Update the version and date of the release

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
