### PR TITLE
Fix Safari issue where buttons disappears below view height on some host apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Public: Fixed video recording in liveness capture step not working for Firefox >= 71
 - Internal: Fix flaky modal UI tests
 - Public: Fixed bug where blob was not handled correctly when an upload event was fired on IE11
-- Public: Fixed camera permission screen layout issue on desktop Safari
+- Public: Fixed camera permission screen layout issue on desktop Safari where buttons disappears below view height
 
 ## [5.7.0] - 2020-01-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Public: Fixed video recording in liveness capture step not working for Firefox >= 71
 - Internal: Fix flaky modal UI tests
 - Public: Fixed bug where blob was not handled correctly when an upload event was fired on IE11
+- Public: Fixed camera permission screen layout issue on desktop Safari
 
 ## [5.7.0] - 2020-01-22
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2640,6 +2640,12 @@
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
       "dev": true
     },
+    "basic-auth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
+      "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
+      "dev": true
+    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -3410,8 +3416,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -7055,25 +7060,27 @@
       }
     },
     "http-server": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.11.1.tgz",
-      "integrity": "sha512-6JeGDGoujJLmhjiRGlt8yK8Z9Kl0vnl/dQoQZlc4oeqaUoAKQg94NILLfrY3oWzSyFaQCVNTcKE5PZ3cH8VP9w==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.12.1.tgz",
+      "integrity": "sha512-T0jB+7J7GJ2Vo+a4/T7P7SbQ3x2GPDnqRqQXdfEuPuUOmES/9NBxPnDm7dh1HGEeUWqUmLUNtGV63ZC5Uy3tGA==",
       "dev": true,
       "requires": {
-        "colors": "1.0.3",
-        "corser": "~2.0.0",
-        "ecstatic": "^3.0.0",
-        "http-proxy": "^1.8.1",
-        "opener": "~1.4.0",
-        "optimist": "0.6.x",
-        "portfinder": "^1.0.13",
-        "union": "~0.4.3"
+        "basic-auth": "^1.0.3",
+        "colors": "^1.3.3",
+        "corser": "^2.0.1",
+        "ecstatic": "^3.3.2",
+        "http-proxy": "^1.17.0",
+        "opener": "^1.5.1",
+        "optimist": "~0.6.1",
+        "portfinder": "^1.0.20",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0"
       },
       "dependencies": {
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+        "opener": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
+          "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
           "dev": true
         }
       }
@@ -11910,6 +11917,8 @@
     },
     "react-webcam-onfido": {
       "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/react-webcam-onfido/-/react-webcam-onfido-0.1.16.tgz",
+      "integrity": "sha512-TvLhzOlJnZyngWR+Kehc+K5Suwne9sjxP3XIvqYyl2A+S7hl2sIBQBUn37CLpsdPQvf3ubnsipIa+a2G84Y4Cw==",
       "dev": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.4.3",
@@ -12515,6 +12524,12 @@
       "requires": {
         "compute-scroll-into-view": "1.0.11"
       }
+    },
+    "secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=",
+      "dev": true
     },
     "select-hose": {
       "version": "2.0.0",
@@ -14030,20 +14045,12 @@
       "dev": true
     },
     "union": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/union/-/union-0.4.6.tgz",
-      "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
       "dev": true,
       "requires": {
-        "qs": "~2.3.3"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-          "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
-          "dev": true
-        }
+        "qs": "^6.4.0"
       }
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "file-loader": "^0.9.0",
     "flow-bin": "^0.93.0",
     "html-webpack-plugin": "^3.2.0",
-    "http-server": "^0.11.1",
+    "http-server": "^0.12.1",
     "imports-loader": "^0.8.0",
     "jest": "^24.1.0",
     "jest-cli": "^24.1.0",

--- a/src/components/CameraPermissions/Primer/style.css
+++ b/src/components/CameraPermissions/Primer/style.css
@@ -50,11 +50,10 @@
   background-image: url('assets/allow.svg');
   background-repeat: no-repeat;
   background-size: 100%;
-  position: relative;
-  flex: 0 1 100%;
-  /* 90.2% is the aspect ratio of responsive div */
-  /* The percentage has been calculated by dividing the original height value divided by the original width value. In this case 94.67/105.01 = 0.992 */
-  padding-top: 90.2%;
+  background-position: center;
+  height: 136*@unit;
+  width: 136*@unit;
+  min-width: 16%;
 }
 
 .allow {

--- a/src/components/CameraPermissions/Primer/style.css
+++ b/src/components/CameraPermissions/Primer/style.css
@@ -53,7 +53,6 @@
   background-position: center;
   height: 136*@unit;
   width: 136*@unit;
-  min-width: 16%;
 }
 
 .allow {


### PR DESCRIPTION
# Problem
On desktop Safari browser for some clients' host app/site, when the user reaches the camera permission screen the call to action button is not visible in the viewport and there is a very big whitespace between the camera permission icon and the text below it.

# Solution
Remove the redundant flex styling on `onfido-sdk-ui-CameraPermissions-Primer-graphic` class

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [n/a] Has the README been updated?
- [n/a] Has the RELEASE_GUIDELINES been updated?
- [n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [n/a] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a] Have any new automated tests been implemented or the existing ones changed?
- [n/a] Have any new manual tests been written down or the existing ones changed?
- [n/a] Have any new strings been translated or the existing ones changed?
