### PR TITLE
Fix double scrollbar on PDF preview

### DIFF
--- a/src/components/Confirm/CaptureViewer/style.css
+++ b/src/components/Confirm/CaptureViewer/style.css
@@ -29,10 +29,6 @@
   position: static;
 }
 
-.pdfWrapper {
-  overflow: scroll;
-}
-
 .videoWrapper {
   margin-bottom: 64*@unit;
   flex: 1;


### PR DESCRIPTION
# Problem
Currently, two scrollbars are visible on the PDF preview on Chrome (Windows). On Firefox, where only the icon is displayed the scrollbars are also visible
![Screenshot 2019-06-25 at 14 34 32](https://user-images.githubusercontent.com/7127427/60102866-6e003600-9756-11e9-9873-04b4e2794881.png)


# Solution
Remove redundant `overflow: scroll;` from pdf previewer component
I've tested on Safari (High Sierra and Mojave), Firefox (Windows), Edge and IE11
The screenshot below is from Chrome on Windows
![Screenshot 2019-06-25 at 14 34 09](https://user-images.githubusercontent.com/7127427/60102883-76f10780-9756-11e9-828d-eb9337c4af07.png)



## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
