### PR TITLE
Remove redundant manual test cases

### DIFF
--- a/MANUAL_REGRESSION.md
+++ b/MANUAL_REGRESSION.md
@@ -349,7 +349,8 @@ Given webcam is connected to the computer
 ### 25. Face video on desktop with webcam
 (on private mode of: Safari and Edge browsers - these browsers do not support video recording)
 
-0. Given webcam is connected to the computer
+Given webcam is connected to the computer
+
 1. Open link with additional GET parameter `?liveness=true`
 2. Go through the flow to face capture
 3. You should see a screen that guides you to use your mobile

--- a/MANUAL_REGRESSION.md
+++ b/MANUAL_REGRESSION.md
@@ -98,32 +98,16 @@ Given user is
 3. Open link on mobile device (for each mobile browser)
     - user should see that the SDK is in Spanish
 
-### 6. Cross-device resend SMS
-(on private mode of another browser)
-
-Given user is on first page of cross-device flow
-
-1. Type valid mobile number connected to mobile test device and send
-    - user should see `Check your mobile` screen
-    - user should see option to resend link
-2. Click `Resend link`
-    - user should see `Continue verification on your mobile` screen again
-    - user should be able to provide mobile number again
-    - user should see the option to send SMS
-
-### 7. Cross-device errors
+### 6. Cross-device errors
 (on private mode of yet another browser)
 
 Given user is on first page of cross-device flow
 
-1. Type invalid mobile number and click send
-    - user should see an validation error
-    - user should persist on the same screen
-2. **STAGING ONLY:** Type invalid US number (+1 234 567 8912) and click send
+1. **STAGING ONLY:** Type invalid US number (+1 234 567 8912) and click send
     - user should see `Something's gone wrong` error
     - user should persist on the same screen
 
-### 8. Prevent opening cross-device URL on web browsers
+### 7. Prevent opening cross-device URL on web browsers
 (on private mode of: Google Chrome, Firefox, Safari and Microsoft Edge browsers)
 
 Given user is on first page of cross-device flow
@@ -135,7 +119,7 @@ Given user is on first page of cross-device flow
     - user should see `You must open this link on a mobile device` message
     - user should see the icon with the phone, screen and the red cross
 
-###  9. Cross device transition between browsers with different liveness support
+###  8. Cross device transition between browsers with different liveness support
 (on private mode of: Google Chrome, Firefox)
 
 Given webcam is connected to the computer
@@ -157,7 +141,7 @@ Given webcam is not connected to the computer
 4. Open the cross device link on a mobile device that has media recorder API support (Chrome on Android)
     - user should be taken to the liveness intro screen
 
-### 10. Check happy path flow on other desktop browsers
+### 9. Check happy path flow on other desktop browsers
 (on private mode of: Safari, Firefox, IE11 and Microsoft Edge browsers)
 
 Go through the flow looking for layout/usability inconsistencies between browsers:
@@ -169,7 +153,7 @@ Go through the flow looking for layout/usability inconsistencies between browser
 3. Upload face photo
     - everything should be displayed properly and layout should not be broken
 
-### 11. Check happy path flow on mobile browsers
+### 10. Check happy path flow on mobile browsers
 (on private mode of: Android Google Chrome and iOS Safari browsers)
 
 Go through the flow looking for layout/usability inconsistencies between browsers:
@@ -181,20 +165,20 @@ Go through the flow looking for layout/usability inconsistencies between browser
 3. Upload face photo
     - everything should be displayed properly and layout should not be broken
 
-### 12. Check the camera is mirroring
+### 11. Check the camera is mirroring
 (ONLY ON browsers with getUserMedia support: on an iOS and Android device; a laptop with camera; desktop or laptop with a third-party USB camera)
 
 1. Go to the face step
 2. Move your face to the left
     - Make sure your face also moves to the left on camera feed (like looking at a mirror)
 
