### PR TITLE
Don't show x-device button if on `mobileFlow` on a desktop

### DIFF
--- a/src/components/Uploader/index.js
+++ b/src/components/Uploader/index.js
@@ -64,9 +64,9 @@ const DesktopUploadArea = ({ translate, onFileSelected, error, uploadIcon, chang
         </Button>}
       <CustomFileInput className={ style.desktopUpload } onChange={ onFileSelected }>
         {error && <UploadError { ...{ error, translate } } />}
-        <span tabindex="0" role="button" className={ theme.link } data-onfido-qa="uploaderButtonLink">
+        <button className={ theme.link } data-onfido-qa="uploaderButtonLink">
           { translate('capture.upload_file') }
-        </span>
+        </button>
       </CustomFileInput>
     </div>
   </div>

--- a/src/components/Uploader/index.js
+++ b/src/components/Uploader/index.js
@@ -4,14 +4,15 @@ import { isDesktop } from '~utils'
 import { camelCase } from '~utils/string'
 import { findKey } from '~utils/object'
 import { isOfMimeType } from '~utils/blob.js'
+import { trackComponentAndMode } from '../../Tracker'
+import { localised } from '../../locales'
 import theme from '../Theme/style.css'
 import style from './style.css'
 import errors from '../strings/errors'
-import { trackComponentAndMode } from '../../Tracker'
 import CustomFileInput from '../CustomFileInput'
 import PageTitle from '../PageTitle'
 import Button from '../Button'
-import { localised } from '../../locales'
+
 
 const UploadError = ({ error, translate }) => {
   const { message, instruction } = errors[error.name]
@@ -49,17 +50,18 @@ const MobileUploadArea = ({ onFileSelected, children, isPoA, translate }) =>
     </div>
   </div>
 
-const DesktopUploadArea = ({ translate, onFileSelected, error, uploadIcon, changeFlowTo }) =>
+const DesktopUploadArea = ({ translate, onFileSelected, error, uploadIcon, changeFlowTo, mobileFlow }) =>
   <div className={ style.crossDeviceInstructionsContainer }>
     <i className={ classNames(theme.icon, style.icon, style[uploadIcon]) } />
     <div>
-      <Button
-        variants={['centered', 'primary']}
-        className={ style.crossDeviceButton }
-        onClick={() => changeFlowTo('crossDeviceSteps')}
-      >
-        { translate('capture.switch_device') }
-      </Button>
+      {!mobileFlow && // Hide for mobileFlow on desktop browser as `test` Node environment has restrictedXDevice set to false
+        <Button
+          variants={['centered', 'primary']}
+          className={ style.crossDeviceButton }
+          onClick={() => changeFlowTo('crossDeviceSteps')}
+        >
+          { translate('capture.switch_device') }
+        </Button>}
       <CustomFileInput className={ style.desktopUpload } onChange={ onFileSelected }>
         {error && <UploadError { ...{ error, translate } } />}
         <span tabindex="0" role="button" className={ theme.link } data-onfido-qa="uploaderButtonLink">
@@ -99,7 +101,8 @@ class Uploader extends Component {
       allowCrossDeviceFlow,
       uploadType,
       instructions,
-      translate
+      translate,
+      mobileFlow
     } = this.props
     const isPoA = uploadType === 'proof_of_address'
     const { error } = this.state
@@ -115,7 +118,8 @@ class Uploader extends Component {
               changeFlowTo={ changeFlowTo }
               uploadIcon={ `${camelCase(uploadType)}Icon` }
               error={error}
-              translate={translate} />
+              translate={translate}
+              mobileFlow={mobileFlow} />
             ) : (
             <MobileUploadArea
               onFileSelected={ this.handleFileSelected }


### PR DESCRIPTION
# Problem
For `test` Node environment, e.g. the `development` Surge link, the error message displayed when a user tries to open the x-device link on a desktop browser does not get displayed.

# Solution
Add a check to only display the "Continue on phone" button if user is not already on the x-device mobile flow.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Have the CHANGELOG, README, MIGRATION, RELEASE_GUIDELINES docs been updated?
- [ ] Have new automated tests been implemented?
- [ ] Have new manual tests been written down?
- [ ] Have any new strings been translated?
