### PR TITLE
Surge latest updating incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ## [Next version]
 
+### Fixed
+- Internal: Latest Surge link gets updated only on release of a full version, not release candidates or beta releases
+
+
 ## [5.5.0] - 2019-10-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ## [Next version]
 
+### Added
+
 ### Fixed
 - Internal: Latest Surge link gets updated only on release of a full version, not release candidates or beta releases
 
+### Changed
 
 ## [5.5.0] - 2019-10-31
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -31,8 +31,10 @@ then
     #sort -V              ref: http://stackoverflow.com/a/14273595/689223
     #sort -t ...          ref: http://stackoverflow.com/a/4495368/689223
     #reverse with sed     ref: http://stackoverflow.com/a/744093/689223
-    #git tags | ignore release candidates | sort versions | reverse | pick first line
-    LATEST_TAG=`git tag | grep -v rc | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | sed '1!G;h;$!d' | sed -n 1p`
+    #git tag regex        explanation and tests: https://regex101.com/r/wFxLmb/8
+    #git tags | ignore matches for git tag regex | sort versions | reverse | pick first line
+    GIT_TAG_REGEX="\-[a-z]\{2,4\}.[0-9]"
+    LATEST_TAG=`git tag | grep -v $GIT_TAG_REGEX | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | sed '1!G;h;$!d' | sed -n 1p`
     echo $LATEST_TAG
 
     if [ "$TRAVIS_TAG" == "$LATEST_TAG" ]

--- a/deploy.sh
+++ b/deploy.sh
@@ -31,10 +31,10 @@ then
     #sort -V              ref: http://stackoverflow.com/a/14273595/689223
     #sort -t ...          ref: http://stackoverflow.com/a/4495368/689223
     #reverse with sed     ref: http://stackoverflow.com/a/744093/689223
-    #git tag regex        explanation and tests: https://regex101.com/r/wFxLmb/8
-    #git tags | ignore matches for git tag regex | sort versions | reverse | pick first line
-    GIT_TAG_REGEX="\-[a-z]\{2,4\}.[0-9]"
-    LATEST_TAG=`git tag | grep -v $GIT_TAG_REGEX | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | sed '1!G;h;$!d' | sed -n 1p`
+    #git tag regex        explanation and tests: https://regex101.com/r/CjNA8f/2
+    #git tags | match git tag regex pattern (ignore if has any extra label appended, e.g. 3.2.1-rc.1) | sort versions | reverse | pick first line
+    GIT_TAG_REGEX="^\d\{1,3\}.\d\{1,2\}.\d\{1,2\}$"
+    LATEST_TAG=`git tag | grep $GIT_TAG_REGEX | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | sed '1!G;h;$!d' | sed -n 1p`
     echo $LATEST_TAG
 
     if [ "$TRAVIS_TAG" == "$LATEST_TAG" ]


### PR DESCRIPTION
# Problem
Following 5.5.0 release, JS SDK version on Surge latest was not updated to 5.5.0 and still on 5.5.0-beta.2

# Solution
Use a more robust/strict check using a regex pattern so that if a git tag has any trailing labels after the version number (i.e. "-rc", "-beta", etc.), the deploy script should ignore it

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have any new strings been translated?
