### PR TITLE
Fix Camera Permission screen button not displaying on iOS 11 Safari

### DIFF
--- a/src/components/CameraPermissions/Primer/index.js
+++ b/src/components/CameraPermissions/Primer/index.js
@@ -7,7 +7,7 @@ import style from './style.css'
 import { localised } from '../../../locales'
 
 const Permissions = ({onNext, translate}) => (
-  <div className={`${style.container} ${theme.fullHeightContainer}`}>
+  <div className={theme.fullHeightContainer}>
     <PageTitle title={translate('webcam_permissions.allow_access')} subTitle={translate('webcam_permissions.enable_webcam_for_selfie')} />
     <div className={`${theme.thickWrapper} ${style.bodyWrapper}`}>
       <div className={style.image}>

--- a/src/components/CameraPermissions/Primer/style.css
+++ b/src/components/CameraPermissions/Primer/style.css
@@ -78,5 +78,5 @@
 .buttonInstructions {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;;
+  justify-content: space-between;
 }

--- a/src/components/CameraPermissions/Primer/style.css
+++ b/src/components/CameraPermissions/Primer/style.css
@@ -1,10 +1,5 @@
 @import (less) "../../Theme/constants.css";
 
-.container {
-  width: 100%;
-  height: 100%;
-}
-
 .bodyWrapper {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
# Problem
On iOS 11 Safari when user is on mobile x-device flow on reaching the Face capture step and camera permission is required the button is not visible so user is stuck on that screen.

![image](https://user-images.githubusercontent.com/2497081/65965975-61773200-e457-11e9-939c-1f5e9497033f.png)

# Solution
Remove stray/extra semicolon in `.buttonInstructions` style of the component's CSS.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have any new strings been translated?
