### PR TITLE
Allow to set nextButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Fixed
 - UI: Accessibility - Non-interactive Header elements do not get announced with "Double tap to activate" by Android Talkback
+- UI: Custom string `nextButton` set for the `welcome` step is now displayed
 
 ## [5.4.0]
 

--- a/src/components/Welcome/index.js
+++ b/src/components/Welcome/index.js
@@ -9,9 +9,10 @@ import {localised} from '../../locales'
 const localisedDescriptions = translate =>
   [translate('welcome.description_p_1'), translate('welcome.description_p_2')]
 
-const Welcome = ({title, descriptions, nextStep, translate}) => {
+const Welcome = ({title, descriptions, nextButton, nextStep, translate}) => {
   const welcomeTitle = title ? title : translate('welcome.title')
   const welcomeDescriptions = descriptions ? descriptions : localisedDescriptions(translate)
+  const welcomeNextButton = nextButton ? nextButton : translate('welcome.next_button')
   return (
     <div>
       <PageTitle title={welcomeTitle} />
@@ -20,7 +21,7 @@ const Welcome = ({title, descriptions, nextStep, translate}) => {
           {welcomeDescriptions.map(description => <p>{description}</p>)}
         </div>
         <Button onClick={nextStep} variants={['centered', 'primary']}>
-          {translate('welcome.next_button')}
+          {welcomeNextButton}
         </Button>
       </div>
     </div>


### PR DESCRIPTION
# Problem

Documentation states that you can set a custom text fort `nextButton` for the Welcome step, however it does not seem to be applied on UI.

# Solution

Add ability to display custom set `nextButton` on UI.

This fixes https://github.com/onfido/onfido-sdk-ui/issues/391.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have any new strings been translated?
