### PR TITLE
Added document pre-selection feature to previewer

### DIFF
--- a/src/demo/demoUtils.js
+++ b/src/demo/demoUtils.js
@@ -95,24 +95,6 @@ export const commonSteps = {
     'face'
   ],
 
-  'upload fallback': [
-    'welcome',
-    {
-      type: 'document',
-      options: {
-        useWebcam: false,
-      }
-    },
-    {
-      type: 'face',
-      options: {
-        useWebcam: true,
-        uploadFallback: true
-      }
-    },
-    'complete'
-  ],
-
   'document autocapture (beta)': [
     'welcome',
     {
@@ -124,6 +106,19 @@ export const commonSteps = {
     'face',
     'complete'
   ],
+
+  'pre-selected document': [
+    'welcome',
+    {
+      type: 'document',
+      options: {
+        documentTypes: { passport: true }
+      }
+    },
+    'face',
+    'complete'
+  ],
+
   'no upload fallback': [
     'welcome',
     {
@@ -141,6 +136,7 @@ export const commonSteps = {
     },
     'complete'
   ],
+
   'multiple selfie': [
     'welcome',
     'document',

--- a/src/demo/demoUtils.js
+++ b/src/demo/demoUtils.js
@@ -119,6 +119,21 @@ export const commonSteps = {
     'complete'
   ],
 
+  'no document step with selfie' : [
+    'welcome',
+    'face',
+    'complete'
+  ],
+
+  'no document step with video' : [
+    'welcome',
+    {
+      type: 'face',
+      options: { requestedVariant: 'video' }
+    },
+    'complete'
+  ],
+
   'no upload fallback': [
     'welcome',
     {


### PR DESCRIPTION
# Problem
When PR #557 was created the feature that allows integrators to preselect documents had not been implemented, therefore the configuration is not available on the current PR.

# Solution
Add configuration to allow previewer to display only the pre-selected document. 
Bonus: 
- Added document auto-capture previewer
- Removed upload fallback option as it is enabled by default
- Added configuration to test face step only to improve testing on browserstack mobile devices

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [x] Have tests passed locally?
- [ ] Have any new strings been translated?
