### PR TITLE
Pass url to chainMultiframeUpload function, fix multiple selfie frame…

### DIFF
--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -71,7 +71,7 @@ const Previews = localised(({capture, retakeAction, confirmAction, error, method
   )
 })
 
-const chainMultiframeUpload = (snapshot, selfie, token, onSuccess, onError) => {
+const chainMultiframeUpload = (snapshot, selfie, token, url, onSuccess, onError) => {
   const snapshotData = {
     file: {
       blob: snapshot.blob,
@@ -82,11 +82,10 @@ const chainMultiframeUpload = (snapshot, selfie, token, onSuccess, onError) => {
     advanced_validation: false
   }
   const { blob, filename, sdkMetadata } = selfie
-  const url = this.props.urls.onfido_api_url
 
   // try to upload snapshot first, if success upload selfie, else handle error
   uploadLivePhoto(snapshotData, url, token,
-    () => uploadLivePhoto({ file: { blob, filename }, url, sdkMetadata }, token,
+    () => uploadLivePhoto({ file: { blob, filename }, sdkMetadata }, url, token,
       onSuccess, onError
     ),
     onError
@@ -166,9 +165,10 @@ class Confirm extends Component {
 
   handleSelfieUpload = ({snapshot, ...selfie }, token) => {
     // if snapshot is present, it needs to be uploaded together with the user initiated selfie
+    const url = this.props.urls.onfido_api_url
     if (snapshot) {
       sendEvent('Starting multiframe selfie upload')
-      chainMultiframeUpload(snapshot, selfie, token,
+      chainMultiframeUpload(snapshot, selfie, token, url,
         this.onApiSuccess, this.onApiError
       )
     }
@@ -178,7 +178,6 @@ class Confirm extends Component {
       // Captures that have been taken via the Uploader component do not have filename
       // and the blob is a File type
       const filePayload = filename ? { blob, filename } : blob
-      const url = this.props.urls.onfido_api_url
       uploadLivePhoto({ file: filePayload, sdkMetadata }, url, token,
         this.onApiSuccess, this.onApiError
       )

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -164,8 +164,8 @@ class Confirm extends Component {
   }
 
   handleSelfieUpload = ({snapshot, ...selfie }, token) => {
-    // if snapshot is present, it needs to be uploaded together with the user initiated selfie
     const url = this.props.urls.onfido_api_url
+    // if snapshot is present, it needs to be uploaded together with the user initiated selfie
     if (snapshot) {
       sendEvent('Starting multiframe selfie upload')
       chainMultiframeUpload(snapshot, selfie, token, url,


### PR DESCRIPTION
# Problem
When trying to upload a selfie using the `useMultipleSelfieCapture` option, the user cannot reach the complete step. 

# Solution
Pass url to chainMultiframeUpload function, fix multiple selfie frame capture submission

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have tests passed locally?
- [ ] Have any new strings been translated?
