### PR TITLE
Reduce timeouts on UI tests to fail faster

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "file": "test/specs/chrome.js",
-      "timeout": 120000,
+      "timeout": 5000,
       "browsers": [
         {
           "browserName": "chrome",
@@ -12,7 +12,7 @@
     },
     {	
       "file": "test/specs/multipleBrowsersDocumentUpload.js",	
-      "timeout": 120000,	
+      "timeout": 5000,	
       "browsers": [	
         {	
           "browserName": "IE",	
@@ -26,7 +26,7 @@
     },
     {	
       "file": "test/specs/multipleBrowsersDocumentUpload.js",	
-      "timeout": 120000,	
+      "timeout": 5000,	
       "browsers": [	
         {	
           "browserName": "firefox",	
@@ -40,7 +40,7 @@
     },
     {	
       "file": "test/specs/multipleBrowsersDocumentUpload.js",	
-      "timeout": 120000,	
+      "timeout": 5000,	
       "browsers": [	
         {	
           "browserName": "edge",	


### PR DESCRIPTION
# Problem
Our current timeout for UI tests is 120000ms. It should be reduced to 5000ms.

# Solution
Timeout should be reduced to 5000ms for all test group.


## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
