### PR TITLE
Live doc image capture in JPEG format

### DIFF
--- a/src/components/Photo/DocumentLiveCapture.js
+++ b/src/components/Photo/DocumentLiveCapture.js
@@ -62,7 +62,7 @@ export default class DocumentLiveCapture extends Component<Props, State> {
   captureDocumentPhoto = () => {
     this.setState({ isLoading: true })
     sendEvent('Taking live photo of document')
-    screenshot(this.webcam, this.captureDocument)
+    screenshot(this.webcam, this.captureDocument, 'image/jpeg')
   }
 
   componentWillUnmount() {

--- a/src/components/utils/blob.js
+++ b/src/components/utils/blob.js
@@ -41,13 +41,13 @@ const base64toBlob = (image) => {
   return new Blob([base64Data.integerArray], {type: base64Data.mimeString})
 }
 
-export const canvasToBlob = (canvas, callback) => {
+export const canvasToBlob = (canvas, callback, mimeType = 'image/png') => {
   if (!HTMLCanvasElement.prototype.toBlob) {
     // Handle browsers that do not support canvas.toBlob() like Edge
     const dataUrlImg = canvas.toDataURL()
     return callback(base64toBlob(dataUrlImg))
   }
-  return canvas.toBlob(callback, "image/png")
+  return canvas.toBlob(callback, mimeType)
 }
 
 const toDataUrl = type => (canvas, callback) => callback(canvas.toDataURL(type))

--- a/src/components/utils/camera.js
+++ b/src/components/utils/camera.js
@@ -1,13 +1,13 @@
 import { canvasToBlob } from './blob'
 
-export const screenshot = (webcam, callback) => {
+export const screenshot = (webcam, callback, mimeType) => {
   const canvas = webcam && webcam.getCanvas()
   if (!canvas) {
     console.error('webcam canvas is null')
     return
   }
   const sdkMetadata = getDeviceInfo(webcam.stream)
-  canvasToBlob(canvas, blob => callback(blob, sdkMetadata))
+  canvasToBlob(canvas, blob => callback(blob, sdkMetadata), mimeType)
 }
 
 export const getRecordedVideo = (webcam, callback) => {


### PR DESCRIPTION
# Problem
PNG image file for live document image capture file size ranged between 1-3MB which might be a problem for users on slower networks. We want to see how big the file size and image quality difference if we were to switch to a JPEG image file.

# Solution
Add ability to switch document capture photo format (PNG is still the default).

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have any new strings been translated?
