### PR TITLE
Fix Submit Verification button on x-device submission screen triggering multiple onComplete events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Fixed
 - UI: Accessibility - Make camera feed view accessible to screen readers
 - UI: Accessibility - More descriptive ARIA label for camera shutter button
+- Public: Fixed user being able to submit verification multiple times on coming back to desktop from the cross device flow if integrator has opted to exclude the `complete` step in SDK setup
 
 ## [5.3.0] - 2019-09-03
 

--- a/src/components/Button/style.css
+++ b/src/components/Button/style.css
@@ -47,15 +47,17 @@
 
   background-color: @color-primary-button;
 
-  &.hoverDesktop {
+  &.hoverDesktop:not(:disabled) {
     &:hover {
       background-color: @color-primary-button-hover;
     }
   }
 
-  &:active,
-  &.hoverDesktop:active {
-    background-color: @color-primary-button-active;
+  &:not(:disabled) {
+    &:active,
+    &.hoverDesktop:active {
+      background-color: @color-primary-button-active;
+    }
   }
 }
 

--- a/src/components/Button/style.css
+++ b/src/components/Button/style.css
@@ -17,8 +17,8 @@
 
   &:disabled {
     cursor: not-allowed;
-    background-color: #e8ecf0;
-    color: #d5dae0;
+    background-color: @color-primary-button-disabled;
+    color: darken(@color-primary-button-disabled, 20%);
   }
 }
 

--- a/src/components/Button/style.css
+++ b/src/components/Button/style.css
@@ -17,6 +17,8 @@
 
   &:disabled {
     cursor: not-allowed;
+    background-color: #e8ecf0;
+    color: #d5dae0;
   }
 }
 

--- a/src/components/Theme/constants.css
+++ b/src/components/Theme/constants.css
@@ -92,6 +92,7 @@
 @color-primary-button: @color-primary-500;
 @color-primary-button-hover: #5c6cff;
 @color-primary-button-active: #232aad;
+@color-primary-button-disabled: #e8ecf0;
 
 @color-secondary-button: @color-transparent;
 @color-secondary-button-hover: rgba(92, 108, 255, 0.15);

--- a/src/components/crossDevice/CrossDeviceSubmit/index.js
+++ b/src/components/crossDevice/CrossDeviceSubmit/index.js
@@ -10,6 +10,13 @@ import style from './style.css'
 import { localised } from '../../../locales'
 
 class CrossDeviceSubmit extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      isSubmitDisabled: false
+    }
+  }
+
   hasMultipleDocuments = () => {
     const { steps } = this.props
     const documentSteps = steps.filter(step => step.type === 'document')
@@ -24,6 +31,11 @@ class CrossDeviceSubmit extends Component {
     const { captures = {} } = this.props
     const { face = {} } = captures
     return face && face.metadata ? face.metadata.variant : 'standard'
+  }
+
+  handleSubmitButtonClick = () => {
+    this.setState({ isSubmitDisabled: true })
+    this.props.nextStep()
   }
 
   render () {
@@ -57,7 +69,8 @@ class CrossDeviceSubmit extends Component {
           <div>
             <Button
               variants={["primary", "centered"]}
-              onClick={nextStep}
+              onClick={this.handleSubmitButtonClick}
+              disabled={this.state.isSubmitDisabled}
             >
               {translate('cross_device.submit.action')}
             </Button>

--- a/src/components/crossDevice/CrossDeviceSubmit/index.js
+++ b/src/components/crossDevice/CrossDeviceSubmit/index.js
@@ -11,10 +11,8 @@ import { localised } from '../../../locales'
 
 class CrossDeviceSubmit extends Component {
   hasMultipleDocuments = () => {
-    const {steps} = this.props
-    const documentSteps = steps.filter(step =>
-      step.type === 'document'
-    )
+    const { steps } = this.props
+    const documentSteps = steps.filter(step => step.type === 'document')
     return documentSteps.length > 1
   }
 
@@ -42,14 +40,16 @@ class CrossDeviceSubmit extends Component {
           <ul className={style.uploadList} aria-label={translate('cross_device.tips')} >
             <li className={style.uploadListItem}>
               <span className={`${theme.icon} ${style.icon}`}/>
-              <span className={classNames(style.listText, style.documentUploadedLabel)}>{translate(documentCopy)}</span>
+              <span className={classNames(style.listText, style.documentUploadedLabel)}>
+                {translate(documentCopy)}
+              </span>
             </li>
             { this.hasFaceCaptureStep() &&
               <li className={style.uploadListItem}>
                 <span className={`${theme.icon} ${style.icon}`}/>
-                <span className={classNames(style.listText, style[`${faceCaptureVariant}UploadedLabel`])}>{
-                  translate(`cross_device.submit.${faceCaptureVariant}_uploaded`)
-                }</span>
+                <span className={classNames(style.listText, style[`${faceCaptureVariant}UploadedLabel`])}>
+                  {translate(`cross_device.submit.${faceCaptureVariant}_uploaded`)}
+                </span>
               </li>
             }
           </ul>

--- a/src/components/crossDevice/CrossDeviceSubmit/index.js
+++ b/src/components/crossDevice/CrossDeviceSubmit/index.js
@@ -39,7 +39,7 @@ class CrossDeviceSubmit extends Component {
   }
 
   render () {
-    const { translate, nextStep } = this.props
+    const { translate } = this.props
     const documentCopy = this.hasMultipleDocuments() ?
       'cross_device.submit.multiple_docs_uploaded' : 'cross_device.submit.one_doc_uploaded'
     const faceCaptureVariant = this.getFaceCaptureVariant() === 'standard' ? 'selfie' : 'video'

--- a/src/components/crossDevice/CrossDeviceSubmit/index.js
+++ b/src/components/crossDevice/CrossDeviceSubmit/index.js
@@ -10,8 +10,8 @@ import style from './style.css'
 import { localised } from '../../../locales'
 
 class CrossDeviceSubmit extends Component {
-  constructor(props) {
-    super(props)
+  constructor() {
+    super()
     this.state = {
       isSubmitDisabled: false
     }

--- a/src/demo/demoUtils.js
+++ b/src/demo/demoUtils.js
@@ -48,7 +48,7 @@ export const getInitSdkOptions = () => {
           : 1000
       }
     },
-    'complete'
+    queryParamToValueString.noCompleteStep !== 'true' && 'complete'
   ].filter(Boolean)
 
   const smsNumberCountryCode = queryParamToValueString.countryCode


### PR DESCRIPTION
# Problem
From a tech support issue: If integrator has set up SDK without a Complete step, user can click on "Submit verification" button multiple times, hence triggering multiple onComplete callbacks. 

# Solution
Disable button on click so that onComplete event is only fired once.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [n/a] Have any new strings been translated?
