### PR TITLE
JS UI test for forceCrossDevice=true

### DIFF
--- a/MANUAL_REGRESSION.md
+++ b/MANUAL_REGRESSION.md
@@ -451,17 +451,7 @@ On iOS:
     - if the number is correct the user should be able to successfully send an SMS
     - if the number is invalid the user will see an error when clicking "Send link"
 
-##### 35. Force cross device for document upload
-(on one of the desktop browsers)
-
-1. Open link with additional GET parameter `?forceCrossDevice=true`
-2. Click on "Verify Identity"
-    - user should be forced to use x-device to submit document capture
-2. Click on link to start cross-device flow
-    - user should see `Continue your verification on mobile` screen
-    - user should be able to successfully submit a document capture on their mobile phone
-
-##### 36. Browse back after enlarging the document
+##### 35. Browse back after enlarging the document
 (desktop and mobile browsers)
 
 1. Upload a document

--- a/test/features/sdk_flow.feature
+++ b/test/features/sdk_flow.feature
@@ -221,10 +221,3 @@ Feature: SDK File Upload Tests
 #         | type | locale |
 #         |      |        |
 #         | pdf  | es     |
-
-    Scenario Outline: I should be taken to the cross-device flow if forceCrossDevice option is enabled
-      Given I navigate to the SDK with forceCrossDevice feature enabled
-      When I click on primary_button ()
-      Then I should see 3 document_select_buttons ()
-      When I click on passport ()
-      Then page_title should include translation for "cross_device.intro.document.title"

--- a/test/js/specs/happy.js
+++ b/test/js/specs/happy.js
@@ -597,5 +597,16 @@ describe('Happy Paths', options, ({driver, pageObjects}) => {
       crossDeviceSubmit.clickOnSubmitVerificationButton()
       verificationComplete.verifyUIElements(verificationCompleteCopy)
     })
+
+    it('should navigate to cross device when forceCrossDevice set to true ', async () => {
+      driver.get(localhostUrl + `?forceCrossDevice=true`)
+      const crossDeviceIntroCopy = crossDeviceIntro.copy()
+
+      welcome.primaryBtn.click(crossDeviceIntroCopy)
+      documentSelector.clickOnPassportIcon()
+      crossDeviceIntro.verifyTitle(crossDeviceIntroCopy)
+      crossDeviceIntro.verifyIcons()
+      crossDeviceIntro.verifyMessages(crossDeviceIntroCopy)
+    })
   })
 })


### PR DESCRIPTION
# Problem
UI test for forceCrossDevice=true parameter is in Ruby and in manual regression.

# Solution
Implement automated test in JS, remove Ruby one and scenario from manual regression.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
