### PR TITLE
Bump version of react-webcam-onfido to 0.1.14 for Firefox 71 camera fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Fixed
 - Public: Fixed bug where iPads on iOS13 were detected as desktop devices.
+- Public: Fixed video recording in liveness capture step not working for Firefox >= 71
 
 ## [5.7.0]
 

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "react-native-listener": "1.0.1",
     "react-phone-number-input": "^2.4.1",
     "react-redux": "~4.4.6",
-    "react-webcam-onfido": "^0.1.13",
+    "react-webcam-onfido": "^0.1.14",
     "regenerator-runtime": "^0.12.1",
     "rimraf": "^2.5.4",
     "selenium-webdriver": "^4.0.0-alpha.5",


### PR DESCRIPTION
# Problem
The video variant of the face step doesn't work on Firefox >= 71. It was working in Firefox 70. Issue reported in #891 

# Solution
Fix done on the onfido/react-webcam fork in this PR: https://github.com/onfido/react-webcam/pull/34
This PR is to bump the `react-webcam-onfido` dependency in JS SDK up to the version with the fix (0.1.14)

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
