### PR TITLE
Fix modal flaky tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Fixed
 - Public: Fixed bug where iPads on iOS13 were detected as desktop devices.
 - Public: Fixed video recording in liveness capture step not working for Firefox >= 71
+- Internal: Fix flaky modal UI tests
 
 ## [5.7.0]
 

--- a/test/pageobjects/Welcome.js
+++ b/test/pageobjects/Welcome.js
@@ -7,7 +7,7 @@ class Welcome extends BasePage {
   get text() { return this.$('.onfido-sdk-ui-Welcome-text')}
   get footer() { return this.$('.onfido-sdk-ui-Theme-footer')}
   async primaryBtn() { return this.waitAndFind('.onfido-sdk-ui-Button-button')}
-  get openModalButton() { return this.$('#button')}
+  async openModalButton() { return this.waitAndFind('#button')}
   get closeModalButton() { return this.$('.onfido-sdk-ui-Modal-closeButton')}
   get backArrow() { return this.$('.onfido-sdk-ui-NavigationBar-iconBack')}
 
@@ -36,7 +36,7 @@ class Welcome extends BasePage {
   }
 
   async clickOnOpenModalButton() {
-    this.openModalButton.click()
+    this.clickWhenClickable(this.openModalButton())
   }
 
   async clickOnCloseModalButton() {


### PR DESCRIPTION
# Problem
Currently, the modal UI tests are flaky and fail randomly when the element cannot be clicked.

# Solution
Wait for element to be clickable

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [x] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
