### PR TITLE
Feature/improve buttons ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Public: Updated Browser Compatibility section in `README.md` to better indicate IE11, Firefox support
 - Public: Update English copy text for error message shown when no document is in the cameras view
 - Public: The `useMultipleSelfieCapture` configuration option is now stable and enabled by default
+- UI: All primary/secondary buttons now use the new width styling. This change also fixes the buttons UI issues noticeable when using `de_DE` as a language.
 
 ### Fixed
 - UI: Accessibility - Focus is at document start

--- a/src/components/Button/style.css
+++ b/src/components/Button/style.css
@@ -97,7 +97,7 @@
   }
 }
 
-.button-small {
+.button-overlay {
   background-color: @color-small-button;
   border-radius: 4*@unit;
   color: @color-white;

--- a/src/components/Button/style.css
+++ b/src/components/Button/style.css
@@ -1,5 +1,12 @@
 @import (less) "../Theme/constants.css";
 
+@lg_btn_width_lg_screen: 272*@unit;
+@lg_btn_width_sm_screen: 100%;
+
+@sm_btn_width_lg_screen: 200*@unit;
+@sm_btn_width_sm_screen: 160*@unit;
+
+
 .button {
   height: 56*@unit;
   line-height: 56*@unit;
@@ -36,15 +43,10 @@
 
   /*layout*/
   display: block;
-  width: 216*@unit;
   max-width: 100%;
 
   border-radius: 4*@unit;
   border: none;
-
-  @media (--small-viewport) {
-    width: 100%;
-  }
 
   background-color: @color-primary-button;
 
@@ -62,13 +64,26 @@
   }
 }
 
+.button-lg {
+  width: @lg_btn_width_lg_screen;
+  @media (--small-viewport) {
+    width: 100%;
+  }
+}
+
+.button-sm {
+  width: @sm_btn_width_lg_screen;
+  @media (--small-viewport) {
+    width: @sm_btn_width_sm_screen;
+  }
+}
+
 .button-secondary {
   border: 1px solid @color-button-border;
   border-radius: 4*@unit;
   background-color: @color-transparent;
   color: @color-secondary-button-text;
   line-height: 16*@unit;
-  padding: 19.2*@unit 32*@unit;
 
   &.hoverDesktop {
     &:hover {

--- a/src/components/Button/style.css
+++ b/src/components/Button/style.css
@@ -67,7 +67,7 @@
 .button-lg {
   width: @lg_btn_width_lg_screen;
   @media (--small-viewport) {
-    width: 100%;
+    width: @lg_btn_width_sm_screen;
   }
 }
 

--- a/src/components/CameraPermissions/Primer/index.js
+++ b/src/components/CameraPermissions/Primer/index.js
@@ -16,7 +16,7 @@ const Permissions = ({onNext, translate}) => (
       <div className={style.buttonInstructions}>
         <p className={style.instructions}>{translate('webcam_permissions.click_allow')}</p>
         <Button
-          variants={["centered", "primary"]}
+          variants={["centered", "primary", "lg"]}
           onClick={onNext}
         >
           {translate('webcam_permissions.enable_webcam')}

--- a/src/components/CameraPermissions/Recover/index.js
+++ b/src/components/CameraPermissions/Recover/index.js
@@ -30,7 +30,7 @@ const Recover = ({translate}) => (
     <div className={theme.thickWrapper}>
       <Button
         className={style.button}
-        variants={["primary"]}
+        variants={["primary", "lg"]}
         onClick={() => window.location.reload()}
       >
         {translate('webcam_permissions.refresh')}

--- a/src/components/Confirm/Actions.js
+++ b/src/components/Confirm/Actions.js
@@ -4,11 +4,11 @@ import style from './style.css'
 import Button from '../Button'
 import { localised } from '../../locales'
 
-const RetakeAction = localised(({retakeAction, translate}) =>
+const RetakeAction = localised(({retakeAction, translate, btnSize}) =>
   <Button
     onClick={retakeAction}
     className={style['btn-secondary']}
-    variants={['secondary']}
+    variants={['secondary', btnSize]}
   >
     {translate('confirm.redo')}
   </Button>
@@ -17,7 +17,7 @@ const RetakeAction = localised(({retakeAction, translate}) =>
 const ConfirmAction = localised(({ confirmAction, isUploading, translate, error }) =>
   <Button
     className={style['btn-primary']}
-    variants={['primary']}
+    variants={['primary', 'sm']}
     onClick={confirmAction}
     disabled={isUploading}
   >
@@ -31,7 +31,7 @@ const Actions = ({ retakeAction, confirmAction, isUploading, error }) => (
         style.actions,
         {[style.error]: error.type === 'error'}
       )}>
-      <RetakeAction {...{retakeAction}} />
+      <RetakeAction {...{retakeAction}} btnSize={error.type === 'error' ? 'lg' : 'sm'} />
       { error.type === 'error' ?
         null : <ConfirmAction {...{ confirmAction, isUploading, error }} /> }
     </div>

--- a/src/components/Confirm/Actions.js
+++ b/src/components/Confirm/Actions.js
@@ -16,7 +16,6 @@ const RetakeAction = localised(({retakeAction, translate, btnSize}) =>
 
 const ConfirmAction = localised(({ confirmAction, isUploading, translate, error }) =>
   <Button
-    className={style['btn-primary']}
     variants={['primary', 'sm']}
     onClick={confirmAction}
     disabled={isUploading}

--- a/src/components/Confirm/style.css
+++ b/src/components/Confirm/style.css
@@ -36,7 +36,7 @@
   width: 100%;
   display: flex;
   justify-content: space-between;
-  margin-right: -16px;
+  margin-right: -16*@unit;
   @media (--small-viewport) {
     margin-right: -8*@unit;
   }

--- a/src/components/Confirm/style.css
+++ b/src/components/Confirm/style.css
@@ -31,30 +31,26 @@
   }
 }
 
-.btn-secondary {
-  width: 160*@unit;
-  @media (--small-viewport) {
-    width: 120*@unit;
-  }
-}
-
 .actions{
   padding: 0;
   width: 100%;
   display: flex;
   justify-content: space-between;
-
-  .btn-primary {
-    @media (--small-viewport) {
-      width: 135*@unit;
-    }
+  margin-right: -16px;
+  @media (--small-viewport) {
+    margin-right: -8*@unit;
   }
 }
+
+.btn-secondary {
+  margin-right: 16*@unit;
+  @media (--small-viewport) {
+    margin-right: 8*@unit;
+  }
+}
+
 
 .error {
   display: block;
   margin-bottom: 8*@unit;
-  .btn-secondary {
-    width: 90%;
-  }
 }

--- a/src/components/EnlargedPreview/index.js
+++ b/src/components/EnlargedPreview/index.js
@@ -92,7 +92,7 @@ class EnlargedPreview extends Component<Props, State> {
         <Button
           className={style.button}
           textClassName={style['button-text']}
-          variants={['small']}
+          variants={['overlay']}
           onClick={this.toggle}
         >
           {isExpanded ?

--- a/src/components/Photo/SelfieIntro.js
+++ b/src/components/Photo/SelfieIntro.js
@@ -40,7 +40,7 @@ class Intro extends Component<Props, State> {
       <InstructionsPure listScreenReaderText={translate("capture.face.intro.accessibility.selfie_capture_tips")} instructions={instructions} />
       <div className={theme.thickWrapper}>
         <Button
-          variants={['primary', 'centered']}
+          variants={['primary', 'centered', 'lg']}
           onClick={nextStep}
         >
           {translate("continue")}

--- a/src/components/ProofOfAddress/Guidance/index.js
+++ b/src/components/ProofOfAddress/Guidance/index.js
@@ -27,7 +27,7 @@ const Guidance = ({translate, parseTranslatedTags, poaDocumentType, nextStep}) =
     </div>
     <div className={theme.thickWrapper}>
       <Button
-        variants={["primary", "centered"]}
+        variants={["primary", "centered", "lg"]}
         onClick={nextStep}
       >
         {translate('proof_of_address.guidance.continue')}

--- a/src/components/ProofOfAddress/PoAIntro/index.js
+++ b/src/components/ProofOfAddress/PoAIntro/index.js
@@ -27,7 +27,7 @@ const PoAIntro = ({country, translate, parseTranslatedTags, nextStep}) => (
     </div>
     <div className={theme.thickWrapper}>
       <Button
-        variants={["primary", "centered"]}
+        variants={["primary", "centered", "lg"]}
         onClick={nextStep}
       >
         {translate('proof_of_address.intro.start')}

--- a/src/components/Uploader/index.js
+++ b/src/components/Uploader/index.js
@@ -22,26 +22,24 @@ const UploadError = ({ error, translate }) => {
 const MobileUploadArea = ({ onFileSelected, children, isPoA, translate }) =>
   <div className={classNames(style.uploadArea, style.uploadAreaMobile)}>
     { children }
-    <div className={style.buttons}>
+    <div className={classNames(style.buttons, { [style.poaButtons]: isPoA } )}>
       <CustomFileInput
-        className={style.buttonContainer}
+        className={classNames({[style.buttonContainer]: !isPoA, [style.poaBtnContainer]: isPoA })}
         onChange={onFileSelected}
         accept="image/*"
         capture
       >
         <Button
-          variants={['centered', isPoA ? 'secondary' : 'primary']}
-          className={style.button}
+          variants={isPoA ? ['secondary', 'sm'] : ['centered','primary', 'lg']}
         >
           {translate('capture.take_photo')}
         </Button>
       </CustomFileInput>
       {
         isPoA &&
-          <CustomFileInput onChange={onFileSelected} className={style.buttonContainer}>
+          <CustomFileInput onChange={onFileSelected}>
             <Button
-              variants={['centered', 'primary']}
-              className={style.button}
+              variants={['primary', 'sm']}
             >
               {translate(`capture.upload_${isDesktop ? 'file' : 'document'}`)}
             </Button>
@@ -56,7 +54,7 @@ const DesktopUploadArea = ({ translate, onFileSelected, error, uploadIcon, chang
     <div>
       {!mobileFlow && // Hide for mobileFlow on desktop browser as `test` Node environment has restrictedXDevice set to false
         <Button
-          variants={['centered', 'primary']}
+          variants={['centered', 'primary', 'lg']}
           className={ style.crossDeviceButton }
           onClick={() => changeFlowTo('crossDeviceSteps')}
         >

--- a/src/components/Uploader/style.css
+++ b/src/components/Uploader/style.css
@@ -45,9 +45,9 @@
 }
 
 .poaButtons {
-  margin-right: -16px;
+  margin-right: -16*@unit;
   @media (--small-viewport) {
-    margin-right: -8px;
+    margin-right: -8*@unit;
   }
 }
 
@@ -57,9 +57,9 @@
 }
 
 .poaBtnContainer {
-  margin-right: 16px;
+  margin-right: 16*@unit;
   @media (--small-viewport) {
-    margin-right: 8px;
+    margin-right: 8*@unit;
   }
 }
 

--- a/src/components/Uploader/style.css
+++ b/src/components/Uploader/style.css
@@ -44,19 +44,22 @@
   justify-content: space-around;
 }
 
+.poaButtons {
+  margin-right: -16px;
+  @media (--small-viewport) {
+    margin-right: -8px;
+  }
+}
+
 .buttonContainer {
   display: flex;
   width: 100%;
 }
 
-.button {
-  display: block;
-  margin: 0 5*@unit;
-  flex: 1;
-  padding: 0 16*@unit;
-
+.poaBtnContainer {
+  margin-right: 16px;
   @media (--small-viewport) {
-    flex-grow: 1;
+    margin-right: 8px;
   }
 }
 

--- a/src/components/Video/Intro.js
+++ b/src/components/Video/Intro.js
@@ -36,7 +36,7 @@ const Intro = ({ translate, parseTranslatedTags, nextStep }: Props) => (
     </div>
     <div className={theme.thickWrapper}>
       <Button
-        variants={['primary', 'centered']}
+        variants={['primary', 'centered', 'lg']}
         onClick={nextStep}
       >
         {translate('capture.liveness.intro.continue')}

--- a/src/components/Video/Recording.js
+++ b/src/components/Video/Recording.js
@@ -47,7 +47,7 @@ const Recording = ({
       </div>
       {!isLastChallenge ? (
         <Button
-          variants={['centered', 'primary']}
+          variants={['centered', 'primary', 'lg']}
           disabled={disableInteraction}
           onClick={onNext}
         >

--- a/src/components/Welcome/index.js
+++ b/src/components/Welcome/index.js
@@ -20,7 +20,7 @@ const Welcome = ({title, descriptions, nextButton, nextStep, translate}) => {
         <div className={style.text}>
           {welcomeDescriptions.map(description => <p>{description}</p>)}
         </div>
-        <Button onClick={nextStep} variants={['centered', 'primary']}>
+        <Button onClick={nextStep} variants={['centered', 'primary', 'lg']}>
           {welcomeNextButton}
         </Button>
       </div>

--- a/src/components/crossDevice/CrossDeviceSubmit/index.js
+++ b/src/components/crossDevice/CrossDeviceSubmit/index.js
@@ -68,7 +68,7 @@ class CrossDeviceSubmit extends Component {
 
           <div>
             <Button
-              variants={["primary", "centered"]}
+              variants={["primary", "centered", "lg"]}
               onClick={this.handleSubmitButtonClick}
               disabled={this.state.isSubmitDisabled}
             >

--- a/src/components/crossDevice/Intro/index.js
+++ b/src/components/crossDevice/Intro/index.js
@@ -48,7 +48,7 @@ const Intro = ({translate, nextStep, mobileConfig}) => {
       </ol>
       <div className={classNames(theme.thickWrapper, style.buttonContainer)}>
         <Button
-          variants={["primary", "centered"]}
+          variants={["primary", "centered", "lg"]}
           onClick={nextStep}
         >
           {translate(`cross_device.intro.action`)}

--- a/test/pageobjects/Confirm.js
+++ b/test/pageobjects/Confirm.js
@@ -4,7 +4,7 @@ import { verifyElementCopy } from '../utils/mochaw'
 class Confirm extends BasePage {
   async message() { return this.$('.onfido-sdk-ui-Confirm-message')}
   async redoBtn() { return this.$('.onfido-sdk-ui-Confirm-btn-secondary')}
-  async confirmBtn() { return this.$('.onfido-sdk-ui-Confirm-btn-primary')}
+  async confirmBtn() { return this.$('.onfido-sdk-ui-Button-button-primary')}
   async uploaderError() { return this.$('.onfido-sdk-ui-Uploader-error')}
   async errorTitleText() { return this.$('.onfido-sdk-ui-Error-title-text')}
   async errorTitleIcon() { return this.$('.onfido-sdk-ui-Error-title-icon-error')}


### PR DESCRIPTION
# Problem
The current button style is not up to date with the new buttons design


# Solution
All primary/secondary buttons should follow the new width styling as per design spec. 
The primary and secondary buttons now have only 2 sizes (large and small) and the size varies depending if you are on a large screen or on a small screen. I've added the following constants to make it easier to change these values later on:

`@lg_btn_width_lg_screen: 272px;` for large buttons on large screens
`@lg_btn_width_sm_screen: 100%; `for large buttons on small screens

`@sm_btn_width_lg_screen: 200px;` for small buttons on large screens
`@sm_btn_width_sm_screen: 160px; ` for small buttons on small screen

This change will also fix some UI issues spotted when introducing new language translations.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
