### PR TITLE
Update ruby version use in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
   directories:
     - "node_modules"
 before_install:
+  - sudo apt-get install -y ruby2.3-dev
   - openssl aes-256-cbc -K $encrypted_1688a3f2e0a8_key -iv $encrypted_1688a3f2e0a8_iv -in test/monster_rsa.enc -out ~/.ssh/monster_rsa -d
   - chmod ugo+x ./test/scripts/setup_test_environment.sh
   - sudo ./test/scripts/setup_test_environment.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - lts/dubnium
 os:
   - linux
+dist: xenial
 env:
   - NODE_ENV=test
   - NODE_ENV=staging

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -29,7 +29,6 @@ Cucumber::Rake::Task.new(:run_features) do |t|
   t.cucumber_opts = [
     '--tags', (ENV['CUCUMBER_TAGS'] || '~none'),
     ENV['BROWSER_STACK'] == 'true' ? '' : 'BROWSER=${BROWSER:-chrome}',
-    '--headless',
     '--no-sandbox',
     '--disable-dev-shm-usage'
   ]

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -28,8 +28,10 @@ end
 Cucumber::Rake::Task.new(:run_features) do |t|
   t.cucumber_opts = [
     '--tags', (ENV['CUCUMBER_TAGS'] || '~none'),
-    ENV['BROWSER_STACK'] == 'true' ?
-      '' : 'BROWSER=${BROWSER:-chrome}'
+    ENV['BROWSER_STACK'] == 'true' ? '' : 'BROWSER=${BROWSER:-chrome}',
+    '--headless',
+    '--no-sandbox',
+    '--disable-dev-shm-usage'
   ]
 end
 task :default => [:cucumber]

--- a/test/features/support/env.rb
+++ b/test/features/support/env.rb
@@ -59,6 +59,8 @@ def create_driver
   capabilities['build'] = "PR"
   capabilities['name'] = "Compatibility tests"
 
+  capabilities['commandLineFlags'] = "--no-sandbox --headless --disable-dev-shm-usage"
+
   url = "http://#{ENV['BS_USERNAME']}:#{ENV['BROWSERSTACK_ACCESS_KEY']}@hub-cloud.browserstack.com/wd/hub"
 
   driver = Selenium::WebDriver.for(:remote, :url => url, :desired_capabilities => capabilities)


### PR DESCRIPTION
# Problem
Travis was complaining about the ruby version when running the ruby part of the tests.

# Solution
We update the ubuntu linux image used by travis from trusty to xenial. The new version uses ruby 2.3 instead of 2.2.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
