### PR TITLE
x-device error message for opening x-device link on desktop browser not displayed

### DIFF
--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -45,8 +45,9 @@ class CrossDeviceMobileRouter extends Component {
       crossDeviceError: false,
       loading: true
     }
-    console.log('restrictedXDevice:',restrictedXDevice)
-    console.log('isDesktop:',isDesktop)
+    console.log('DEBUG - NODE_ENV:',process.env.NODE_ENV)
+    console.log('DEBUG - restrictedXDevice:',restrictedXDevice)
+    console.log('DEBUG - isDesktop:',isDesktop)
     if (restrictedXDevice && isDesktop) {
       return this.setError('FORBIDDEN_CLIENT_ERROR')
     }

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -45,6 +45,8 @@ class CrossDeviceMobileRouter extends Component {
       crossDeviceError: false,
       loading: true
     }
+    console.log('restrictedXDevice:',restrictedXDevice)
+    console.log('isDesktop:',isDesktop)
     if (restrictedXDevice && isDesktop) {
       return this.setError('FORBIDDEN_CLIENT_ERROR')
     }


### PR DESCRIPTION
# Problem
x-device error message when opening x-device link on a desktop browser is not being displayed on `development` branch Surge link

# Solution
TBD - creating this PR to debug as unable to reproduce locally

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have any new strings been translated?
