### PR TITLE
Use patch versions for socket.io-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Changed
 - Public: Disable console warning for client integrations that override only some strings for a supported language. If they provide partial translations for an unsupported language, warning is still displayed.
+- Public: Only upgrade to patch versions of `socket.io-client`. See issue [here](https://github.com/socketio/socket.io-client/issues/1325)
 
 ### Fixed
 - UI: Accessibility - Make camera feed view accessible to screen readers

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "raven-js": "^3.26.3",
     "redux": "~3.5.2",
     "reselect": "~2.5.1",
-    "socket.io-client": "^2.0.4",
+    "socket.io-client": "~2.2.0",
     "supports-webp": "~1.0.3",
     "visibilityjs": "~1.2.4"
   }


### PR DESCRIPTION
# Problem
The latest version of `socket.io-client` does not support ES5. This is a bug and it's affecting some of our clients.
https://github.com/socketio/socket.io-client/issues/1325

# Solution
Only upgrade to patch versions for `socket.io-client`


## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have any new strings been translated?
