### PR TITLE
Disable analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ## [Next version]
 
+### Added
+- Internal: Analytics can now be disabled via the `disableAnalytics` option
+
 ### Fixed
 - Public: Fixed bug where iPads on iOS13 were detected as desktop devices.
 

--- a/src/Tracker/index.js
+++ b/src/Tracker/index.js
@@ -39,6 +39,10 @@ const uninstall = () => {
       process.exit()
     })
   }
+  uninstallWoopra()
+}
+
+const uninstallWoopra = () => {
   woopra.dispose()
   shouldSendEvents = false
 }
@@ -150,6 +154,6 @@ const setWoopraCookie = (cookie) => {
 const getWoopraCookie = () =>
   woopra.cookie
 
-export { setUp, install, uninstall, trackException, sendEvent, sendScreen, trackComponent,
+export { setUp, install, uninstall, uninstallWoopra, trackException, sendEvent, sendScreen, trackComponent,
                  trackComponentAndMode, appendToTracking, setWoopraCookie,
                  getWoopraCookie }

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -16,8 +16,10 @@ class ModalApp extends Component {
     super(props)
     this.events = new EventEmitter()
     this.events.on('complete', this.trackOnComplete)
-    Tracker.setUp()
-    Tracker.install()
+    if (!props.options.disableAnalytics) {
+      Tracker.setUp()
+      Tracker.install()
+    }
     this.bindEvents(props.options.onComplete, props.options.onError)
   }
 

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -10,7 +10,7 @@ import StepsRouter from './StepsRouter'
 import { themeWrap } from '../Theme'
 import Spinner from '../Spinner'
 import GenericError from '../GenericError'
-import { getWoopraCookie, setWoopraCookie, trackException } from '../../Tracker'
+import { getWoopraCookie, setWoopraCookie, trackException, uninstallWoopra } from '../../Tracker'
 import { LocaleProvider } from '../../locales'
 
 const restrictedXDevice = process.env.RESTRICTED_XDEVICE_FEATURE_ENABLED
@@ -98,10 +98,16 @@ class CrossDeviceMobileRouter extends Component {
       poaDocumentType,
       step: userStepIndex,
       clientStepIndex,
-      woopraCookie
+      woopraCookie,
+      disableAnalytics
     } = data
 
-    setWoopraCookie(woopraCookie)
+    if (disableAnalytics) {
+      uninstallWoopra()
+    }
+    else {
+      setWoopraCookie(woopraCookie)
+    }
     if (!token) {
       console.error('Desktop did not send token')
       trackException('Desktop did not send token')
@@ -180,11 +186,11 @@ class MainRouter extends Component {
 
   generateMobileConfig = () => {
     const {documentType, poaDocumentType, deviceHasCameraSupport, options} = this.props
-    const {steps, token, language} = options
-    const woopraCookie = getWoopraCookie()
+    const {steps, token, language, disableAnalytics} = options
+    const woopraCookie = !disableAnalytics ? getWoopraCookie() : null
 
     return {
-      steps, token, language, documentType, poaDocumentType, deviceHasCameraSupport, woopraCookie,
+      steps, token, language, documentType, poaDocumentType, deviceHasCameraSupport, woopraCookie, disableAnalytics,
       step: this.state.crossDeviceInitialStep,
       clientStepIndex:this.state.crossDeviceInitialClientStep
     }

--- a/src/demo/demoUtils.js
+++ b/src/demo/demoUtils.js
@@ -61,6 +61,7 @@ export const getInitSdkOptions = () => {
     useModal: queryParamToValueString.useModal === 'true',
     shouldCloseOnOverlayClick: queryParamToValueString.shouldCloseOnOverlayClick !== 'true',
     language,
+    disableAnalytics: queryParamToValueString.disableAnalytics === 'true',
     steps,
     mobileFlow: false,
     userDetails: {


### PR DESCRIPTION
# Problem
Analytics tracking currently is not optional. This is a problem for clients who wish to disable them.

# Solution
Added option for disabling analytics

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
