### PR TITLE
Fix IE11 UI tests failing on BrowserStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - UI: Accessibility - Focus is at document start
 - Public: Fix unexpected back button behaviour due to `createBrowserHistory` usage. The SDK now uses `createMemoryHistory`.
 - UI: Fixed blank screen displaying instead of Cross Device screen on desktop browsers when `uploadFallback` is disabled and browser does not have getUserMedia API support, e.g. IE11, or device does not have a camera.
+- Internal: Fix failing IE11 UI test for Passport upload
 
 ## [5.9.2] - 2020-05-14
 

--- a/src/components/Uploader/ImageQualityGuide.js
+++ b/src/components/Uploader/ImageQualityGuide.js
@@ -95,16 +95,10 @@ class ImageQualityGuide extends Component<Props, State> {
             <DocumentExample type="all_good" />
           </div>
         </div>
-        <div className={theme.thickWrapper}>
+        <div>
           {error && <UploadError {...{ error, translate }} />}
           {isDesktop ? (
-            <CustomFileInput
-              className={classNames(
-                style.desktopUpload,
-                style.passportUploadContainer
-              )}
-              onChange={this.handleFileSelected}
-            >
+            <CustomFileInput onChange={this.handleFileSelected}>
               <UploadButton />
             </CustomFileInput>
           ) : (

--- a/src/components/Uploader/index.js
+++ b/src/components/Uploader/index.js
@@ -144,9 +144,7 @@ class Uploader extends Component {
           uploadType={uploadType}
           changeFlowTo={ changeFlowTo }
           mobileFlow={mobileFlow}>
-          <CustomFileInput
-            className={style.desktopUpload}
-            onChange={this.handleFileSelected}
+          <CustomFileInput onChange={this.handleFileSelected}
           >
             {error && <UploadError {...{ error, translate }} />}
             <button

--- a/src/components/Uploader/style.css
+++ b/src/components/Uploader/style.css
@@ -205,10 +205,6 @@
   text-align: center;
 }
 
-.passportUploadContainer {
-  margin: 0 auto;
-}
-
 .passportUploadBtn {
   margin-bottom: 16*@unit;
 }

--- a/test/pageobjects/PassportUploadImageGuide.js
+++ b/test/pageobjects/PassportUploadImageGuide.js
@@ -19,7 +19,7 @@ export default class PassportUploadImageGuide extends BasePage {
   async getUploadInput() {
     const input = this.uploadInput()
     this.driver.executeScript((el) => {
-      el.setAttribute('style','display: block !important')
+      el.setAttribute('style','display: block !important; height: 100px; width: 200px;')
     }, input)
     return input
   }

--- a/test/pageobjects/PassportUploadImageGuide.js
+++ b/test/pageobjects/PassportUploadImageGuide.js
@@ -13,9 +13,9 @@ export default class PassportUploadImageGuide extends BasePage {
   async docGlareText() { return this.$('[data-onfido-qa="documentExampleLabelGlare"]')}
   async docExampleImgGood() { return this.$('.onfido-sdk-ui-Uploader-documentExampleImgGood')}
   async docIsGoodText() { return this.$('[data-onfido-qa="documentExampleLabelGood"]')}
-  async uploaderBtnText() { return this.$('.onfido-sdk-ui-Uploader-passportUploadContainer .onfido-sdk-ui-Button-button-text')}
+  async uploaderBtnText() { return this.$('.onfido-sdk-ui-Button-button-text')}
 
-  async uploadInput() { return this.$('.onfido-sdk-ui-Uploader-passportUploadContainer .onfido-sdk-ui-CustomFileInput-input') }
+  async uploadInput() { return this.$('.onfido-sdk-ui-CustomFileInput-input') }
   async getUploadInput() {
     const input = this.uploadInput()
     this.driver.executeScript((el) => {
@@ -26,7 +26,7 @@ export default class PassportUploadImageGuide extends BasePage {
 
   async upload(filename) {
     // Input here cannot use the uploadInput() function above
-    const input = this.$('.onfido-sdk-ui-Uploader-passportUploadContainer .onfido-sdk-ui-CustomFileInput-input')
+    const input = this.$('.onfido-sdk-ui-CustomFileInput-input')
     const pathToTestFiles = '../resources/'
     // This will detect local file, ref: https://www.browserstack.com/automate/node#enhancements-uploads-downloads
     this.driver.setFileDetector(new remote.FileDetector())

--- a/test/specs/multipleBrowsersDocumentUpload.js
+++ b/test/specs/multipleBrowsersDocumentUpload.js
@@ -32,7 +32,7 @@ describe('DOCUMENT UPLOAD ON MULTIPLE BROWSERS', options, ({driver, pageObjects}
   it('should upload document with JPG', async () => {
     goToPassportUploadScreen(driver, welcome, documentSelector)
     documentUpload.clickUploadButton()
-    driver.sleep(500)  // add delay to account for IE11 taking a while to transition to this screen on Browserstack
+    passportUploadImageGuide.verifyTitle(copy)
     uploadFileAndClickConfirmButton(passportUploadImageGuide, confirm, 'passport.jpg')
   })
 
@@ -46,7 +46,7 @@ describe('DOCUMENT UPLOAD ON MULTIPLE BROWSERS', options, ({driver, pageObjects}
   it('should show cross device intro screen if camera not detected and uploadFallback disabled', async () => {
     goToPassportUploadScreen(driver, welcome, documentSelector, `?uploadFallback=false`)
     documentUpload.clickUploadButton()
-    driver.sleep(500)  // add delay to account for IE11 taking a while to transition to this screen on Browserstack
+    passportUploadImageGuide.verifyTitle(copy)
     uploadFileAndClickConfirmButton(passportUploadImageGuide, confirm, 'passport.jpg')
     crossDeviceIntro.verifyTitle(copy)
     crossDeviceIntro.verifySubTitle(copy)


### PR DESCRIPTION
# Problem
The automated IE11 UI tests for document uploads fail on BrowserStack with a "Element not found" error for the new Passport Upload step. Manually user can successfully complete a flow with Passport document upload.

# Solution
Verify Passport Upload Image Guide title before attempting file upload.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [n/a] Has the README been updated?
- [n/a] Has the CONTRIBUTING doc been updated?
- [n/a] Has the RELEASE_GUIDELINES been updated?
- [n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [n/a] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a] Have any new automated tests been implemented or the existing ones changed?
- [n/a] Have any new manual tests been written down or the existing ones changed?
- [n/a] Have any new strings been translated or the existing ones changed?
