### PR TITLE
Clean webpack output ModuleConcatenation logs

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -219,8 +219,6 @@ const baseConfig = {
     colors: true,
     // Examine all modules
     maxModules: Infinity,
-    // Display bailout reasons
-    optimizationBailout: true
   },
 
   node: {

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -219,6 +219,8 @@ const baseConfig = {
     colors: true,
     // Examine all modules
     maxModules: Infinity,
+    // Display bailout reasons	
+    optimizationBailout: false
   },
 
   node: {


### PR DESCRIPTION
# Problem
Our Ci builds are polluted so much with these types of outputs
`ModuleConcatenation bailout: Cannot concat with...`

# Solution
Remove the `optimizationBailout: true` flag from webpack config.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
