### PR TITLE
Add --ignore-certificate-errors to skip not secure connection window

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -36,7 +36,7 @@ const random = () => Math.random().toString(36).substring(7)
 
 const chromeCapabilities = Capabilities.chrome()
 const chromeOptions = {
-  'args': ['--use-fake-device-for-media-stream','--use-fake-ui-for-media-stream', '--use-file-for-fake-video-capture=${__dirname}/resources/test-stream.y4m', '--ignore-certificate-errors']
+  'args': ['--use-fake-device-for-media-stream','--use-fake-ui-for-media-stream', `--use-file-for-fake-video-capture=${__dirname}/resources/test-stream.y4m`, '--ignore-certificate-errors']
 }
 // chromeOptions changed to goog:chromeOptions'
 //please refer https://github.com/elgalu/docker-selenium/issues/201

--- a/test/main.js
+++ b/test/main.js
@@ -36,7 +36,7 @@ const random = () => Math.random().toString(36).substring(7)
 
 const chromeCapabilities = Capabilities.chrome()
 const chromeOptions = {
-  'args': ['--use-fake-device-for-media-stream','--use-fake-ui-for-media-stream', `--use-file-for-fake-video-capture=${__dirname}/resources/test-stream.y4m`]
+  'args': ['--use-fake-device-for-media-stream','--use-fake-ui-for-media-stream', '--use-file-for-fake-video-capture=${__dirname}/resources/test-stream.y4m', '--ignore-certificate-errors']
 }
 // chromeOptions changed to goog:chromeOptions'
 //please refer https://github.com/elgalu/docker-selenium/issues/201


### PR DESCRIPTION
# Problem
![image](https://user-images.githubusercontent.com/23279455/71348028-8913fd00-2563-11ea-8108-4b4bfa00eb42.png)
blocking test executoion

# Solution
`--ignore-certificate-errors` needs to be added to `chromeOptions`

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
