### PR TITLE
Capture button clickable before allowing camera permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Fixed
 - Public: Fix moderate vulnerabilities in `minimist`, a sub-dependecy used by `@babel/cli` and `@babel/register`.
 - Public: Fixed hybrid device camera detection and access request
+- Public: Fixed bug where user is able to click/tap on the button on the Camera screen before allowing/denying permission.
 
 ## [5.8.0] - 2020-03-19
 

--- a/MANUAL_REGRESSION.md
+++ b/MANUAL_REGRESSION.md
@@ -217,7 +217,20 @@ Go through the flow looking for layout/usability inconsistencies between browser
 1. Go to the face step. If on desktop resize the window to less than 480px width wise (if the browser let's you reduce that far)
 2. The capture component should be fullscreen
 
-### 14. Check that custom strings can be passed
+### 14. Check camera button cannot be clicked until camera permission is granted
+(ONLY ON browsers with getUserMedia support: on an iOS and Android device; a laptop with camera; desktop or laptop with a third-party USB camera)
+
+1. On private mode of a browser that has getUserMedia support, go to the face step
+2. User should see a browser notification asking to Allow or Block camera permission
+    - Button should appear disabled (darkened out)
+    - Click on the camera button
+    - Nothing should happen, user does not proceed to next step
+3. Click on browser notification to Allow camera permission
+    - Button should become enabled (no longer darkened out)
+    - Click on the camera button
+    - User proceeds to next step with preview of photo taken
+
+### 15. Check that custom strings can be passed
 (on any browser)
 
 1. Go to latest JSFiddle
@@ -230,7 +243,7 @@ language: {
 ```
 3. Then the title on the welcome screen should be 'Ouvrez votre nouveau compte bancaire'
 
-### 15. Overriding strings for a supported language
+### 16. Overriding strings for a supported language
 (on any browser)
 
 1. Go to latest JSFiddle
@@ -244,7 +257,7 @@ language: {
 3. Then the title on the welcome screen should be 'A custom string'
 4. All the other strings should be in Spanish
 
-### 16. Overriding strings for a supported language on mobile
+### 17. Overriding strings for a supported language on mobile
 (on any browser)
 
 1. Go to latest JSFiddle
@@ -261,7 +274,7 @@ language: {
 6. When you open the link on your mobile device, the title on the cross device client should be `A custom string`
 7. All the other strings should be in Spanish
 
-### 17. Upload a document in PDF format
+### 18. Upload a document in PDF format
 *Feature is available on desktop browsers only.*
 (on Firefox, Safari, IE11 and Microsoft Edge browsers)
 
@@ -274,7 +287,7 @@ Outcome:
 - on Safari (and Chrome - this is automated) you should see a preview of the PDF
 - on Firefox, IE11, Microsoft Edge and mobile browsers you should see an icon of a PDF
 
-### 18. Overriding the document options
+### 19. Overriding the document options
 
 1. Go to latest JSFiddle
 2. Add the following options to the initialisation params:
@@ -300,7 +313,7 @@ Outcome:
 
 - On the document selection screen only "Passport" and "Driver's License" options should be visible.
 
-### 19. Check permission priming screen displays when webcam is available and permission was not yet granted
+### 20. Check permission priming screen displays when webcam is available and permission was not yet granted
 (on Firefox, Safari and Microsoft Edge browsers)
 
 1. Go through the flow to document capture
@@ -310,7 +323,7 @@ Outcome:
 5. Click `Enable webcam`
 6. You should see the capture screen and camera permissions prompt
 
-### 20. Check permission priming screen does not display when webcam is available and permission was already granted
+### 21. Check permission priming screen does not display when webcam is available and permission was already granted
 (on Chrome)
 
 1. Go through the flow to document capture
@@ -318,7 +331,7 @@ Outcome:
 3. Click `Confirm`
 4. You should see the capture screen
 
-### 21. Check permission denied / recovery screen displays when webcam is available and permission wasn't previously denied and is denied after prompt
+### 22. Check permission denied / recovery screen displays when webcam is available and permission wasn't previously denied and is denied after prompt
 (on Chrome)
 
 1. Go through the flow to document capture
@@ -330,7 +343,7 @@ Outcome:
 7. Click `Block`
 8. You should see the permission denied / recovery screen
 
-### 22. Check permission denied / recovery screen displays when webcam is available and permission was previously denied
+### 23. Check permission denied / recovery screen displays when webcam is available and permission was previously denied
 (on Firefox, Safari and Microsoft Edge browsers)
 
 1. Go through the flow to document capture
@@ -340,7 +353,7 @@ Outcome:
 5. Click `Enable webcam`
 6. You should see the permission denied / recovery screen if the browser does not remember previous decision
 
-### 23. Live face capture fallback on Desktop
+### 24. Live face capture fallback on Desktop
 (on private mode of: Google Chrome, Firefox, Safari and Microsoft Edge browsers)
 
 Given webcam is connected to the computer
@@ -354,7 +367,7 @@ Given webcam is connected to the computer
 4. Click on "Use your mobile"
     - You should be able to continue on mobile
 
-### 24. Live face capture fallback on mobile
+### 25. Live face capture fallback on mobile
 (on private mode of getUsermedia supported browser: latest Google Chrome on Android and Safari on iOS11+)
 
 1. Go through the flow to face capture
@@ -366,7 +379,7 @@ Given webcam is connected to the computer
 4. Click on "Try the basic camera mode instead"
     - You should be able to take a picture with your native camera
 
-### 25. Face video on desktop with webcam
+### 26. Face video on desktop with webcam
 (on private mode of: Google Chrome and Firefox browsers)
 
 Given webcam is connected to the computer
@@ -385,7 +398,7 @@ Given webcam is connected to the computer
     - once completed, you should be able to see the video and to click on "Confirm"
     - you should see the complete screen
 
-### 26. Face video on desktop with webcam
+### 27. Face video on desktop with webcam
 (on private mode of: Safari and Edge browsers - these browsers do not support video recording)
 
 Given webcam is connected to the computer
@@ -399,7 +412,7 @@ Given webcam is connected to the computer
     - Upload selfie
     - Confirm
 
-### 27. Face video on desktop with no video support or no webcam
+### 28. Face video on desktop with no video support or no webcam
 (on private mode of: any browser with no webcam OR Safari and Edge browsers)
 
 Given there is no webcam connected to the computer
@@ -439,7 +452,7 @@ ADDITIONAL TEST (for scenario where integrator sets `requestedVariant: 'video'` 
 ```
 3. Should see same flow as from steps 3-4 above
 
-### 28. Custom SMS country code and flag
+### 29. Custom SMS country code and flag
 (on one of the desktop browsers)
 
 Given there is no webcam connected to the computer
@@ -451,7 +464,7 @@ Given there is no webcam connected to the computer
     - user should see the option to send SMS
     - the SMS input flag should be the US flag
 
-### 29. Custom SMS with invalid country code
+### 30. Custom SMS with invalid country code
 (on one of the desktop browsers)
 
 Given there is no webcam connected to the computer
@@ -463,7 +476,7 @@ Given there is no webcam connected to the computer
     - user should see the option to send SMS
     - the SMS input flag should be the UK one
 
-### 30. Prevent upload fallback when requested
+### 31. Prevent upload fallback when requested
 
 Given user opened the link with `?uploadFallback=false` flag
 
@@ -490,7 +503,7 @@ Given user opened the link with `?uploadFallback=false` flag
     - user should see `Restart the process with a different device` message
     - user should see the icon with the phone, screen and the red cross
 
-### 31. Custom SMS number
+### 32. Custom SMS number
 (on one of the desktop browsers)
 
 1. Open link with additional GET parameter `?smsNumber=+447955555555`
@@ -501,7 +514,7 @@ Given user opened the link with `?uploadFallback=false` flag
     - if the number is correct the user should be able to successfully send an SMS
     - if the number is invalid the user will see an error when clicking "Send link"
 
-### 32. Browse back after enlarging the document
+### 33. Browse back after enlarging the document
 (desktop and mobile browsers)
 
 1. Upload a document
@@ -510,7 +523,7 @@ Given user opened the link with `?uploadFallback=false` flag
     - "Check readability" text and back arrow retain the colour
     - Back navigation in the browser doesn't cause any other UI changes in the SDK
 
-### 33a. Check happy path flow of live document capture on mobile devices with media recorder API support
+### 34a. Check happy path flow of live document capture on mobile devices with media recorder API support
 (on private mode of both Android Chrome and Safari on iOS11+ mobile browsers)
 
 1. Open link with additional GET parameter `?useLiveDocumentCapture=true`
@@ -525,7 +538,7 @@ Given user opened the link with `?uploadFallback=false` flag
     - confirmation screen should eventually show up containing photo that was taken
     - user should be able to retake or continue with that photo
 
-### 33b. Live document capture fallback on mobile
+### 34b. Live document capture fallback on mobile
 (on private mode of Google Chrome on Android and Safari on iOS11+)
 
 1. Open link with additional GET parameter `?useLiveDocumentCapture=true&uploadFallback=true`
@@ -538,7 +551,7 @@ Given user opened the link with `?uploadFallback=false` flag
 5. Click on "Try the basic camera mode instead"
     - You should be able to take a picture with your native camera
 
-### 33c. Live document capture fallback on Hybrid
+### 34c. Live document capture fallback on Hybrid
 (private mode for browsers on Microsoft Surface or other hybrid device)
 
 1. Open link with additional GET parameter `?useLiveDocumentCapture=true`
@@ -551,7 +564,7 @@ Given user opened the link with `?uploadFallback=false` flag
 5. Click on "continue verification on your phone"
     - You should be able to switch to the cross device flow and use a mobile device to capture a document
 
-### 33d. Live document capture facingMode: {exact: "environment"} constraint
+### 34d. Live document capture facingMode: {exact: "environment"} constraint
 (private mode for mobile browsers, browsers on Ipad, and browsers on Microsoft Surface or other hybrid device)
 
 1. Open link with additional GET parameter `?useLiveDocumentCapture=true`
@@ -561,7 +574,7 @@ Given user opened the link with `?uploadFallback=false` flag
     - photo capture frame should display preview from camera
     - camera should be rear/environment facing
 
-### 33e. Live document capture attempt on non hybrid desktop
+### 34e. Live document capture attempt on non hybrid desktop
 (private mode for desktop browsers, not on Surface or other hybrid device, OR if on hybrid device, with rear camera disabled through device manager)
 
 1. Open link with additional GET parameter `?useLiveDocumentCapture=true`

--- a/src/components/Button/CameraButton.js
+++ b/src/components/Button/CameraButton.js
@@ -1,10 +1,10 @@
 import { h } from 'preact'
 
-const CameraButton = ({disabled, onClick, ariaLabel, className}) =>
+const CameraButton = ({disableInteraction, onClick, ariaLabel, className}) =>
   <button
     type="button"
     aria-label={ariaLabel}
-    disabled={disabled}
+    disabled={disableInteraction}
     onClick={onClick}
     className={className}
   />

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -32,9 +32,9 @@ export type Props = {
   isRecording?: boolean,
   facing?: 'user' | 'environment',
   idealCameraHeight?: number,
-  captureButtonType?: string,
-  onCaptureClick: Function,
-  isCaptureDisabled: boolean,
+  buttonType?: string,
+  onButtonClick: Function,
+  isButtonDisabled: boolean,
   hasGrantedPermission: boolean
 }
 
@@ -52,9 +52,9 @@ const CameraPure = ({
   translate,
   facing = 'user',
   idealCameraHeight,
-  captureButtonType,
-  onCaptureClick,
-  isCaptureDisabled,
+  buttonType,
+  onButtonClick,
+  isButtonDisabled,
   hasGrantedPermission
 }: Props) => (
   <div className={classNames(style.camera, className)}>
@@ -74,20 +74,20 @@ const CameraPure = ({
         />
       </div>
       <div className={style.actions}>
-        {captureButtonType === 'photo' &&
+        {buttonType === 'photo' &&
           <CameraButton
             ariaLabel={translate('accessibility.shutter')}
-            disableInteraction={!hasGrantedPermission || isCaptureDisabled}
-            onClick={onCaptureClick}
+            disableInteraction={!hasGrantedPermission || isButtonDisabled}
+            onClick={onButtonClick}
             className={classNames(style.btn, {
-              [style.disabled]: !hasGrantedPermission || isCaptureDisabled
+              [style.disabled]: !hasGrantedPermission || isButtonDisabled
             })}
           />}
       </div>
-      {(captureButtonType === 'video' && !isRecording) &&
+      {(buttonType === 'video' && !isRecording) &&
         <NotRecording
-          disableInteraction={!hasGrantedPermission || isCaptureDisabled}
-          onStart={onCaptureClick}
+          disableInteraction={!hasGrantedPermission || isButtonDisabled}
+          onStart={onButtonClick}
         />}
       <div
         id="cameraViewAriaLabel"

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -7,7 +7,7 @@ import classNames from 'classnames'
 import withFailureHandling from './withFailureHandling'
 import withPermissionsFlow from '../CameraPermissions/withPermissionsFlow'
 import CameraButton from '../Button/CameraButton'
-import NotRecording from '../Video/NotRecording'
+import StartRecording from '../Video/StartRecording'
 
 import style from './style.css'
 import { compose } from '~utils/func'
@@ -85,7 +85,7 @@ const CameraPure = ({
           />}
       </div>
       {(buttonType === 'video' && !isRecording) &&
-        <NotRecording
+        <StartRecording
           disableInteraction={!hasGrantedPermission || isButtonDisabled}
           onStart={onButtonClick}
         />}

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -6,6 +6,7 @@ import Webcam from 'react-webcam-onfido'
 import classNames from 'classnames'
 import withFailureHandling from './withFailureHandling'
 import withPermissionsFlow from '../CameraPermissions/withPermissionsFlow'
+import CameraButton from '../Button/CameraButton'
 import style from './style.css'
 import { compose } from '~utils/func'
 import { localised } from '../../locales'
@@ -27,7 +28,10 @@ export type Props = {
   webcamRef: React.Ref<typeof Webcam>,
   video?: boolean,
   facing?: 'user' | 'environment',
-  idealCameraHeight?: number
+  idealCameraHeight?: number,
+  onCaptureClick: Function,
+  isCaptureDisabled: boolean,
+  hasGrantedPermission: boolean
 }
 
 const CameraPure = ({
@@ -42,12 +46,19 @@ const CameraPure = ({
   video,
   translate,
   facing = 'user',
-  idealCameraHeight
+  idealCameraHeight,
+  onCaptureClick,
+  isCaptureDisabled,
+  hasGrantedPermission
 }: Props) => (
   <div className={classNames(style.camera, className)}>
     {renderTitle}
     <div className={classNames(style.container, containerClassName)}>
-      <div className={style.webcamContainer} role='group' aria-describedby='cameraViewAriaLabel'>
+      <div
+        className={style.webcamContainer}
+        role="group"
+        aria-describedby="cameraViewAriaLabel"
+      >
         <Webcam
           className={style.video}
           audio={!!video}
@@ -56,7 +67,22 @@ const CameraPure = ({
           {...{ onUserMedia, ref: webcamRef, onFailure }}
         />
       </div>
-      <div id='cameraViewAriaLabel' aria-label={translate('accessibility.camera_view')}></div>
+      <div
+        className={classNames(style.actions, {
+          [style.disabled]: !hasGrantedPermission
+        })}
+      >
+        <CameraButton
+          ariaLabel={translate('accessibility.shutter')}
+          disabled={!hasGrantedPermission || isCaptureDisabled}
+          onClick={onCaptureClick}
+          className={style.btn}
+        />
+      </div>
+      <div
+        id="cameraViewAriaLabel"
+        aria-label={translate('accessibility.camera_view')}
+      ></div>
       {children}
       {renderError}
     </div>

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -7,6 +7,7 @@ import classNames from 'classnames'
 import withFailureHandling from './withFailureHandling'
 import withPermissionsFlow from '../CameraPermissions/withPermissionsFlow'
 import CameraButton from '../Button/CameraButton'
+
 import style from './style.css'
 import { compose } from '~utils/func'
 import { localised } from '../../locales'
@@ -27,9 +28,10 @@ export type Props = {
   onUserMedia?: Function,
   webcamRef: React.Ref<typeof Webcam>,
   video?: boolean,
+  isRecording?: boolean,
   facing?: 'user' | 'environment',
   idealCameraHeight?: number,
-  hideCaptureButton: boolean,
+  captureButtonType?: string,
   onCaptureClick: Function,
   isCaptureDisabled: boolean,
   hasGrantedPermission: boolean
@@ -48,7 +50,7 @@ const CameraPure = ({
   translate,
   facing = 'user',
   idealCameraHeight,
-  hideCaptureButton,
+  captureButtonType,
   onCaptureClick,
   isCaptureDisabled,
   hasGrantedPermission
@@ -74,7 +76,7 @@ const CameraPure = ({
           [style.disabled]: !hasGrantedPermission || isCaptureDisabled
         })}
       >
-        {!hideCaptureButton &&
+        {captureButtonType === 'photo' &&
           <CameraButton
             ariaLabel={translate('accessibility.shutter')}
             disabled={!hasGrantedPermission || isCaptureDisabled}

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -29,6 +29,7 @@ export type Props = {
   video?: boolean,
   facing?: 'user' | 'environment',
   idealCameraHeight?: number,
+  hideCaptureButton: boolean,
   onCaptureClick: Function,
   isCaptureDisabled: boolean,
   hasGrantedPermission: boolean
@@ -47,6 +48,7 @@ const CameraPure = ({
   translate,
   facing = 'user',
   idealCameraHeight,
+  hideCaptureButton = false,
   onCaptureClick,
   isCaptureDisabled,
   hasGrantedPermission
@@ -72,12 +74,13 @@ const CameraPure = ({
           [style.disabled]: !hasGrantedPermission
         })}
       >
-        <CameraButton
-          ariaLabel={translate('accessibility.shutter')}
-          disabled={!hasGrantedPermission || isCaptureDisabled}
-          onClick={onCaptureClick}
-          className={style.btn}
-        />
+        {!hideCaptureButton &&
+          <CameraButton
+            ariaLabel={translate('accessibility.shutter')}
+            disabled={!hasGrantedPermission || isCaptureDisabled}
+            onClick={onCaptureClick}
+            className={style.btn}
+          />}
       </div>
       <div
         id="cameraViewAriaLabel"

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -7,6 +7,7 @@ import classNames from 'classnames'
 import withFailureHandling from './withFailureHandling'
 import withPermissionsFlow from '../CameraPermissions/withPermissionsFlow'
 import CameraButton from '../Button/CameraButton'
+import NotRecording from '../Video/NotRecording'
 
 import style from './style.css'
 import { compose } from '~utils/func'
@@ -47,6 +48,7 @@ const CameraPure = ({
   onUserMedia,
   onFailure,
   video,
+  isRecording,
   translate,
   facing = 'user',
   idealCameraHeight,
@@ -71,19 +73,22 @@ const CameraPure = ({
           {...{ onUserMedia, ref: webcamRef, onFailure }}
         />
       </div>
-      <div
-        className={classNames(style.actions, {
-          [style.disabled]: !hasGrantedPermission || isCaptureDisabled
-        })}
-      >
+      <div className={style.actions}>
         {captureButtonType === 'photo' &&
           <CameraButton
             ariaLabel={translate('accessibility.shutter')}
-            disabled={!hasGrantedPermission || isCaptureDisabled}
+            disableInteraction={!hasGrantedPermission || isCaptureDisabled}
             onClick={onCaptureClick}
-            className={style.btn}
+            className={classNames(style.btn, {
+              [style.disabled]: !hasGrantedPermission || isCaptureDisabled
+            })}
           />}
       </div>
+      {(captureButtonType === 'video' && !isRecording) &&
+        <NotRecording
+          disableInteraction={!hasGrantedPermission || isCaptureDisabled}
+          onStart={onCaptureClick}
+        />}
       <div
         id="cameraViewAriaLabel"
         aria-label={translate('accessibility.camera_view')}

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -48,7 +48,7 @@ const CameraPure = ({
   translate,
   facing = 'user',
   idealCameraHeight,
-  hideCaptureButton = false,
+  hideCaptureButton,
   onCaptureClick,
   isCaptureDisabled,
   hasGrantedPermission
@@ -71,7 +71,7 @@ const CameraPure = ({
       </div>
       <div
         className={classNames(style.actions, {
-          [style.disabled]: !hasGrantedPermission
+          [style.disabled]: !hasGrantedPermission || isCaptureDisabled
         })}
       >
         {!hideCaptureButton &&

--- a/src/components/Camera/style.css
+++ b/src/components/Camera/style.css
@@ -41,6 +41,46 @@
   }
 }
 
+.actions {
+  position: absolute;
+  z-index: 1000;
+  bottom: 48*@unit;
+  left: 16*@unit;
+  right: 16*@unit;
+
+  &.disabled {
+    z-index: 0;
+  }
+}
+
+.btn {
+  cursor: pointer;
+  outline-offset: 6*@unit;
+  background-color: @color-camera-button;
+  font-size: inherit;
+  border-radius: 50%;
+  border: 3*@unit solid @color-black;
+  box-shadow: 0 0 0 4*@unit @color-white;
+  height: 56*@unit;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 0;
+  width: 56*@unit;
+
+  &:hover {
+    background-color: @color-camera-button-hover;
+  }
+
+  &:active {
+    background-color: @color-camera-button-active;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    background-color: @color-camera-button-disabled;
+  }
+}
+
 
 .webcamContainer {
   position: absolute;

--- a/src/components/Photo/DocumentAutoCapture.js
+++ b/src/components/Photo/DocumentAutoCapture.js
@@ -114,6 +114,7 @@ export default class DocumentAutoCapture extends Component<Props, State> {
             /> :
             undefined
           }
+          hideCaptureButton={true}
         >
           <DocumentOverlay />
         </Camera>

--- a/src/components/Photo/DocumentAutoCapture.js
+++ b/src/components/Photo/DocumentAutoCapture.js
@@ -114,7 +114,6 @@ export default class DocumentAutoCapture extends Component<Props, State> {
             /> :
             undefined
           }
-          hideCaptureButton={true}
         >
           <DocumentOverlay />
         </Camera>

--- a/src/components/Photo/DocumentLiveCapture.js
+++ b/src/components/Photo/DocumentLiveCapture.js
@@ -99,6 +99,7 @@ export default class DocumentLiveCapture extends Component<Props, State> {
             isUploadFallbackDisabled={isUploadFallbackDisabled}
             trackScreen={trackScreen}
             onError={this.handleCameraError}
+            renderFallback={renderFallback}
             renderError={
               hasBecomeInactive ? (
                 <CameraError

--- a/src/components/Photo/DocumentLiveCapture.js
+++ b/src/components/Photo/DocumentLiveCapture.js
@@ -109,8 +109,9 @@ export default class DocumentLiveCapture extends Component<Props, State> {
                 />
               ) : null
             }
-            onCaptureClick={this.captureDocumentPhoto}
-            isCaptureDisabled={hasCameraError || isCapturing}
+            buttonType="photo"
+            onButtonClick={this.captureDocumentPhoto}
+            isButtonDisabled={hasCameraError || isCapturing}
           >
             {!hasCameraError && (
               <Timeout seconds={10} onTimeout={this.handleTimeout} />

--- a/src/components/Photo/DocumentLiveCapture.js
+++ b/src/components/Photo/DocumentLiveCapture.js
@@ -11,7 +11,6 @@ import Spinner from '../Spinner'
 import Timeout from '../Timeout'
 import Camera from '../Camera'
 import CameraError from '../CameraError'
-import CameraButton from '../Button/CameraButton'
 import style from './style.css'
 
 type State = {
@@ -85,40 +84,40 @@ export default class DocumentLiveCapture extends Component<Props, State> {
     const idealCameraHeightInPixels = 1280
     return (
       <div className={style.container}>
-        {this.state.isCapturing ?
-        <Spinner /> :
-        <Camera
-          facing={{exact: 'environment'}}
-          idealCameraHeight={ idealCameraHeightInPixels }
-          className={ className }
-          containerClassName={ containerClassName }
-          renderTitle={ renderTitle }
-          renderError={ renderError }
-          translate={ translate }
-          webcamRef={ c => this.webcam = c }
-          isUploadFallbackDisabled={ isUploadFallbackDisabled }
-          trackScreen={ trackScreen }
-          onError={ this.handleCameraError }
-          renderError={ hasBecomeInactive ?
-            <CameraError
-              {...{trackScreen, renderFallback}}
-              error={getInactiveError(isUploadFallbackDisabled)}
-              isDismissible
-            /> : null
-          }
-        >
-          { !hasCameraError && <Timeout seconds={ 10 } onTimeout={ this.handleTimeout } /> }
-          <ToggleFullScreen />
-          <DocumentOverlay isFullScreen={true} documentSize={documentSize} />
-          <div className={style.actions}>
-            <CameraButton
-              ariaLabel={translate('accessibility.shutter')}
-              disabled={hasCameraError || isCapturing}
-              onClick={this.captureDocumentPhoto}
-              className={style.btn}
-            />
-          </div>
-        </Camera>}
+        {this.state.isCapturing ? (
+          <Spinner />
+        ) : (
+          <Camera
+            facing={{ exact: 'environment' }}
+            idealCameraHeight={idealCameraHeightInPixels}
+            className={className}
+            containerClassName={containerClassName}
+            renderTitle={renderTitle}
+            renderError={renderError}
+            translate={translate}
+            webcamRef={c => (this.webcam = c)}
+            isUploadFallbackDisabled={isUploadFallbackDisabled}
+            trackScreen={trackScreen}
+            onError={this.handleCameraError}
+            renderError={
+              hasBecomeInactive ? (
+                <CameraError
+                  {...{ trackScreen, renderFallback }}
+                  error={getInactiveError(isUploadFallbackDisabled)}
+                  isDismissible
+                />
+              ) : null
+            }
+            onCaptureClick={this.captureDocumentPhoto}
+            isCaptureDisabled={hasCameraError || isCapturing}
+          >
+            {!hasCameraError && (
+              <Timeout seconds={10} onTimeout={this.handleTimeout} />
+            )}
+            <ToggleFullScreen />
+            <DocumentOverlay isFullScreen={true} documentSize={documentSize} />
+          </Camera>
+        )}
       </div>
     )
   }

--- a/src/components/Photo/Selfie.js
+++ b/src/components/Photo/Selfie.js
@@ -106,6 +106,7 @@ export default class SelfieCapture extends Component<Props, State> {
             isDismissible
           /> : null
         }
+        captureButtonType="photo"
         onCaptureClick={this.takeSelfie}
         isCaptureDisabled={hasCameraError || isCapturing}
       >

--- a/src/components/Photo/Selfie.js
+++ b/src/components/Photo/Selfie.js
@@ -106,9 +106,9 @@ export default class SelfieCapture extends Component<Props, State> {
             isDismissible
           /> : null
         }
-        captureButtonType="photo"
-        onCaptureClick={this.takeSelfie}
-        isCaptureDisabled={hasCameraError || isCapturing}
+        buttonType="photo"
+        onButtonClick={this.takeSelfie}
+        isButtonDisabled={hasCameraError || isCapturing}
       >
         { !hasCameraError && <Timeout seconds={ 10 } onTimeout={ this.handleTimeout } /> }
         <ToggleFullScreen />

--- a/src/components/Photo/Selfie.js
+++ b/src/components/Photo/Selfie.js
@@ -9,8 +9,6 @@ import { ToggleFullScreen } from '../FullScreen'
 import Timeout from '../Timeout'
 import Camera from '../Camera'
 import CameraError from '../CameraError'
-import CameraButton from '../Button/CameraButton'
-import style from './style.css'
 
 type State = {
   hasBecomeInactive: boolean,
@@ -92,7 +90,7 @@ export default class SelfieCapture extends Component<Props, State> {
   }
 
   render() {
-    const { translate, trackScreen, renderFallback, inactiveError } = this.props
+    const { trackScreen, renderFallback, inactiveError } = this.props
     const { hasBecomeInactive, hasCameraError, isCapturing } = this.state
 
     return (
@@ -108,18 +106,12 @@ export default class SelfieCapture extends Component<Props, State> {
             isDismissible
           /> : null
         }
+        onCaptureClick={this.takeSelfie}
+        isCaptureDisabled={hasCameraError || isCapturing}
       >
         { !hasCameraError && <Timeout seconds={ 10 } onTimeout={ this.handleTimeout } /> }
         <ToggleFullScreen />
         <FaceOverlay />
-        <div className={style.actions}>
-          <CameraButton
-            ariaLabel={translate('accessibility.shutter')}
-            disabled={hasCameraError || isCapturing}
-            onClick={this.takeSelfie}
-            className={style.btn}
-          />
-        </div>
       </Camera>
     )
   }

--- a/src/components/Photo/style.css
+++ b/src/components/Photo/style.css
@@ -4,41 +4,6 @@
   display: flex;
 }
 
-.actions {
-  position: absolute;
-  bottom: 48*@unit;
-  left: 16*@unit;
-  right: 16*@unit;
-}
-
-.btn {
-  cursor: pointer;
-  outline-offset: 6*@unit;
-  background-color: @color-camera-button;
-  font-size: inherit;
-  border-radius: 50%;
-  border: 3*@unit solid @color-black;
-  box-shadow: 0 0 0 4*@unit @color-white;
-  height: 56*@unit;
-  margin-left: auto;
-  margin-right: auto;
-  padding: 0;
-  width: 56*@unit;
-
-  &:hover {
-    background-color: @color-camera-button-hover;
-  }
-
-  &:active {
-    background-color: @color-camera-button-active;
-  }
-
-  &:disabled {
-    cursor: not-allowed;
-    background-color: @color-camera-button-disabled;
-  }
-}
-
 @import (less) "../Theme/constants.css";
 
 .thinWrapper {

--- a/src/components/Video/NotRecording.js
+++ b/src/components/Video/NotRecording.js
@@ -2,33 +2,27 @@
 import * as React from 'react'
 import { h } from 'preact'
 import classNames from 'classnames'
-import Timeout from '../Timeout'
 import style from './style.css'
 import { localised } from '../../locales'
 import type { LocalisedType } from '../../locales'
 
 type Props = {
-  hasError: boolean,
   disableInteraction: boolean,
-  onTimeout: void => void,
   onStart: void => void,
 } & LocalisedType
 
-const NotRecording = ({ translate, onStart, hasError, disableInteraction, onTimeout }: Props) => (
-  <div>
-    { !hasError ? <Timeout key="notRecording" seconds={ 12 } onTimeout={ onTimeout } /> : null }
-    <div className={style.actions}>
-      <div className={classNames(style.captureActionsHint, style.recordAction)}>
-        { translate('capture.liveness.press_record') }
-      </div>
-      <button
-        type="button"
-        aria-label={translate('accessibility.start_recording')}
-        disabled={disableInteraction}
-        onClick={onStart}
-        className={classNames(style.btn, style.startRecording)}
-      />
+const NotRecording = ({ translate, onStart, disableInteraction }: Props) => (
+  <div className={style.actions}>
+    <div className={classNames(style.captureActionsHint, style.recordAction)}>
+      { translate('capture.liveness.press_record') }
     </div>
+    <button
+      type="button"
+      aria-label={translate('accessibility.start_recording')}
+      disabled={disableInteraction}
+      onClick={onStart}
+      className={classNames(style.btn, style.startRecording)}
+    />
   </div>
 )
 

--- a/src/components/Video/Recording.js
+++ b/src/components/Video/Recording.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react'
 import { h } from 'preact'
-import Timeout from '../Timeout'
 import Challenge from './Challenge'
 import type { ChallengeType } from './Challenge'
 import classNames from 'classnames'
@@ -15,14 +14,19 @@ type Props = {
   isLastChallenge: boolean,
   hasError: boolean,
   disableInteraction: boolean,
-  onTimeout: void => void,
   onNext: void => void,
   onStop: void => void,
 } & LocalisedType
 
-const Recording = ({ onTimeout, onStop, onNext, currentChallenge, isLastChallenge, hasError, disableInteraction, translate }: Props) => (
+const Recording = ({
+  onStop,
+  onNext,
+  currentChallenge,
+  isLastChallenge,
+  disableInteraction,
+  translate
+}: Props) => (
   <div>
-    { !hasError && <Timeout key="recording" seconds={ 20 } onTimeout={ onTimeout } /> }
     <div className={style.caption}>
       <div>
         <div className={style.recordingIndicator}>
@@ -30,30 +34,34 @@ const Recording = ({ onTimeout, onStop, onNext, currentChallenge, isLastChalleng
             {translate('capture.liveness.recording')}
           </span>
         </div>
-        <Challenge {...{...currentChallenge}} />
+        <Challenge {...{ ...currentChallenge }} />
       </div>
     </div>
     <div className={style.actions}>
       <div className={style.captureActionsHint}>
-        {translate(`capture.liveness.challenges.done_${ isLastChallenge ? 'stop' : 'next' }`)}
+        {translate(
+          `capture.liveness.challenges.done_${
+            isLastChallenge ? 'stop' : 'next'
+          }`
+        )}
       </div>
-      {
-        !isLastChallenge ?
-          <Button
-            variants={['centered', 'primary']}
-            disabled={disableInteraction}
-            onClick={onNext}
-          >
-            {translate('capture.liveness.challenges.next')}
-          </Button> :
-          <button
-            type="button"
-            aria-label={translate('accessibility.stop_recording')}
-            disabled={disableInteraction}
-            onClick={onStop}
-            className={classNames(style.btn, style.stopRecording)}
-          />
-      }
+      {!isLastChallenge ? (
+        <Button
+          variants={['centered', 'primary']}
+          disabled={disableInteraction}
+          onClick={onNext}
+        >
+          {translate('capture.liveness.challenges.next')}
+        </Button>
+      ) : (
+        <button
+          type="button"
+          aria-label={translate('accessibility.stop_recording')}
+          disabled={disableInteraction}
+          onClick={onStop}
+          className={classNames(style.btn, style.stopRecording)}
+        />
+      )}
     </div>
   </div>
 )

--- a/src/components/Video/StartRecording.js
+++ b/src/components/Video/StartRecording.js
@@ -11,7 +11,7 @@ type Props = {
   onStart: void => void,
 } & LocalisedType
 
-const NotRecording = ({ translate, onStart, disableInteraction }: Props) => (
+const StartRecording = ({ translate, onStart, disableInteraction }: Props) => (
   <div className={style.actions}>
     <div className={classNames(style.captureActionsHint, style.recordAction)}>
       { translate('capture.liveness.press_record') }
@@ -26,4 +26,4 @@ const NotRecording = ({ translate, onStart, disableInteraction }: Props) => (
   </div>
 )
 
-export default localised(NotRecording)
+export default localised(StartRecording)

--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -163,18 +163,29 @@ class Video extends Component<Props, State> {
       <div>
         <Camera
           {...this.props}
-          webcamRef={ c => this.webcam = c }
-          onUserMedia={ this.handleMediaStream }
-          onError={ this.handleCameraError }
-          renderTitle={ !isRecording &&
-            <PageTitle title={translate('capture.liveness.challenges.position_face')} />}
-          {...(hasTimeoutError ? { renderError: this.renderError() } : {}) }
-          hideCaptureButton={true}
+          webcamRef={c => (this.webcam = c)}
+          onUserMedia={this.handleMediaStream}
+          onError={this.handleCameraError}
+          renderTitle={
+            !isRecording && (
+              <PageTitle
+                title={translate('capture.liveness.challenges.position_face')}
+              />
+            )
+          }
+          {...(hasTimeoutError ? { renderError: this.renderError() } : {})}
+          isCaptureDisabled={
+            hasCameraError ||
+            (isRecording && hasTimeoutError) ||
+            (!isRecording && hasRecordingTakenTooLong)
+          }
+          captureButtonType="video"
+          isRecording={isRecording}
           video
         >
           <ToggleFullScreen />
-          <FaceOverlay isWithoutHole={ hasCameraError || isRecording } />
-          { isRecording ?
+          <FaceOverlay isWithoutHole={hasCameraError || isRecording} />
+          {isRecording ? (
             <Recording
               {...{
                 currentChallenge,

--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -74,6 +74,7 @@ class Video extends Component<Props, State> {
   }
 
   handleRecordingStart = () => {
+    console.log('handleRecordingStart!')
     if (this.state.hasMediaStream) {
       this.startRecording()
       this.setState({ startedAt: currentMilliseconds() })
@@ -169,6 +170,7 @@ class Video extends Component<Props, State> {
           renderTitle={ !isRecording &&
             <PageTitle title={translate('capture.liveness.challenges.position_face')} />}
           {...(hasTimeoutError ? { renderError: this.renderError() } : {}) }
+          hideCaptureButton={true}
           video
         >
           <ToggleFullScreen />

--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -207,10 +207,10 @@ class Video extends Component<Props, State> {
             )
           }
           {...(hasTimeoutError ? { renderError: this.renderError() } : {})}
-          captureButtonType="video"
+          buttonType="video"
           isRecording={isRecording}
-          onCaptureClick={this.handleRecordingStart}
-          isCaptureDisabled={disableRecording}
+          onButtonClick={this.handleRecordingStart}
+          isButtonDisabled={disableRecording}
           video
         >
           <ToggleFullScreen />

--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -74,7 +74,6 @@ class Video extends Component<Props, State> {
   }
 
   handleRecordingStart = () => {
-    console.log('handleRecordingStart!')
     if (this.state.hasMediaStream) {
       this.startRecording()
       this.setState({ startedAt: currentMilliseconds() })

--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -154,8 +154,8 @@ class Video extends Component<Props, State> {
     if (!hasError) {
       return (
         <Timeout
-          key="notRecording"
-          seconds={12}
+          key="recording"
+          seconds={20}
           onTimeout={this.handleRecordingTimeout}
         />
       )
@@ -168,8 +168,8 @@ class Video extends Component<Props, State> {
     if (!hasError) {
       return (
         <Timeout
-          key="recording"
-          seconds={20}
+          key="notRecording"
+          seconds={12}
           onTimeout={this.handleInactivityTimeout}
         />
       )

--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -12,7 +12,7 @@ import { currentMilliseconds } from '~utils'
 import { getRecordedVideo } from '~utils/camera'
 import { sendScreen } from '../../Tracker'
 import Recording from './Recording'
-import NotRecording from './NotRecording'
+import Timeout from '../Timeout'
 import withChallenges from './withChallenges'
 import { localised } from '../../locales'
 import type { LocalisedType } from '../../locales'
@@ -143,6 +143,39 @@ class Video extends Component<Props, State> {
     )
   }
 
+  renderRecordingTimeoutMessage = () => {
+    const {
+      hasBecomeInactive,
+      hasRecordingTakenTooLong,
+      hasCameraError
+    } = this.state
+    const hasTimeoutError = hasBecomeInactive || hasRecordingTakenTooLong
+    const hasError = hasTimeoutError || this.state.hasCameraError
+    if (!hasError) {
+      return (
+        <Timeout
+          key="notRecording"
+          seconds={12}
+          onTimeout={this.handleRecordingTimeout}
+        />
+      )
+    }
+  }
+
+  renderInactivityTimeoutMessage = () => {
+    const { hasRecordingTakenTooLong, hasCameraError } = this.state
+    const hasError = hasRecordingTakenTooLong || hasCameraError
+    if (!hasError) {
+      return (
+        <Timeout
+          key="recording"
+          seconds={20}
+          onTimeout={this.handleInactivityTimeout}
+        />
+      )
+    }
+  }
+
   render = () => {
     const { translate, challenges = [] } = this.props
     const {
@@ -156,9 +189,9 @@ class Video extends Component<Props, State> {
     const currentChallenge = challenges[currentIndex] || {}
     const isLastChallenge = currentIndex === challenges.length - 1
     const hasTimeoutError = hasBecomeInactive || hasRecordingTakenTooLong
-    // Recording button should not be clickable on camera error, when recording takes too long
-    // or when camera stream is not ready
-    const disableRecording = hasRecordingTakenTooLong || hasCameraError || !hasMediaStream
+    // Recording button should not be clickable on camera error, when recording takes too long,
+    // when camera stream is not ready or when camera stream is recording
+    const disableRecording = hasRecordingTakenTooLong || hasCameraError || !hasMediaStream || isRecording
     return (
       <div>
         <Camera
@@ -174,18 +207,18 @@ class Video extends Component<Props, State> {
             )
           }
           {...(hasTimeoutError ? { renderError: this.renderError() } : {})}
-          isCaptureDisabled={
-            hasCameraError ||
-            (isRecording && hasTimeoutError) ||
-            (!isRecording && hasRecordingTakenTooLong)
-          }
           captureButtonType="video"
           isRecording={isRecording}
+          onCaptureClick={this.handleRecordingStart}
+          isCaptureDisabled={disableRecording}
           video
         >
           <ToggleFullScreen />
           <FaceOverlay isWithoutHole={hasCameraError || isRecording} />
-          {isRecording ? (
+          {isRecording ?
+            this.renderRecordingTimeoutMessage() :
+            this.renderInactivityTimeoutMessage()}
+          {isRecording &&
             <Recording
               {...{
                 currentChallenge,
@@ -196,16 +229,7 @@ class Video extends Component<Props, State> {
               onNext={this.handleNextChallenge}
               onStop={this.handleRecordingStop}
               onTimeout={this.handleRecordingTimeout}
-            /> :
-            <NotRecording
-              {...{
-                hasError: hasRecordingTakenTooLong || hasCameraError,
-                disableInteraction: disableRecording
-              }}
-              onStart={this.handleRecordingStart}
-              onTimeout={this.handleInactivityTimeout}
-            />
-          }
+            />}
         </Camera>
       </div>
     )

--- a/src/components/Video/style.css
+++ b/src/components/Video/style.css
@@ -78,9 +78,14 @@
 
 .actions {
   position: absolute;
+  z-index: 1000;
   bottom: 48*@unit;
   left: 16*@unit;
   right: 16*@unit;
+
+  &.disabled {
+    z-index: 0;
+  }
 }
 
 .btn:extend(.btn, .btn-centered, .btn-primary) {
@@ -148,7 +153,7 @@
     opacity: 0.7;
   }
 
-  &:hover {
+  &:hover:not(:disabled) {
     filter: brightness(200%);
   }
 

--- a/test/pageobjects/Camera.js
+++ b/test/pageobjects/Camera.js
@@ -2,7 +2,7 @@ import BasePage from './BasePage.js'
 
 class Camera extends BasePage {
   async continueButton () { return this.$('.onfido-sdk-ui-Button-button-primary')}
-  async shutterButton() { return this.$('.onfido-sdk-ui-Photo-btn')}
+  async shutterButton() { return this.$('.onfido-sdk-ui-Camera-btn')}
   async recordButton() { return this.$('.onfido-sdk-ui-Video-startRecording')}
   async stopButton() { return this.$('.onfido-sdk-ui-Video-stopRecording') }
   async warningMessage() { return this.$('.onfido-sdk-ui-Error-container-warning') }


### PR DESCRIPTION
# Problem
User is able to click on Capture button before allowing camera permission if they choose to ignore the browser popup. The Capture button then becomes blocked and `webcam canvas is null` error appears in browser console.

# Solution
Disable button behind overlay until permission is given by the user for all screens with a visible capture button.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [n/a] Has the README been updated?
- [n/a] Has the RELEASE_GUIDELINES been updated?
- [n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [n/a] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a] Have any new automated tests been implemented or the existing ones changed?
- [n/a] Have any new manual tests been written down or the existing ones changed?
- [n/a] Have any new strings been translated or the existing ones changed?
