### PR TITLE
Cropped document capture preview in Confirmation screen

### DIFF
--- a/src/components/Confirm/CaptureViewer/CaptureImageViewer.js
+++ b/src/components/Confirm/CaptureViewer/CaptureImageViewer.js
@@ -1,14 +1,13 @@
 import { h } from 'preact'
 import classNames from 'classnames'
 import style from './style.css'
-import { withBlobPreviewUrl, withBlobBase64 } from './hocs';
-import { isDesktop } from '~utils'
+import { withBlobPreviewUrl, withBlobBase64 } from './hocs'
 import EnlargedPreview from '../../EnlargedPreview'
 
-const CaptureImageViewer = ({ src, id, isDocument, isFullScreen, previewOrientation, altTag }) => {
-  const isCroppedPreview = isDocument && !isDesktop && previewOrientation === 'landscape'
+const CaptureImageViewer = ({ src, id, isDocument, isFullScreen, isCroppedView, altTag }) => {
+  const isCroppedPreview = isDocument && isCroppedView
   return (
-    <span className={classNames(style.imageWrapper, {
+    <span className={classNames(isCroppedPreview ? style.croppedImageWrapper : style.imageWrapper, {
       [style.fullscreenImageWrapper]: isFullScreen,
     })}>
       {

--- a/src/components/Confirm/CaptureViewer/CaptureImageViewer.js
+++ b/src/components/Confirm/CaptureViewer/CaptureImageViewer.js
@@ -22,7 +22,7 @@ const CaptureImageViewer = ({ src, id, isDocument, isFullScreen, altTag }) => (
       !isFullScreen &&
         <img
           key={id}//WORKAROUND necessary to prevent img recycling, see bug: https://github.com/developit/preact/issues/351
-          className={isDocument && !isDesktop ? style.croppedImage : style.image}
+          className={isDocument && !isDesktop ? style.croppedDocumentImage : style.image}
           //we use base64 if the capture is a File, since its base64 version is exif rotated
           //if it's not a File (just a Blob), it means it comes from the webcam,
           //so the base64 version is actually lossy and since no rotation is necessary

--- a/src/components/Confirm/CaptureViewer/CaptureImageViewer.js
+++ b/src/components/Confirm/CaptureViewer/CaptureImageViewer.js
@@ -5,35 +5,38 @@ import { withBlobPreviewUrl, withBlobBase64 } from './hocs';
 import { isDesktop } from '~utils'
 import EnlargedPreview from '../../EnlargedPreview'
 
-const CaptureImageViewer = ({ src, id, isDocument, isFullScreen, altTag }) => (
-  <span className={classNames(style.imageWrapper, {
-    [style.fullscreenImageWrapper]: isFullScreen,
-  })}>
-    {
-      isDocument &&
-        <EnlargedPreview
-          {...{
-            src,
-            altTag
-          }}
-        />
-    }
-    {
-      !isFullScreen &&
-        <img
-          key={id}//WORKAROUND necessary to prevent img recycling, see bug: https://github.com/developit/preact/issues/351
-          className={isDocument && !isDesktop ? style.croppedDocumentImage : style.image}
-          //we use base64 if the capture is a File, since its base64 version is exif rotated
-          //if it's not a File (just a Blob), it means it comes from the webcam,
-          //so the base64 version is actually lossy and since no rotation is necessary
-          //the blob is the best candidate in this case
-          src={src}
-          alt={altTag}
-          aria-hidden={isDocument} // This prevents the image alt tag from being read twice for document as the document alt tag is already announced inside EnlargedPreview component
-        />
-    }
-  </span>
-)
+const CaptureImageViewer = ({ src, id, isDocument, isFullScreen, previewOrientation, altTag }) => {
+  const isCroppedPreview = isDocument && !isDesktop && previewOrientation === 'landscape'
+  return (
+    <span className={classNames(style.imageWrapper, {
+      [style.fullscreenImageWrapper]: isFullScreen,
+    })}>
+      {
+        isDocument &&
+          <EnlargedPreview
+            {...{
+              src,
+              altTag
+            }}
+          />
+      }
+      {
+        !isFullScreen &&
+          <img
+            key={id}//WORKAROUND necessary to prevent img recycling, see bug: https://github.com/developit/preact/issues/351
+            className={isCroppedPreview ? style.croppedDocumentImage : style.image}
+            //we use base64 if the capture is a File, since its base64 version is exif rotated
+            //if it's not a File (just a Blob), it means it comes from the webcam,
+            //so the base64 version is actually lossy and since no rotation is necessary
+            //the blob is the best candidate in this case
+            src={src}
+            alt={altTag}
+            aria-hidden={isDocument} // This prevents the image alt tag from being read twice for document as the document alt tag is already announced inside EnlargedPreview component
+          />
+      }
+    </span>
+  )
+}
 
 const CaptureImageViewerWithPreviewUrl = withBlobPreviewUrl(
   ({ previewUrl, ...props }) => <CaptureImageViewer src={previewUrl} {...props} />

--- a/src/components/Confirm/CaptureViewer/CaptureImageViewer.js
+++ b/src/components/Confirm/CaptureViewer/CaptureImageViewer.js
@@ -4,38 +4,35 @@ import style from './style.css'
 import { withBlobPreviewUrl, withBlobBase64 } from './hocs'
 import EnlargedPreview from '../../EnlargedPreview'
 
-const CaptureImageViewer = ({ src, id, isDocument, isFullScreen, isCroppedView, altTag }) => {
-  const isCroppedPreview = isDocument && isCroppedView
-  return (
-    <span className={classNames(isCroppedPreview ? style.croppedImageWrapper : style.imageWrapper, {
-      [style.fullscreenImageWrapper]: isFullScreen,
-    })}>
-      {
-        isDocument &&
-          <EnlargedPreview
-            {...{
-              src,
-              altTag
-            }}
-          />
-      }
-      {
-        !isFullScreen &&
-          <img
-            key={id}//WORKAROUND necessary to prevent img recycling, see bug: https://github.com/developit/preact/issues/351
-            className={isCroppedPreview ? style.croppedDocumentImage : style.image}
-            //we use base64 if the capture is a File, since its base64 version is exif rotated
-            //if it's not a File (just a Blob), it means it comes from the webcam,
-            //so the base64 version is actually lossy and since no rotation is necessary
-            //the blob is the best candidate in this case
-            src={src}
-            alt={altTag}
-            aria-hidden={isDocument} // This prevents the image alt tag from being read twice for document as the document alt tag is already announced inside EnlargedPreview component
-          />
-      }
-    </span>
-  )
-}
+const CaptureImageViewer = ({ src, id, isDocument, isFullScreen, isPreviewCropped, altTag }) => (
+  <span className={classNames(isPreviewCropped ? style.croppedImageWrapper : style.imageWrapper, {
+    [style.fullscreenImageWrapper]: isFullScreen,
+  })}>
+    {
+      isDocument &&
+        <EnlargedPreview
+          {...{
+            src,
+            altTag
+          }}
+        />
+    }
+    {
+      !isFullScreen &&
+        <img
+          key={id}//WORKAROUND necessary to prevent img recycling, see bug: https://github.com/developit/preact/issues/351
+          className={isPreviewCropped ? style.croppedDocumentImage : style.image}
+          //we use base64 if the capture is a File, since its base64 version is exif rotated
+          //if it's not a File (just a Blob), it means it comes from the webcam,
+          //so the base64 version is actually lossy and since no rotation is necessary
+          //the blob is the best candidate in this case
+          src={src}
+          alt={altTag}
+          aria-hidden={isDocument} // This prevents the image alt tag from being read twice for document as the document alt tag is already announced inside EnlargedPreview component
+        />
+    }
+  </span>
+)
 
 const CaptureImageViewerWithPreviewUrl = withBlobPreviewUrl(
   ({ previewUrl, ...props }) => <CaptureImageViewer src={previewUrl} {...props} />

--- a/src/components/Confirm/CaptureViewer/CaptureImageViewer.js
+++ b/src/components/Confirm/CaptureViewer/CaptureImageViewer.js
@@ -2,6 +2,7 @@ import { h } from 'preact'
 import classNames from 'classnames'
 import style from './style.css'
 import { withBlobPreviewUrl, withBlobBase64 } from './hocs';
+import { isDesktop } from '~utils'
 import EnlargedPreview from '../../EnlargedPreview'
 
 const CaptureImageViewer = ({ src, id, isDocument, isFullScreen, altTag }) => (
@@ -21,7 +22,7 @@ const CaptureImageViewer = ({ src, id, isDocument, isFullScreen, altTag }) => (
       !isFullScreen &&
         <img
           key={id}//WORKAROUND necessary to prevent img recycling, see bug: https://github.com/developit/preact/issues/351
-          className={style.image}
+          className={isDocument && !isDesktop ? style.croppedImage : style.image}
           //we use base64 if the capture is a File, since its base64 version is exif rotated
           //if it's not a File (just a Blob), it means it comes from the webcam,
           //so the base64 version is actually lossy and since no rotation is necessary

--- a/src/components/Confirm/CaptureViewer/index.js
+++ b/src/components/Confirm/CaptureViewer/index.js
@@ -5,7 +5,7 @@ import CaptureImageViewer from './CaptureImageViewer'
 import CaptureVideoViewer from './CaptureVideoViewer'
 
 const CaptureViewer = ({
-  capture: { blob, id, variant, filename },
+  capture: { blob, id, variant, isPreviewCropped },
   method,
   isFullScreen,
   imageAltTag,
@@ -20,7 +20,7 @@ const CaptureViewer = ({
     blob={blob}
     id={id}
     isDocument={method === 'document'}
-    isCroppedView={filename && filename.includes('document_capture.')}
+    isPreviewCropped={isPreviewCropped}
     isFullScreen={isFullScreen}
     altTag={imageAltTag}
   />

--- a/src/components/Confirm/CaptureViewer/index.js
+++ b/src/components/Confirm/CaptureViewer/index.js
@@ -4,7 +4,14 @@ import PdfViewer from './PdfViewer'
 import CaptureImageViewer from './CaptureImageViewer'
 import CaptureVideoViewer from './CaptureVideoViewer'
 
-const CaptureViewer = ({ capture: { blob, id, variant }, method, isFullScreen, imageAltTag, videoAriaLabel }) => {
+const CaptureViewer = ({
+  capture: { blob, id, variant },
+  method,
+  isFullScreen,
+  previewOrientation,
+  imageAltTag,
+  videoAriaLabel
+}) => {
   if (isOfMimeType(['pdf'], blob))
     return <PdfViewer blob={blob} />
   else if (variant === 'video')
@@ -14,6 +21,7 @@ const CaptureViewer = ({ capture: { blob, id, variant }, method, isFullScreen, i
     blob={blob}
     id={id}
     isDocument={method === 'document'}
+    previewOrientation={previewOrientation}
     isFullScreen={isFullScreen}
     altTag={imageAltTag}
   />

--- a/src/components/Confirm/CaptureViewer/index.js
+++ b/src/components/Confirm/CaptureViewer/index.js
@@ -5,10 +5,9 @@ import CaptureImageViewer from './CaptureImageViewer'
 import CaptureVideoViewer from './CaptureVideoViewer'
 
 const CaptureViewer = ({
-  capture: { blob, id, variant },
+  capture: { blob, id, variant, filename },
   method,
   isFullScreen,
-  previewOrientation,
   imageAltTag,
   videoAriaLabel
 }) => {
@@ -21,7 +20,7 @@ const CaptureViewer = ({
     blob={blob}
     id={id}
     isDocument={method === 'document'}
-    previewOrientation={previewOrientation}
+    isCroppedView={filename && filename.includes('document_capture.')}
     isFullScreen={isFullScreen}
     altTag={imageAltTag}
   />

--- a/src/components/Confirm/CaptureViewer/style.css
+++ b/src/components/Confirm/CaptureViewer/style.css
@@ -39,6 +39,12 @@
   overflow: overlay;  /* append scrollbars if necessary and overlay over/above content (only for Chrome, to avoid double scrollbars) */
 }
 
+@media (--small-viewport) {
+  .imageWrapper {
+    min-height: 14em;
+  }
+}
+
 .image {
   max-width: 100%;
   max-height: 100%;
@@ -56,12 +62,9 @@
     https://caniuse.com/#feat=object-position */
 .croppedDocumentImage {
   width: 100%;
-  height: 13.5em;
+  height: 14em;
   object-fit: cover;
   object-position: center;
-  @media (--small-viewport) and (orientation: landscape) {
-    max-height: 310px;
-  }
 }
 
 .video {

--- a/src/components/Confirm/CaptureViewer/style.css
+++ b/src/components/Confirm/CaptureViewer/style.css
@@ -50,9 +50,9 @@
   object-fit: contain;
 }
 
-.croppedImage {
+.croppedDocumentImage {
   width: 100%;
-  height: calc(0.63 * 23em);
+  height: 13.5em;
   object-fit: cover;
   object-position: center;
   @media (--small-viewport) and (orientation: landscape) {

--- a/src/components/Confirm/CaptureViewer/style.css
+++ b/src/components/Confirm/CaptureViewer/style.css
@@ -21,11 +21,12 @@
   margin: 0 48*@unit;
 
   @media (--small-viewport) {
-    margin: 0 @small-text-margin 32*@unit;
+    margin: 0 @small-text-margin;
   }
 }
 
-.imageWrapper.fullscreenImageWrapper {
+.imageWrapper.fullscreenImageWrapper,
+.croppedImageWrapper.fullscreenImageWrapper {
   position: static;
 }
 
@@ -39,12 +40,6 @@
   overflow: overlay;  /* append scrollbars if necessary and overlay over/above content (only for Chrome, to avoid double scrollbars) */
 }
 
-@media (--small-viewport) {
-  .imageWrapper {
-    min-height: 14em;
-  }
-}
-
 .image {
   max-width: 100%;
   max-height: 100%;
@@ -56,6 +51,15 @@
   object-fit: contain;
 }
 
+
+.croppedImageWrapper {
+  &:extend(.imageWrapper);
+
+  @media (--small-viewport) {
+    min-height: 12em;
+  }
+}
+
 /* Only used for mobile device view */
 /* For browser compatibility for object-fit, object-position see
     https://caniuse.com/#feat=object-fit
@@ -65,6 +69,9 @@
   height: 14em;
   object-fit: cover;
   object-position: center;
+  @media (--small-viewport) {
+    height: 12em;
+  }
 }
 
 .video {

--- a/src/components/Confirm/CaptureViewer/style.css
+++ b/src/components/Confirm/CaptureViewer/style.css
@@ -50,6 +50,12 @@
   object-fit: contain;
 }
 
+.croppedImage {
+  max-width: 100%;
+  object-fit: cover;
+  object-position: center;
+}
+
 .video {
   width: 100%;
   height: 100%;

--- a/src/components/Confirm/CaptureViewer/style.css
+++ b/src/components/Confirm/CaptureViewer/style.css
@@ -50,6 +50,10 @@
   object-fit: contain;
 }
 
+/* Only used for mobile device view */
+/* For browser compatibility for object-fit, object-position see
+    https://caniuse.com/#feat=object-fit
+    https://caniuse.com/#feat=object-position */
 .croppedDocumentImage {
   width: 100%;
   height: 13.5em;

--- a/src/components/Confirm/CaptureViewer/style.css
+++ b/src/components/Confirm/CaptureViewer/style.css
@@ -18,7 +18,7 @@
   display: flex;
   position: relative;
   min-height: 90*@unit;
-  margin: 0 48*@unit 32*@unit;
+  margin: 0 48*@unit;
 
   @media (--small-viewport) {
     margin: 0 @small-text-margin 32*@unit;

--- a/src/components/Confirm/CaptureViewer/style.css
+++ b/src/components/Confirm/CaptureViewer/style.css
@@ -51,9 +51,13 @@
 }
 
 .croppedImage {
-  max-width: 100%;
+  width: 100%;
+  height: calc(0.63 * 23em);
   object-fit: cover;
   object-position: center;
+  @media (--small-viewport) and (orientation: landscape) {
+    max-height: 310px;
+  }
 }
 
 .video {

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -49,10 +49,12 @@ const Actions = ({ retakeAction, confirmAction, error }) => (
 
 const Previews = localised(
   ({ capture, retakeAction, confirmAction, error, method, documentType, translate, isFullScreen }) => {
+    console.log('documentType',documentType)
   const methodNamespace = method === 'face' ? `confirm.face.${capture.variant}` : `confirm.${method}`
   const title = translate(`${methodNamespace}.title`)
   const imageAltTag = translate(`${methodNamespace}.alt`)
   const videoAriaLabel = translate('accessibility.replay_video')
+  const previewOrientation = documentType ? 'landscape' : 'portrait'
 
   const message = method === 'face' ?
     translate(`confirm.face.${capture.variant}.message`) :
@@ -66,7 +68,7 @@ const Previews = localised(
           error.type ?
             <Error {...{error, withArrow: true, role: "alert", focusOnMount: false}} /> :
             <PageTitle title={title} smaller={true} className={style.title}/> }
-      <CaptureViewer {...{ capture, method, isFullScreen, imageAltTag, videoAriaLabel }} />
+      <CaptureViewer {...{ capture, method, isFullScreen, previewOrientation, imageAltTag, videoAriaLabel }} />
         {!isFullScreen &&
           <div>
             <p className={style.message}>

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -18,7 +18,7 @@ import { localised } from '../../locales'
 const RetakeAction = localised(({retakeAction, translate}) =>
   <Button
     onClick={retakeAction}
-    className={style.retake}
+    className={style['btn-secondary']}
     variants={['secondary']}
   >
     {translate('confirm.redo')}
@@ -27,8 +27,8 @@ const RetakeAction = localised(({retakeAction, translate}) =>
 
 const ConfirmAction = localised(({confirmAction, translate, error}) =>
   <Button
-    className={style["btn-primary"]}
-    variants={["primary"]}
+    className={style['btn-primary']}
+    variants={['primary']}
     onClick={confirmAction}>
     { error.type === 'warn' ? translate('confirm.continue') : translate('confirm.confirm') }
   </Button>

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -53,7 +53,6 @@ const Previews = localised(
   const title = translate(`${methodNamespace}.title`)
   const imageAltTag = translate(`${methodNamespace}.alt`)
   const videoAriaLabel = translate('accessibility.replay_video')
-  console.log('capture',capture)
   const message = method === 'face' ?
     translate(`confirm.face.${capture.variant}.message`) :
     translate(`confirm.${documentType}.message`)

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -53,8 +53,7 @@ const Previews = localised(
   const title = translate(`${methodNamespace}.title`)
   const imageAltTag = translate(`${methodNamespace}.alt`)
   const videoAriaLabel = translate('accessibility.replay_video')
-  const previewOrientation = documentType ? 'landscape' : 'portrait'
-
+  console.log('capture',capture)
   const message = method === 'face' ?
     translate(`confirm.face.${capture.variant}.message`) :
     translate(`confirm.${documentType}.message`)
@@ -67,7 +66,7 @@ const Previews = localised(
           error.type ?
             <Error {...{error, withArrow: true, role: "alert", focusOnMount: false}} /> :
             <PageTitle title={title} smaller={true} className={style.title}/> }
-      <CaptureViewer {...{ capture, method, isFullScreen, previewOrientation, imageAltTag, videoAriaLabel }} />
+      <CaptureViewer {...{ capture, method, isFullScreen, imageAltTag, videoAriaLabel }} />
         {!isFullScreen &&
           <div>
             <p className={style.message}>

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -49,7 +49,6 @@ const Actions = ({ retakeAction, confirmAction, error }) => (
 
 const Previews = localised(
   ({ capture, retakeAction, confirmAction, error, method, documentType, translate, isFullScreen }) => {
-    console.log('documentType',documentType)
   const methodNamespace = method === 'face' ? `confirm.face.${capture.variant}` : `confirm.${method}`
   const title = translate(`${methodNamespace}.title`)
   const imageAltTag = translate(`${methodNamespace}.alt`)

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -54,7 +54,7 @@ const Previews = localised(
   const imageAltTag = translate(`${methodNamespace}.alt`)
   const videoAriaLabel = translate('accessibility.replay_video')
 
-  const subTitle = method === 'face' ?
+  const message = method === 'face' ?
     translate(`confirm.face.${capture.variant}.message`) :
     translate(`confirm.${documentType}.message`)
 
@@ -65,9 +65,16 @@ const Previews = localised(
       { isFullScreen ? null :
           error.type ?
             <Error {...{error, withArrow: true, role: "alert", focusOnMount: false}} /> :
-            <PageTitle title={title} subTitle={subTitle} smaller={true} className={style.title}/> }
+            <PageTitle title={title} smaller={true} className={style.title}/> }
       <CaptureViewer {...{ capture, method, isFullScreen, imageAltTag, videoAriaLabel }} />
-        {!isFullScreen && <Actions {...{ retakeAction, confirmAction, error }} />}
+        {!isFullScreen &&
+          <div>
+            <p className={style.message}>
+              {message}
+            </p>
+            <Actions {...{ retakeAction, confirmAction, error }} />
+          </div>
+        }
     </div>
   )
   }

--- a/src/components/Confirm/style.css
+++ b/src/components/Confirm/style.css
@@ -31,8 +31,6 @@
   }
 }
 
-@smallScreenButtonWidth: 125*@unit;
-
 .btn-secondary {
   width: 160*@unit;
   @media (--small-viewport) {

--- a/src/components/Confirm/style.css
+++ b/src/components/Confirm/style.css
@@ -24,11 +24,19 @@
   flex: 0 0 auto;
 }
 
-.retake {
-  width: 160*@unit;
-  padding: 0;
+.message {
+  margin: 32*@unit @large-text-margin 16*@unit;
   @media (--small-viewport) {
-    width: 112*@unit;
+    margin: 0 @small-text-margin 16*@unit;
+  }
+}
+
+@smallScreenButtonWidth: 125*@unit;
+
+.btn-secondary {
+  width: 160*@unit;
+  @media (--small-viewport) {
+    width: 120*@unit;
   }
 }
 
@@ -40,7 +48,7 @@
 
   .btn-primary {
     @media (--small-viewport) {
-      width: 152*@unit;
+      width: 135*@unit;
     }
   }
 }

--- a/src/components/Overlay/style.css
+++ b/src/components/Overlay/style.css
@@ -33,7 +33,7 @@
 
 
 @card-frame-height: 0%;
-@card-frame-width: 85%;
+@card-frame-width: 92%;
 
 .id1Card {
   &:extend(.overlay);

--- a/src/components/Photo/DocumentLiveCapture.js
+++ b/src/components/Photo/DocumentLiveCapture.js
@@ -53,7 +53,8 @@ export default class DocumentLiveCapture extends Component<Props, State> {
     const documentCapture = {
       blob,
       sdkMetadata,
-      filename: `document_capture.${mimeType(blob)}`
+      filename: `document_capture.${mimeType(blob)}`,
+      isPreviewCropped: true
     }
     this.props.onCapture(documentCapture)
     this.setState({ isLoading: false })

--- a/test/pageobjects/Confirm.js
+++ b/test/pageobjects/Confirm.js
@@ -2,7 +2,7 @@ import BasePage from './BasePage.js'
 import { verifyElementCopy } from '../utils/mochaw'
 
 class Confirm extends BasePage {
-  get redoBtn() { return this.$('.onfido-sdk-ui-Confirm-retake')}
+  get redoBtn() { return this.$('.onfido-sdk-ui-Confirm-btn-secondary')}
   async confirmBtn() { return this.waitAndFind('.onfido-sdk-ui-Confirm-btn-primary')}
   get uploaderError() { return this.$('.onfido-sdk-ui-Uploader-error')}
   get errorTitleText() { return this.$('.onfido-sdk-ui-Error-title-text')}

--- a/test/pageobjects/Confirm.js
+++ b/test/pageobjects/Confirm.js
@@ -2,6 +2,7 @@ import BasePage from './BasePage.js'
 import { verifyElementCopy } from '../utils/mochaw'
 
 class Confirm extends BasePage {
+  get message() { return this.$('.onfido-sdk-ui-Confirm-message')}
   get redoBtn() { return this.$('.onfido-sdk-ui-Confirm-btn-secondary')}
   async confirmBtn() { return this.waitAndFind('.onfido-sdk-ui-Confirm-btn-primary')}
   get uploaderError() { return this.$('.onfido-sdk-ui-Uploader-error')}
@@ -18,17 +19,17 @@ class Confirm extends BasePage {
 
   async verifyMakeSurePassportMessage(copy) {
     const confirmStrings = copy.confirm
-    verifyElementCopy(this.subtitle, confirmStrings.passport.message)
+    verifyElementCopy(this.message, confirmStrings.passport.message)
   }
 
   async verifyMakeSureDrivingLicenceMessage(copy) {
     const confirmStrings = copy.confirm
-    verifyElementCopy(this.subtitle, confirmStrings.driving_licence.message)
+    verifyElementCopy(this.message, confirmStrings.driving_licence.message)
   }
 
   async verifyMakeSureIdentityCardMessage(copy) {
     const confirmStrings = copy.confirm
-    verifyElementCopy(this.subtitle, confirmStrings.national_identity_card.message)
+    verifyElementCopy(this.message, confirmStrings.national_identity_card.message)
   }
 
   async verifyNoDocumentError(copy) {


### PR DESCRIPTION
# Problem
A cropped document review image will lead to a better user experience since user would be only expect the frame to be captured.

<img width="317" alt="Screenshot 2019-10-25 at 16 16 11" src="https://user-images.githubusercontent.com/2497081/67583104-d67e1480-f742-11e9-8884-47d88e3ebbf8.png">
**Note:** Updated copy in design attached is not part of work required for this PR

# Solution
When on mobile and image captured is a ID document, display the visible area of the image preview as a cropped rectangle. Image cropping does not apply to PDF uploads, POA document.


## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have any new strings been translated?
