### PR TITLE
Add symmetric secret to contact sdk token factory

### DIFF
--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -25,6 +25,7 @@ const getToken = (hasPreview, onSuccess) => {
   const url = process.env.JWT_FACTORY
   const request = new XMLHttpRequest()
   request.open('GET', url, true)
+  request.setRequestHeader('Authorization', 'BASIC ' + process.env.SDK_TOKEN_FACTORY_SECRET)
   request.onload = function() {
     if (request.status >= 200 && request.status < 400) {
       const data = JSON.parse(request.responseText)

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -21,6 +21,8 @@ const NODE_ENV = process.env.NODE_ENV || 'production'
 // i.e. fully minified so that testing staging is as realistic as possible
 const PRODUCTION_BUILD = NODE_ENV !== 'development'
 
+const SDK_TOKEN_FACTORY_SECRET = process.env.SDK_TOKEN_FACTORY_SECRET || 'NA'
+
 const baseRules = [
   {
     test: /\.jsx?$/,
@@ -174,6 +176,7 @@ const basePlugins = (bundle_name) => ([
     'BASE_32_VERSION': 'AW',
     'PRIVACY_FEATURE_ENABLED': false,
     'JWT_FACTORY': CONFIG.JWT_FACTORY,
+    SDK_TOKEN_FACTORY_SECRET,
     WOOPRA_WINDOW_KEY,
     WOOPRA_IMPORT: `imports-loader?this=>${WOOPRA_WINDOW_KEY},window=>${WOOPRA_WINDOW_KEY}!wpt/wpt.min.js`
   }))


### PR DESCRIPTION
This symmetric secret is inject by the CI as the SDK is being built.
This way we force that calling the SDK token factory requires a secret.

JIRA CX-3554
