### PR TITLE
Update release guidelines with crowd testing provider instructions

### DIFF
--- a/release/release.js
+++ b/release/release.js
@@ -298,6 +298,7 @@ const regressionTesting = async () => {
   stepTitle('👀 Regression testing')
   console.log('✅ Release candidate complete!')
   console.log('🏃 Go ahead and test the SDK deployment on https://release-[PR-NUMBER]-pr-onfido-sdk-ui-onfido.surge.sh')
+  console.log('If running test cycle with crowd testing provider, share https://release-[PR-NUMBER]-pr-onfido-sdk-ui-onfido.surge.sh and MANUAL_REGRESSION.md file in relevant Slack channel setting up the scope and duration of the cycle.')
 }
 
 const releaseComplete = () => {


### PR DESCRIPTION
# Problem
Release script was missing the instructions about crowd testing provider.

# Solution
Add instructions to release script what to do in case we want to run a test cycle with crowd testing provider before release.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
