### PR TITLE
Fix RC version being generated with stray -

### DIFF
--- a/release/release.js
+++ b/release/release.js
@@ -38,7 +38,7 @@ const confirmReleaseVersion = async () => {
   if (isReleaseCandidate) {
     const isTestReleaseCandidate = await question('Is this a Test Release Candidate?')
     const rcNumber = await getNumberInput('What is the Release Candidate number? ')
-    config.write('versionRC', `${VERSION}-rc.${rcNumber}-${isTestReleaseCandidate ? "-test" : ""}`)
+    config.write('versionRC', `${VERSION}-rc.${rcNumber}${isTestReleaseCandidate ? "-test" : ""}`)
     const isFirstReleaseIteration = parseInt(rcNumber, 10) === 1
     config.write('isFirstReleaseIteration', isFirstReleaseIteration)
     console.log(`This is a ${chalk.bold.yellow('RELEASE CANDIDATE')}.`)


### PR DESCRIPTION
# Problem
When running the release script to create a Release Candidate, the resulting version generated has a stray `-` character at the end if it is not a test Release Candidate.

# Solution
Remove `-` character in `versionRC` string generated at line 41 of release script

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
