### PR TITLE
Fix SDK not centered in IE11 for demo app

### DIFF
--- a/src/components/Modal/style.css
+++ b/src/components/Modal/style.css
@@ -45,7 +45,6 @@
   /* Relative positioning so overflow affects absolute children */
   position: relative;
   overflow: auto;
-  margin: auto;
 
   width: 94vw;
   max-width: 512*@unit;

--- a/src/demo/demo.ejs
+++ b/src/demo/demo.ejs
@@ -40,7 +40,6 @@
         max-width: 100%;
         max-height: 100%;
         box-sizing: border-box;
-        overflow: scroll;
         outline: 10px solid rgba(0, 255, 255, 0.3);
       }
     </style>


### PR DESCRIPTION
# Problem
When the Onfido SDK demo app is viewed on IE11 for any environments built on or branched off from `development` branch, the container SDK is not centred and appears on the right side of the screen.

# Solution
Remove `margin: auto` - it is very unreliable in IE and is apparently bad practice to use it alongside a parent element with `justify-content` (see https://github.com/philipwalton/flexbugs/issues/157 )

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
