### PR TITLE
JS UI test for oneDoc=true 

### DIFF
--- a/MANUAL_REGRESSION.md
+++ b/MANUAL_REGRESSION.md
@@ -451,15 +451,7 @@ On iOS:
     - if the number is correct the user should be able to successfully send an SMS
     - if the number is invalid the user will see an error when clicking "Send link"
 
-##### 35. No document selector screen
-(on one of the desktop browsers)
-
-1. Open link with additional GET parameter `?oneDoc=true`
-2. Go to the document capture step
-  - user should not see the document select screen
-  - user should see `Passport photo page` title of the screen
-
-##### 36. Force cross device for document upload
+##### 35. Force cross device for document upload
 (on one of the desktop browsers)
 
 1. Open link with additional GET parameter `?forceCrossDevice=true`
@@ -469,7 +461,7 @@ On iOS:
     - user should see `Continue your verification on mobile` screen
     - user should be able to successfully submit a document capture on their mobile phone
 
-##### 37. Browse back after enlarging the document
+##### 36. Browse back after enlarging the document
 (desktop and mobile browsers)
 
 1. Upload a document

--- a/test/features/sdk_flow.feature
+++ b/test/features/sdk_flow.feature
@@ -206,6 +206,8 @@ Feature: SDK File Upload Tests
 #   Until monster is updated to support launching Chrome with arguments (--use-fake-ui-for-media-stream, --use-fake-device-for-media-stream)
 #   this full test will fail in Travis
 #
+#   This is commented out test as the privacy feature is turned off behind the feature flag as Legal team didn't ask us to turn it on
+#
 #     Scenario Outline: I should be able to see a permission priming screen before trying to capture using my webcam.
 #       Given I initiate the verification process with <locale>
 #       And I do have a camera

--- a/test/features/sdk_flow.feature
+++ b/test/features/sdk_flow.feature
@@ -222,16 +222,9 @@ Feature: SDK File Upload Tests
 #         |      |        |
 #         | pdf  | es     |
 
-
     Scenario Outline: I should be taken to the cross-device flow if forceCrossDevice option is enabled
       Given I navigate to the SDK with forceCrossDevice feature enabled
       When I click on primary_button ()
       Then I should see 3 document_select_buttons ()
       When I click on passport ()
       Then page_title should include translation for "cross_device.intro.document.title"
-
-    Scenario Outline: I should be able to submit a document without seeing the document selector screen
-      Given I navigate to the SDK with one document type
-      When I click on primary_button ()
-      Then I should not see document_select_buttons ()
-      Then page_title should include translation for "capture.passport.front.title"

--- a/test/js/specs/happy.js
+++ b/test/js/specs/happy.js
@@ -207,6 +207,15 @@ describe('Happy Paths', options, ({driver, pageObjects}) => {
       uploadFileAndClickConfirmButton('face.jpeg')
       verificationComplete.verifyUIElements(verificationCompleteCopy)
     })
+
+    it('should be able to submit a document without seeing the document selector screen', async () => {
+      driver.get(localhostUrl + `?oneDoc=true&?async=false&useWebcam=false`)
+      welcome.primaryBtn.click(documentUploadCopy)
+      documentUpload.verifyPassportTitle(documentUploadCopy)
+      uploadFileAndClickConfirmButton('passport.jpg')
+      uploadFileAndClickConfirmButton('face.jpeg')
+      verificationComplete.verifyUIElements(verificationCompleteCopy)
+    })
   })
 
   describe('CROSS DEVICE SYNC', async () => {

--- a/test/js/specs/happy.js
+++ b/test/js/specs/happy.js
@@ -209,7 +209,7 @@ describe('Happy Paths', options, ({driver, pageObjects}) => {
     })
 
     it('should be able to submit a document without seeing the document selector screen', async () => {
-      driver.get(localhostUrl + `?oneDoc=true&?async=false&useWebcam=false`)
+      driver.get(localhostUrl + `?oneDoc=true&async=false&useWebcam=false`)
       welcome.primaryBtn.click(documentUploadCopy)
       documentUpload.verifyPassportTitle(documentUploadCopy)
       uploadFileAndClickConfirmButton('passport.jpg')


### PR DESCRIPTION
# Problem
UI test for oneDoc=true parameter is in Ruby and in manual regression.

# Solution
Implement automated test in JS, remove Ruby one and scenario from manual regression.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
