### PR TITLE
More descriptive shutter button ARIA label

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -372,7 +372,7 @@
     "close_sdk_screen": "Close identity verification screen",
     "dismiss_alert": "Dismiss alert",
     "camera_view": "View from camera",
-    "shutter": "Shutter",
+    "shutter": "Take a photo",
     "start_recording": "Start recording",
     "stop_recording": "Stop recording",
     "replay_video": "Replay your recorded video",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -287,7 +287,7 @@
     "close_sdk_screen": "Cerrar pantalla de verificación",
     "camera_view": "Vista desde la camara",
     "dismiss_alert": "Cerrar alerta",
-    "shutter": "Obturador",
+    "shutter": "Tome una foto",
     "start_recording": "Iniciar grabación",
     "stop_recording": "Parar grabación",
     "replay_video": "Reproducir su video grabado",


### PR DESCRIPTION
# Problem
Currently the ARIA label for the camera shutter button on Selfie, Liveness capture screens reads as "Shutter". It should read as "Take a photo".

# Solution
Changed ARIA copy label for camera shutter button to "Take a photo", including Spanish translation for it.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [n/a] Have new automated tests been implemented?
- [n/a] Have new manual tests been written down?
- [x] Have tests passed locally?
- [x] Have any new strings been translated?
