### PR TITLE
Close modal view with ESC button

### DIFF
--- a/test/pageobjects/CameraPermissions.js
+++ b/test/pageobjects/CameraPermissions.js
@@ -13,6 +13,7 @@ class CameraPermissions extends Base {
 
   async verifyUIElementsOnTheCameraPermissionsScreen(copy) {
     const cameraPermissionsStrings = copy.webcam_permissions
+    this.driver.sleep(500)
     verifyElementCopy(this.title, cameraPermissionsStrings.allow_access)
     verifyElementCopy(this.subtitle, cameraPermissionsStrings.enable_webcam_for_selfie)
     verifyElementCopy(this.instructions, cameraPermissionsStrings.click_allow)

--- a/test/pageobjects/LivenessIntro.js
+++ b/test/pageobjects/LivenessIntro.js
@@ -11,6 +11,7 @@ class LivenessIntro extends Base {
 
   async verifyUIElementsOnTheLivenessIntroScreen(copy) {
     const livenessIntroStrings = copy.capture.liveness.intro
+    this.driver.sleep(500)
     verifyElementCopy(this.title, livenessIntroStrings.title)
     this.cameraIcon.isDisplayed()
     this.microphoneIcon.isDisplayed()

--- a/test/pageobjects/Welcome.js
+++ b/test/pageobjects/Welcome.js
@@ -1,6 +1,7 @@
 import Base from './BasePage.js'
 import {locale, verifyElementCopy} from '../utils/mochaw'
 import { testFocusManagement, elementCanReceiveFocus } from '../utils/accessibility'
+import { Key } from 'selenium-webdriver'
 
 class Welcome extends Base {
   get title() { return this.$('.onfido-sdk-ui-PageTitle-titleSpan')}
@@ -44,6 +45,10 @@ class Welcome extends Base {
 
   async clickOnCloseModalButton() {
     this.closeModalButton.click()
+  }
+
+  async pressEscapeButton() {
+    this.title.sendKeys(Key.ESCAPE)
   }
 
   async checkBackArrowIsNotDisplayed() {

--- a/test/specs/happy.js
+++ b/test/specs/happy.js
@@ -591,28 +591,32 @@ describe('Happy Paths', options, ({driver, pageObjects}) => {
 
   describe('MODAL VIEW', async () => {
 
+    const closeModalMethod = {
+      CLOSE_BUTTON_CLICK: 'welcome.clickOnCloseModalButton()',
+    }
+    
+    const openAndCloseModal = async (closeMethod) => {
+      driver.get(localhostUrl + `?useModal=true`)
+      const welcomeCopy = welcome.copy()
+      welcome.clickOnOpenModalButton()
+      welcome.verifyTitle(welcomeCopy)
+      driver.sleep(500)
+      if (closeMethod === closeModalMethod.CLOSE_BUTTON_CLICK) {
+        welcome.clickOnCloseModalButton()
+      } else {
+        welcome.pressEscapeButton()
+      }
+      driver.sleep(500)
+      welcome.clickOnOpenModalButton()
+      welcome.verifyTitle(welcomeCopy)
+    }
+  
     it('should be able to open, close and open again a modal view', async () => {
-      driver.get(localhostUrl + `?useModal=true`)
-      const welcomeCopy = welcome.copy()
-      welcome.clickOnOpenModalButton()
-      welcome.verifyTitle(welcomeCopy)
-      driver.sleep(500)
-      welcome.clickOnCloseModalButton()
-      driver.sleep(500)
-      welcome.clickOnOpenModalButton()
-      welcome.verifyTitle(welcomeCopy)
+      openAndCloseModal(closeModalMethod.CLOSE_BUTTON_CLICK)
     })
-
+  
     it('should be able to close modal with ESC button', async () => {
-      driver.get(localhostUrl + `?useModal=true`)
-      const welcomeCopy = welcome.copy()
-      welcome.clickOnOpenModalButton()
-      welcome.verifyTitle(welcomeCopy)
-      driver.sleep(500)
-      welcome.pressEscapeButton()
-      driver.sleep(500)
-      welcome.clickOnOpenModalButton()
-      welcome.verifyTitle(welcomeCopy)
+      openAndCloseModal()
     })
   })
 

--- a/test/specs/happy.js
+++ b/test/specs/happy.js
@@ -602,6 +602,18 @@ describe('Happy Paths', options, ({driver, pageObjects}) => {
       welcome.clickOnOpenModalButton()
       welcome.verifyTitle(welcomeCopy)
     })
+
+    it('should be able to close modal with ESC button', async () => {
+      driver.get(localhostUrl + `?useModal=true`)
+      const welcomeCopy = welcome.copy()
+      welcome.clickOnOpenModalButton()
+      welcome.verifyTitle(welcomeCopy)
+      driver.sleep(500)
+      welcome.pressEscapeButton()
+      driver.sleep(500)
+      welcome.clickOnOpenModalButton()
+      welcome.verifyTitle(welcomeCopy)
+    })
   })
 
   describe('BACK NAVIGATION', () => {


### PR DESCRIPTION
# Problem
Currently, we have the UI test that closes the modal by clicking on x button. Modal can also be closed by pressing the ESC button so would be good to cover that scenario with the test.

# Solution
Add UI test to close modal view with ESC button.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
