### PR TITLE
fix (modal) Fix issue where going back in modal causes going back in …

### DIFF
--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -338,7 +338,7 @@ class HistoryRouter extends Component {
   }
 
   back = () => {
-    this.history.goBack()
+    this.previousStep();
   }
 
   setStepIndex = (newStepIndex, newFlow, excludeStepFromHistory) => {


### PR DESCRIPTION
…browser history.

# Problem

Modal dialog back goes back in browser history which causes side effects in underlying SPA apps.

# Solution

Go to previous step instead

## Checklist
n/a
