### PR TITLE
Blank camera screen on load on Chrome for some Android devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ## [next-version]
 
+### Changed
+- Public: Updated to `react-webcam-onfido@0.1.18` to have fix for camera stream not getting on some Android devices, e.g. Motorola G5, Samsung Galaxy A6
+
 ### Fixed
 - Public: Fix moderate vulnerabilities in `minimist`, a sub-dependecy used by `@babel/cli` and `@babel/register`.
 - Public: Fixed hybrid device camera detection and access request

--- a/package-lock.json
+++ b/package-lock.json
@@ -13912,9 +13912,9 @@
       }
     },
     "react-webcam-onfido": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/react-webcam-onfido/-/react-webcam-onfido-0.1.17.tgz",
-      "integrity": "sha512-F5UmW4PKkLjtNCcui/Pn1oMk36ttImXIP2vl0DLViE7YY3SrSGy33CHXrY8E/olHZrMb08oNsqBNJ93qfRNrZg==",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/react-webcam-onfido/-/react-webcam-onfido-0.1.18.tgz",
+      "integrity": "sha512-lDAusipL4In/vjgZTIjMlbjk03NK2NRV3A7UssOcvdqulQzKs90j1BmZcEEp2q5rEiCaLPUqVG20JarVSwXhMA==",
       "dev": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.4.3",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "react-native-listener": "1.0.1",
     "react-phone-number-input": "^2.5.3",
     "react-redux": "~4.4.6",
-    "react-webcam-onfido": "^0.1.17",
+    "react-webcam-onfido": "^0.1.18",
     "regenerator-runtime": "^0.12.1",
     "rimraf": "^2.5.4",
     "selenium-webdriver": "^4.0.0-alpha.7",

--- a/src/components/utils/camera.js
+++ b/src/components/utils/camera.js
@@ -1,6 +1,10 @@
 import { canvasToBlob } from './blob'
 
 export const screenshot = (webcam, callback, mimeType) => {
+  if (!webcam) {
+    console.error('webcam is null')
+    return
+  }
   const canvas = webcam && webcam.getCanvas()
   if (!canvas) {
     console.error('webcam canvas is null')


### PR DESCRIPTION
# Problem
When visiting the Selfie camera screen, the camera takes a long time to load and in some cases it never loads. Bug confirmed to happen on some Android devices, e.g. Motorola G5, Samsung Galaxy A6.

# Solution
- Bump version of `react-webcam-onfido` to 0.1.18 which contains fix from PR in [#37](https://github.com/onfido/react-webcam/pull/37)
- Add console error for webcam object

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [n/a] Has the README been updated?
- [n/a] Has the RELEASE_GUIDELINES been updated?
- [n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [n/a] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a] Have any new automated tests been implemented or the existing ones changed?
- [n/a] Have any new manual tests been written down or the existing ones changed?
- [n/a] Have any new strings been translated or the existing ones changed?
