### PR TITLE
IE11: Selfie blank screen with `uploadFallback` disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Fixed
 - UI: Accessibility - Focus is at document start
 - Public: Fix unexpected back button behaviour due to `createBrowserHistory` usage. The SDK now uses `createMemoryHistory`.
+- UI: Fixed blank screen displaying instead of Cross Device screen on desktop browsers when `uploadFallback` is disabled and browser does not have getUserMedia API support, e.g. IE11, or device does not have a camera.
 
 ## [5.9.2] - 2020-05-14
 

--- a/src/components/Capture/Document.js
+++ b/src/components/Capture/Document.js
@@ -11,9 +11,9 @@ import withCameraDetection from './withCameraDetection'
 import withCrossDeviceWhenNoCamera from './withCrossDeviceWhenNoCamera'
 import withHybridDetection from './withHybridDetection'
 import { getDocumentTypeGroup } from '../DocumentSelector/documentTypes'
-import { isDesktop, addDeviceRelatedProperties, getMobileOSName } from '~utils'
+import { isDesktop, addDeviceRelatedProperties, getUnsupportedMobileBrowserError } from '~utils'
 import { compose } from '~utils/func'
-import { randomId, upperCase } from '~utils/string'
+import { randomId } from '~utils/string'
 import { localised } from '../../locales'
 import style from './style.css'
 import FallbackButton from '../Button/FallbackButton'
@@ -106,7 +106,7 @@ class Document extends Component {
     }
 
     if (!hasCamera && !uploadFallback && enableLiveDocumentCapture) {
-      return <GenericError error={{ name: `UNSUPPORTED_${upperCase(getMobileOSName())}_BROWSER` }} />
+      return <GenericError error={{ name: getUnsupportedMobileBrowserError() }} />
     }
 
     // Different upload types show different icons

--- a/src/components/Capture/Face.js
+++ b/src/components/Capture/Face.js
@@ -10,9 +10,9 @@ import withCrossDeviceWhenNoCamera from './withCrossDeviceWhenNoCamera'
 import GenericError from '../GenericError'
 import FallbackButton from '../Button/FallbackButton'
 import CustomFileInput from '../CustomFileInput'
-import { isDesktop, addDeviceRelatedProperties, getMobileOSName } from '~utils'
+import { isDesktop, addDeviceRelatedProperties, getUnsupportedMobileBrowserError } from '~utils'
 import { compose } from '~utils/func'
-import { randomId, upperCase } from '~utils/string'
+import { randomId } from '~utils/string'
 import { getInactiveError } from '~utils/inactiveError.js'
 import { localised } from '../../locales'
 import style from './style.css'
@@ -129,7 +129,7 @@ class Face extends Component {
     }
 
     if (hasCamera === false && !uploadFallback) {
-      return <GenericError error={{ name: `UNSUPPORTED_${upperCase(getMobileOSName())}_BROWSER` }} />
+      return <GenericError error={{ name: getUnsupportedMobileBrowserError() }} />
     }
 
     return <GenericError error={{ name: 'INTERRUPTED_FLOW_ERROR' }} />

--- a/src/components/Capture/Face.js
+++ b/src/components/Capture/Face.js
@@ -70,7 +70,14 @@ class Face extends Component {
   isUploadFallbackDisabled = () => !isDesktop && !this.props.uploadFallback
 
   render() {
-    const { hasCamera, requestedVariant, translate, useMultipleSelfieCapture, snapshotInterval, uploadFallback } = this.props
+    const {
+      hasCamera,
+      requestedVariant,
+      translate,
+      useMultipleSelfieCapture,
+      snapshotInterval,
+      uploadFallback
+    } = this.props
     const title = translate('capture.face.title')
     const props = {
       onError: this.handleError,
@@ -128,7 +135,7 @@ class Face extends Component {
       )
     }
 
-    if (hasCamera === false && !uploadFallback) {
+    if (!isDesktop && hasCamera === false && !uploadFallback) {
       return <GenericError error={{ name: getUnsupportedMobileBrowserError() }} />
     }
 

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -37,15 +37,16 @@ export const isSafari131 = () => {
 
 // WARN: use of this util and navigator.userAgent is highly discouraged unless absolutely necessary and for simple use cases
 export const getUnsupportedMobileBrowserError = () => {
-  console.warn("getMobileOSName - use of navigator.userAgent is highly discouraged unless absolutely necessary and only for simple use cases")
+  console.warn('getMobileOSName - use of navigator.userAgent is highly discouraged unless absolutely necessary and only for simple use cases')
   const userAgent = navigator.userAgent
   if (/android/i.test(userAgent)) {
-    return "UNSUPPORTED_ANDROID_BROWSER"
+    return 'UNSUPPORTED_ANDROID_BROWSER'
   }
   if (isIOS) {
-    return "UNSUPPORTED_IOS_BROWSER"
+    return 'UNSUPPORTED_IOS_BROWSER'
   }
   console.error("Unable to determine mobile OS")
+  return 'INTERRUPTED_FLOW_ERROR'
 }
 
 // Copied from https://github.com/muaz-khan/DetectRTC/blob/master/DetectRTC.js

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -36,14 +36,14 @@ export const isSafari131 = () => {
 }
 
 // WARN: use of this util and navigator.userAgent is highly discouraged unless absolutely necessary and for simple use cases
-export const getMobileOSName = () => {
+export const getUnsupportedMobileBrowserError = () => {
   console.warn("getMobileOSName - use of navigator.userAgent is highly discouraged unless absolutely necessary and only for simple use cases")
   const userAgent = navigator.userAgent
   if (/android/i.test(userAgent)) {
-    return "Android"
+    return "UNSUPPORTED_ANDROID_BROWSER"
   }
   if (isIOS) {
-    return "iOS"
+    return "UNSUPPORTED_IOS_BROWSER"
   }
   console.error("Unable to determine mobile OS")
 }


### PR DESCRIPTION
# Problem
When uploadFallback is disabled, on IE11 and any desktop browser where there is no camera attached/working the user gets a blank screen instead of the expected Cross Device intro screen. 

# Solution
- Fix "Unsupported Browser" error screen to only display for mobile devices
- For edge cases where mobile browser could not be detected, fall back to the generic error message

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [n/a] Has the README been updated?
- [n/a] Has the RELEASE_GUIDELINES been updated?
- [n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [n/a] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a] Have any new automated tests been implemented or the existing ones changed?
- [n/a] Have any new manual tests been written down or the existing ones changed?
- [n/a] Have any new strings been translated or the existing ones changed?
