### PR TITLE
Only deploy sourcemaps to Sentry for latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Added
 - Internal: Added UI test for Submit Verification button is not clickable multiple times if Complete step is excluded
+- Internal: Deploy source maps to Sentry using @sentry/cli within our deployment script
 
 ### Changed
 - Internal: Updated `react-webcam-onfido` to get check(s) for stream before calling getVideoTracks/getAudioTracks method

--- a/deploy.sh
+++ b/deploy.sh
@@ -40,6 +40,9 @@ then
     if [ "$TRAVIS_TAG" == "$LATEST_TAG" ]
     then
       DEPLOY_SUBDOMAIN_UNFORMATTED_LIST+=(latest)
+      sentry-cli --auth-token $SENTRY_AUTH_TOKEN
+      sentry-cli releases new $LATEST_TAG --log-level=DEBUG
+      sentry-cli releases files $LATEST_TAG upload-sourcemaps ./dist/
     fi
 
     DEPLOY_SUBDOMAIN_UNFORMATTED_LIST+=(${TRAVIS_TAG}-tag)


### PR DESCRIPTION
# Problem
After upgrading to `@sentry/browser`,  we need to make sure that Sentry is able to find the source maps. 

# Solution
I used `@sentry/cli` to deploy the source maps within our .`/dist` folder to Sentry. Now, Sentry will be able to display a readable stack trace and fetch the source maps

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have any new strings been translated?
