### PR TITLE
Download latest chromedriver instead 74 version

### DIFF
--- a/test/scripts/install_chromedriver_travis.sh
+++ b/test/scripts/install_chromedriver_travis.sh
@@ -3,8 +3,7 @@
 set -ev
 
 # take the latest chromedriver version from https://chromedriver.storage.googleapis.com/LATEST_RELEASE
-# version locked to 74 from  https://chromedriver.storage.googleapis.com/index.html
-CHROME_DRIVER_VERSION=$(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE_74.0.3729)
+CHROME_DRIVER_VERSION=$(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
 CHROME_VERSION="google-chrome-stable"
 
 echo "Uninstalling current Chromium from `which chromium-browser`..."


### PR DESCRIPTION
# Problem
Our script wasn't getting the latest version of chromedriver but it was locked to the version 74 due to the problems with ruby tests in the past (https://github.com/onfido/onfido-sdk-ui/pull/693). Since we do not have any ruby tests on the project we can download the latest version of the chromedriver.

# Solution
Change the script to download the latest version of the chromedriver.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
