### PR TITLE
Only run bundlesize if the travis build is production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
 script:
   - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then audit-ci --moderate; fi
   - npm run build
+  - if [ "$NODE_ENV" == "production" ]; then npm run bundlesize; fi
   - chmod ugo+x ./test.sh
   - ./test.sh
 after_success:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "build:dev": "NODE_ENV=development npm run build",
     "build:test": "NODE_ENV=test npm run build",
     "prebuild": "npm run clean && npm run mkdirs && npm run check && npm run test",
-    "postbuild": "npm run bundlesize",
     "mkdirs": "mkdir -p dist && mkdir -p lib",
     "clean": "rimraf lib dist",
     "prepublish": "npm run clean && npm run check && npm run build",


### PR DESCRIPTION
# Problem
Currently, the `bundlesize` script runs for every travis build. We only want to run it for the production environment to actual bundle size (development and test env bundles are larger)

# Solution
Instead of running `bundlesize` as a post-build script, we run it in the travis.yml file with a condition that the environment is production

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have any new strings been translated?
