### PR TITLE
Make README description of shape of onComplete() argument more accurate

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,6 @@ Onfido.init({
     //     "id": "0af77131-fd71-4221-a7c1-781f22aacd01",
     //     "variant": "standard"
     //   }
-    //   "document_back": {
-    //     "id": "6f63bfff-066e-4152-8024-3427c5fbf45d",
-    //     "type": "passport",
-    //     "side": "back"
-    //   },
     // }
     //
     // For two-sided documents like driving licences, the object will also

--- a/README.md
+++ b/README.md
@@ -136,24 +136,34 @@ Onfido.init({
   onComplete: function(data) {
     console.log("everything is complete")
     // `data` will be an object that looks something like this:
-    // ```
+    //
     // {
     //   "document_front": {
     //     "id": "5c7b8461-0e31-4161-9b21-34b1d35dde61",
     //     "type": "passport",
     //     "side": "front"
     //   },
+    //   "face": {
+    //     "id": "0af77131-fd71-4221-a7c1-781f22aacd01",
+    //     "variant": "standard"
+    //   }
     //   "document_back": {
     //     "id": "6f63bfff-066e-4152-8024-3427c5fbf45d",
     //     "type": "passport",
     //     "side": "back"
     //   },
-    //   "face": {
-    //     "id": "0af77131-fd71-4221-a7c1-781f22aacd01",
-    //     "variant": "standard"
-    //   }
     // }
-    // ```
+    //
+    // For two-sided documents like driving licences, the object will also
+    // contain a `document_back` property representing the reverse side:
+    //
+    // {
+    //   ...
+    //   "document_back": {
+    //     "id": "6f63bfff-066e-4152-8024-3427c5fbf45d",
+    //     "type": "passport",
+    //     "side": "back"
+    // }
     //
     // You can now trigger your backend to start a new check
     // `data.face.variant` will return the variant used for the face step

--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ Onfido.init({
     //     "type": "passport",
     //     "side": "front"
     //   },
+    //   "document_back": {
+    //     "id": "6f63bfff-066e-4152-8024-3427c5fbf45d",
+    //     "type": "passport",
+    //     "side": "back"
+    //   },
     //   "face": {
     //     "id": "0af77131-fd71-4221-a7c1-781f22aacd01",
     //     "variant": "standard"

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Onfido.init({
     //   ...
     //   "document_back": {
     //     "id": "6f63bfff-066e-4152-8024-3427c5fbf45d",
-    //     "type": "passport",
+    //     "type": "driving_licence",
     //     "side": "back"
     // }
     //


### PR DESCRIPTION
# Problem
The `document_back` property in the `onComplete()` callback is not documented.

# Solution
Add it to example argument in the README.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [X] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [n/a] Have tests passed locally?
- [n/a] Have any new strings been translated?
