### PR TITLE
Fix readme indentation for callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ Congratulations! You have successfully started the flow. Carry on reading the ne
 
   ```
   Based on the applicant id, you can then create a check for the user via your backend.
-
-  - **`onError {Function} optional`**
+  
+- **`onError {Function} optional`**
 
     Callback that fires when one an error occurs. The callback returns the following errors types:
     - `exception`


### PR DESCRIPTION
# Problem
Wrong indentation in Handling callbacks [section](https://github.com/onfido/onfido-sdk-ui/#handling-callbacks) in README.

# Solution
Fix indentation

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have any new strings been translated?
