### PR TITLE
Move NPM Login check/prompt to after Git tag creation

### DIFF
--- a/release/release.js
+++ b/release/release.js
@@ -261,6 +261,7 @@ const loginToNpm = async () => {
 
 const publishTag = async () => {
   if (config.data.versionRC) {
+    await loginToNpm()
     stepTitle(`🕑 Creating next tag for release candidate ${config.data.versionRC}`)
     await spawnAssumeOkay('npm', ['publish', '--tag', 'next'])
     console.log('Done. Now make sure that the latest tag has not changed, only the next one:')

--- a/release/release.js
+++ b/release/release.js
@@ -327,13 +327,13 @@ const main = async () => {
   await loginToS3()
   await uploadToS3()
   await didS3uploadSucceed()
-  await loginToNpm()
   await publishTag()
   if (config.data.versionRC) {
     await upgradeDemoAppToTag()
     regressionTesting()
   }
   else {
+    await loginToNpm()
     await publishToNpm()
     await upgradeDemoAppToTag()
     releaseComplete()


### PR DESCRIPTION
# Problem
Following the manual release process notes against the release script's process the release tag should be created before NPM login/publish step. 

Currently the release tag creation happens between NPM login check/prompt and the NPM publish step.

# Solution
Move NPM login check/prompt to after release tag creation.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have any new strings been translated?
