### PR TITLE
Update the error message shown when no document is in the cameras view

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -56,6 +56,7 @@ With release [Next version] there are breaking changes that will affect integrat
 The **English** and **Spanish** copy for the following string(s) has changed:
 * `cross_device.link.copy_link_label`
 * `cross_device.link.sms_label`
+* `errors.invalid_capture`
 
 ## `5.0.0` -> `5.6.0`
 With release 5.6.0 there is a breaking change that will affect integrators with customised languages or UI copy.

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -25,7 +25,7 @@ if (process.env.NODE_ENV === 'development') {
 }
 
 const getTokenFactoryUrl = (region) => {
-  switch(region) {
+  switch (region) {
     case 'US':
       return process.env.US_JWT_FACTORY
     case 'CA':

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -297,7 +297,7 @@
   "errors": {
     "invalid_capture": {
       "message":"No document detected",
-      "instruction": "Make sure all the document is in the photo"
+      "instruction": "Make sure all of the document is in the photo"
     },
     "invalid_type": {
       "message": "File not uploaded.",

--- a/src/locales/en_US/en_US.json
+++ b/src/locales/en_US/en_US.json
@@ -307,7 +307,7 @@
             "message": "Camera not detected"
         },
         "invalid_capture": {
-            "instruction": "Make sure all the document is in the photo",
+            "instruction": "Make sure all of the document is in the photo",
             "message": "No document detected"
         },
         "invalid_number": {


### PR DESCRIPTION
# Problem
Wording of the error message when no document is in the capture.

# Solution
Add in "of" to the sentence

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a] Has the CHANGELOG been updated?
- [n/a] Has the README been updated?
- [n/a] Has the RELEASE_GUIDELINES been updated?
- [n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [y] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a] Have any new automated tests been implemented or the existing ones changed?
- [n/a] Have any new manual tests been written down or the existing ones changed?
- [y] Have any new strings been translated or the existing ones changed?