-### 13. Check the camera is fullscreen on mobile devices/small screens
+### 12. Check the camera is fullscreen on mobile devices/small screens
 (ONLY ON browsers with getUserMedia support: on an iOS and Android device; a laptop with camera; desktop or laptop with a third-party USB camera)
 
 1. Go to the face step. If on desktop resize the window to less than 480px width wise (if the browser let's you reduce that far)
 2. The capture component should be fullscreen
 
-### 14. Check that custom strings can be passed
+### 13. Check that custom strings can be passed
 (on any browser)
 
 1. Go to latest JSFiddle
@@ -207,7 +191,7 @@ language: {
 ```
 3. Then the title on the welcome screen should be 'Ouvrez votre nouveau compte bancaire'
 
-### 15. Overriding strings for a supported language
+### 14. Overriding strings for a supported language
 (on any browser)
 
 1. Go to latest JSFiddle
@@ -221,7 +205,7 @@ language: {
 3. Then the title on the welcome screen should be 'A custom string'
 4. All the other strings should be in Spanish
 
-### 16. Overriding strings for a supported language on mobile
+### 15. Overriding strings for a supported language on mobile
 (on any browser)
 
 1. Go to latest JSFiddle
@@ -238,7 +222,7 @@ language: {
 6. When you open the link on your mobile device, the title on the cross device client should be `A custom string`
 7. All the other strings should be in Spanish
 
-### 17. Upload a document in PDF format
+### 16. Upload a document in PDF format
 *Feature is available on desktop browsers only.*
 (on Firefox, Safari, IE11 and Microsoft Edge browsers)
 
@@ -251,7 +235,7 @@ Outcome:
 - on Safari (and Chrome - this is automated) you should see a preview of the PDF
 - on Firefox, IE11, Microsoft Edge and mobile browsers you should see an icon of a PDF
 
-### 18. Overriding the document options
+### 17. Overriding the document options
 
 1. Go to latest JSFiddle
 1. Add the following options to the initialisation params:
@@ -277,7 +261,7 @@ Outcome:
 
 - On the document selection screen only "Passport" and "Driver's License" options should be visible.
 
-### 19. Check permission priming screen displays when webcam is available and permission was not yet granted
+### 18. Check permission priming screen displays when webcam is available and permission was not yet granted
 (on Firefox, Safari and Microsoft Edge browsers)
 
 1. Go through the flow to document capture
@@ -287,7 +271,7 @@ Outcome:
 5. Click `Enable webcam`
 6. You should see the capture screen and camera permissions prompt
 
-### 20. Check permission priming screen does not display when webcam is available and permission was already granted
+### 19. Check permission priming screen does not display when webcam is available and permission was already granted
 (on Chrome)
 
 1. Go through the flow to document capture
@@ -295,7 +279,7 @@ Outcome:
 3. Click `Confirm`
 4. You should see the capture screen
 
-### 21. Check permission denied / recovery screen displays when webcam is available and permission wasn't previously denied and is denied after prompt
+### 20. Check permission denied / recovery screen displays when webcam is available and permission wasn't previously denied and is denied after prompt
 (on Chrome)
 
 1. Go through the flow to document capture
@@ -307,7 +291,7 @@ Outcome:
 7. Click `Block`
 8. You should see the permission denied / recovery screen
 
-### 22. Check permission denied / recovery screen displays when webcam is available and permission was previously denied
+### 21. Check permission denied / recovery screen displays when webcam is available and permission was previously denied
 (on Firefox, Safari and Microsoft Edge browsers)
 
 1. Go through the flow to document capture
@@ -317,22 +301,7 @@ Outcome:
 5. Click `Enable webcam`
 6. You should see the permission denied / recovery screen if the browser does not remember previous decision
 
-### 23. Check an intro screen is displayed when entering the cross-device  flow
-(on Firefox, Safari, IE11 and Microsoft Edge browsers)
-
-1. Go through the flow to document capture
-2. Click `Need to use your mobile to take photos?`
-3. You should see the cross-device intro screen
-
-### 24. Check flow changes to cross device when no webcam available
-(no webcam / webcam disabled)
-
-1. Go through the flow to document capture
-2. Upload a valid document
-3. Click `Confirm`
-4. You should see the cross-device intro screen
-
-### 25. Live capture fallback on Desktop
+### 22. Live capture fallback on Desktop
 (on private mode of: Google Chrome, Firefox, Safari and Microsoft Edge browsers)
 
 Given webcam is connected to the computer
@@ -346,7 +315,7 @@ Given webcam is connected to the computer
 4. Click on "Use your mobile"
     - You should be able to continue on mobile
 
-### 26. Live capture fallback on mobile
+### 23. Live capture fallback on mobile
 (Google Chrome on Android, getUsermedia supported browser, and Safari on iOS11+)
 
 1. Go through the flow to face capture
@@ -358,7 +327,7 @@ Given webcam is connected to the computer
 4. Click on "Try the basic camera mode instead"
     - You should be able to take a picture with your native camera
 
-### 27. Face video on desktop with webcam
+### 24. Face video on desktop with webcam
 (on private mode of: Google Chrome and Firefox browsers)
 
 Given webcam is connected to the computer
@@ -377,7 +346,7 @@ Given webcam is connected to the computer
     - once completed, you should be able to see the video and to click on "Confirm"
     - you should see the complete screen
 
-### 28. Face video on desktop with webcam
+### 25. Face video on desktop with webcam
 (on private mode of: Safari and Edge browsers - these browsers do not support video recording)
 
 0. Given webcam is connected to the computer
@@ -390,7 +359,7 @@ Given webcam is connected to the computer
     - Upload selfie
     - Confirm
 
-### 29. Face video on desktop with no video support or no webcam
+### 26. Face video on desktop with no video support or no webcam
 (on private mode of: any browser with no webcam OR Safari and Edge browsers)
 
 Given there is no webcam connected to the computer
@@ -410,7 +379,7 @@ On iOS:
     - Upload selfie
     - Confirm
 
-### 30. Custom SMS country code and flag
+### 27. Custom SMS country code and flag
 (on one of the desktop browsers)
 
 Given there is no webcam connected to the computer
@@ -422,7 +391,7 @@ Given there is no webcam connected to the computer
     - user should see the option to send SMS
     - the SMS input flag should be the US flag
 
-### 31. Custom SMS with invalid country code
+### 28. Custom SMS with invalid country code
 (on one of the desktop browsers)
 
 Given there is no webcam connected to the computer
@@ -434,20 +403,7 @@ Given there is no webcam connected to the computer
     - user should see the option to send SMS
     - the SMS input flag should be the UK one
 
-### 32. Proof of Address
-(on private mode of: Google Chrome, Firefox, Safari and Microsoft Edge browsers)
-
-1. Open link with additional GET parameter `?poa=true`
-2. On the welcome screen click on Verify Identity
-3. You should see the PoA intro screen with title "Let’s verify your UK address"
-    - Click "Start Verification"
-4. Select a document type
-    - You should see a guidance screen and the title should be the name of the document type you chose
-5. Click on the "Upload file" button
-    - Confirmation screen should show up containing a photo that was taken
-    - You should be able to retake or continue with taken photo
-
-### 33. Prevent upload fallback when requested
+### 29. Prevent upload fallback when requested
 
 Given user opened the link with `?uploadFallback=false` flag
 
@@ -472,7 +428,7 @@ Given user opened the link with `?uploadFallback=false` flag
     - user should see `Restart the process with a different device` message
     - user should see the icon with the phone, screen and the red cross
 
-### 34. Custom SMS number
+### 30. Custom SMS number
 (on one of the desktop browsers)
 
 1. Open link with additional GET parameter `?smsNumber=+447955555555`
@@ -483,7 +439,7 @@ Given user opened the link with `?uploadFallback=false` flag
     - if the number is correct the user should be able to successfully send an SMS
     - if the number is invalid the user will see an error when clicking "Send link"
 
-### 35. Browse back after enlarging the document
+### 31. Browse back after enlarging the document
 (desktop and mobile browsers)
 
 1. Upload a document


### PR DESCRIPTION
# Problem
Recently we added automated tests that cover some of the manual test cases we have in `MANUAL_REGRESSION.md` document. It would be good to remove the redundant test cases so we will save time while going through the manual regression.

# Solution
Remove redundant test cases from [MANUAL_REGRESSION.md](https://github.com/onfido/onfido-sdk-ui/blob/master/MANUAL_REGRESSION.md) that are covered by automated tests.

```
### 6. Cross-device resend SMS
(on private mode of another browser)

Given user is on first page of cross-device flow

1. Type valid mobile number connected to mobile test device and send
- user should see `Check your mobile` screen
- user should see option to resend link
2. Click `Resend link`
- user should see `Continue verification on your mobile` screen again
- user should be able to provide mobile number again
- user should see the option to send SMS

**Covered by
should be able to resend sms**

7.1. Type invalid mobile number and click send
- user should see an validation error
- user should persist on the same screen

**Covered by
should display error when number is wrong**

### 23. Check an intro screen is displayed when entering the cross-device flow
(on Firefox, Safari, IE11 and Microsoft Edge browsers)

1. Go through the flow to document capture
2. Click `Need to use your mobile to take photos?`
3. You should see the cross-device intro screen

**Covered by
cross device sync intro screen**

### 24. Check flow changes to cross device when no webcam available
(no webcam / webcam disabled)

1. Go through the flow to document capture
2. Upload a valid document
3. Click `Confirm`
4. You should see the cross-device intro screen

**Covered by
should be taken to the cross-device flow if I do not have a camera and liveness variant requested**

### 32. Proof of Address
(on private mode of: Google Chrome, Firefox, Safari and Microsoft Edge browsers)

1. Open link with additional GET parameter `?poa=true`
2. On the welcome screen click on Verify Identity
3. You should see the PoA intro screen with title "Let’s verify your UK address"
- Click "Start Verification"
4. Select a document type
- You should see a guidance screen and the title should be the name of the document type you chose
5. Click on the "Upload file" button
- Confirmation screen should show up containing a photo that was taken
- You should be able to retake or continue with taken photo

**Covered by
We have a bunch of test that cover more than this scenario for proof of address**
```

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
