### PR TITLE
Reduced bundlesize max size

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,11 +46,11 @@
   "bundlesize": [
     {
       "path": "./dist/onfido.min.js",
-      "maxSize": "400 kB"
+      "maxSize": "200 kB"
     },
     {
       "path": "./dist/onfido.crossDevice.min.js",
-      "maxSize": "3 kB"
+      "maxSize": "1.3 kB"
     }
   ],
   "devDependencies": {


### PR DESCRIPTION
# Problem
Currently, the bundle size returned by `bundlesize` is in gzip, while the value for the size limit was defined based on the parsed bundle size.

# Solution
The size limit should be in gzip too. The value has been calculated by adding 25% to the current bundle size value in gzip.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have any new strings been translated?
