### PR TITLE
Increase client-side upload limit to 10mb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Breaking changes result in a different major. UI changes that might break custom
 
 ## [next-version]
 
+## [0.15.2]
+
+### Fixed
+- Public: Update the file size limit to 10MB in line with the new Onfido API and Applicant Form limit.
+
 ## [0.15.1]
 
 ### Fixed

--- a/src/components/Capture/capture.js
+++ b/src/components/Capture/capture.js
@@ -137,7 +137,7 @@ class Capture extends Component {
     }
 
     // The Onfido API only accepts files below 4MB
-    if (file.size > 4000000) {
+    if (file.size > 10000000) {
       this.onFileSizeError()
       return
     }

--- a/src/components/Uploader/index.js
+++ b/src/components/Uploader/index.js
@@ -41,7 +41,7 @@ const ServerError = ({message}) =>
   <UploadError>{message}</UploadError>
 
 InvalidFileSize.defaultProps = {
-  message: 'The file size limit of 4MB has been exceeded. Please try again.'
+  message: 'The file size limit of 10MB has been exceeded. Please try again.'
 }
 
 ServerError.defaultProps = {


### PR DESCRIPTION
# Problem
The applicant form integrates with the onfido-sdk-ui version 0.15.1. This version has a client-side, hardcoded file upload size limit of 4MB. The NGINX web server that routes requests to the applicant form app server actually limits uploads to 10MB and the client side should be updated to reflect this more up-to-date limit. 

The alternative could be to update the version of the sdk to use something newer, however this has turned out to be a much larger effort. As I understand, it could take up to a full sprint to carry out. 

# Solution
Update 4000000 to 10000000 and '4MB' to '10MB'.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [x] Have tests passed locally?