### PR TITLE
Button should not propagate onsubmit event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Internal: Fix flaky modal UI tests
 - Public: Fixed bug where blob was not handled correctly when an upload event was fired on IE11
 - Public: Fixed camera permission screen layout issue on desktop Safari where buttons disappears below view height
+- Public: Prevent "submit" event from being emitted when selecting a document
 
 ## [5.7.1] - 2020-02-25
 

--- a/src/components/Uploader/index.js
+++ b/src/components/Uploader/index.js
@@ -64,7 +64,7 @@ const DesktopUploadArea = ({ translate, onFileSelected, error, uploadIcon, chang
         </Button>}
       <CustomFileInput className={ style.desktopUpload } onChange={ onFileSelected }>
         {error && <UploadError { ...{ error, translate } } />}
-        <button className={ theme.link } data-onfido-qa="uploaderButtonLink">
+        <button type="button" className={ theme.link } data-onfido-qa="uploaderButtonLink">
           { translate('capture.upload_file') }
         </button>
       </CustomFileInput>


### PR DESCRIPTION
# Problem
Currently, when clicking on the upload document link in the document screen, an onsubmit event is emitted. This is a problem if the SDK is wrapped in a `<form>` tag.

# Solution
Prevent onsubmit event propagation by adding `type="button"` to the button. This change fixes issue #923.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
