### PR TITLE
Fix/browser back btn navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ## [next-version]
 
+### Changed
+- Public: Use `history/createBrowserHistory` as the default option to manage the SDK history. This change also gives the integrators the option to use `history/createMemoryHistory` by passing the configuration option `useMemoryHistory: true` to the SDK, in case `history/createBrowserHistory` does not behave as expected.
+
 ## [5.10.0] - 2020-06-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -651,6 +651,7 @@ Latest ✔ | Latest * ✔ | 11 ✔ | Latest ✔ | Latest ✔ |
 
 ### Troubleshooting
 
+#### CSP issues
 In order to mitigate potential cross-site scripting issues, most modern browsers use Content Security Policy (CSP). These policies might prevent the SDK from correctly displaying the images captured during the flow or to correctly load styles. If CSP is blocking some of the SDK functionalities, make sure you add the following snippet inside the `<head>` tag of your application.
 
 ```html
@@ -664,6 +665,17 @@ In order to mitigate potential cross-site scripting issues, most modern browsers
   object-src 'self' blob:;
   frame-src 'self' data: blob:;
 ">
+```
+
+#### SDK navigation issues
+In rare cases, the SDK back button might not work as expected within the application history. This is due to the interaction of `history/createBrowserHistory` with the browser history API.
+If you notice that by clicking on the SDK back button, you get redirected to the page that preceeded the SDK initialisation, you might want to consider using the following configuration option when initialising the SDK: `useMemoryHistory: true`. This configure the SDK to use the `history/createMemoryHistory` function, instead of the `history/createMemoryHistory`. This option is intended as workaround.
+
+Example:
+```javascript
+Onfido.init({
+  useMemoryHistory: true
+})
 ```
 
 ### Support

--- a/README.md
+++ b/README.md
@@ -669,7 +669,7 @@ In order to mitigate potential cross-site scripting issues, most modern browsers
 
 #### SDK navigation issues
 In rare cases, the SDK back button might not work as expected within the application history. This is due to the interaction of `history/createBrowserHistory` with the browser history API.
-If you notice that by clicking on the SDK back button, you get redirected to the page that preceeded the SDK initialisation, you might want to consider using the following configuration option when initialising the SDK: `useMemoryHistory: true`. This option allows the SDK to use the `history/createMemoryHistory` function, instead of the `history/createMemoryHistory`. This option is intended as workaround, while a more permanent fix is implemented.
+If you notice that by clicking on the SDK back button, you get redirected to the page that preceeded the SDK initialisation, you might want to consider using the following configuration option when initialising the SDK: `useMemoryHistory: true`. This option allows the SDK to use the `history/createMemoryHistory` function, instead of the default `history/createBrowserHistory`. This option is intended as workaround, while a more permanent fix is implemented.
 
 Example:
 ```javascript

--- a/README.md
+++ b/README.md
@@ -669,7 +669,7 @@ In order to mitigate potential cross-site scripting issues, most modern browsers
 
 #### SDK navigation issues
 In rare cases, the SDK back button might not work as expected within the application history. This is due to the interaction of `history/createBrowserHistory` with the browser history API.
-If you notice that by clicking on the SDK back button, you get redirected to the page that preceeded the SDK initialisation, you might want to consider using the following configuration option when initialising the SDK: `useMemoryHistory: true`. This configure the SDK to use the `history/createMemoryHistory` function, instead of the `history/createMemoryHistory`. This option is intended as workaround.
+If you notice that by clicking on the SDK back button, you get redirected to the page that preceeded the SDK initialisation, you might want to consider using the following configuration option when initialising the SDK: `useMemoryHistory: true`. This option allows the SDK to use the `history/createMemoryHistory` function, instead of the `history/createMemoryHistory`. This option is intended as workaround, while a more permanent fix is implemented.
 
 Example:
 ```javascript

--- a/README.md
+++ b/README.md
@@ -651,7 +651,7 @@ Latest ✔ | Latest * ✔ | 11 ✔ | Latest ✔ | Latest ✔ |
 
 ### Troubleshooting
 
-#### CSP issues
+#### Content Security Policy issues
 In order to mitigate potential cross-site scripting issues, most modern browsers use Content Security Policy (CSP). These policies might prevent the SDK from correctly displaying the images captured during the flow or to correctly load styles. If CSP is blocking some of the SDK functionalities, make sure you add the following snippet inside the `<head>` tag of your application.
 
 ```html

--- a/src/components/Router/index.js
+++ b/src/components/Router/index.js
@@ -1,5 +1,5 @@
 import { h, Component } from 'preact'
-import createMemoryHistory from 'history/createMemoryHistory'
+import { createMemoryHistory, createBrowserHistory } from 'history'
 
 import { pick } from '~utils/object'
 import { isDesktop } from '~utils'
@@ -277,7 +277,7 @@ class HistoryRouter extends Component {
       step: stepIndex,
       initialStep: stepIndex,
     }
-    this.history = createMemoryHistory()
+    this.history = this.props.options.useMemoryHistory ? createMemoryHistory() : createBrowserHistory()
     this.unlisten = this.history.listen(this.onHistoryChange)
     this.setStepIndex(this.state.step, this.state.flow)
   }

--- a/src/demo/demoUtils.js
+++ b/src/demo/demoUtils.js
@@ -63,6 +63,7 @@ export const getInitSdkOptions = () => {
     shouldCloseOnOverlayClick: queryParamToValueString.shouldCloseOnOverlayClick !== 'true',
     language,
     disableAnalytics: queryParamToValueString.disableAnalytics === 'true',
+    useMemoryHistory: queryParamToValueString.useMemoryHistory === "true",
     steps,
     mobileFlow: false,
     userDetails: {

--- a/test/specs/scenarios/hostAppHistory.js
+++ b/test/specs/scenarios/hostAppHistory.js
@@ -61,10 +61,44 @@ export const hostAppHistoryScenarios = async(lang='en_US') => {
       documentSelector.clickBackArrow()
       welcome.verifyTitle(copy)
       welcome.checkBackArrowIsNotDisplayed()
+    })
+
+    it('by default the SDK back button and the browser back behave consistently', async () => {
+      driver.get(`${localhostUrl}?useHistory=true&async=false&useUploader=true`)
+      dummyHostApp.firstStepTextDisplayed()
+      dummyHostApp.continueToNextStep()
+      dummyHostApp.secondStepTextDisplayed()
+      dummyHostApp.startVerificationFlow()
+      welcome.verifyTitle(copy)
+      welcome.continueToNextStep()
+      documentSelector.verifyTitle(copy)
+      documentSelector.clickBackArrow()
+      // clicking the SDK back button from the DocumentSelector will take you to the Welcome screen
+      welcome.verifyTitle(copy)
+      welcome.continueToNextStep()
+      documentSelector.verifyTitle(copy)
+      // clicking the browser back button from the DocumentSelector will take you to the Welcome screen
+      driver.navigate().back()
+      welcome.verifyTitle(copy)
+    })
+
+    it('when using `useMemoryHistory` the SDK back button and the browser back behave inconsistently', async () => {
+      driver.get(`${localhostUrl}?useHistory=true&async=false&useUploader=true&useMemoryHistory=true`)
+      dummyHostApp.firstStepTextDisplayed()
+      dummyHostApp.continueToNextStep()
+      dummyHostApp.secondStepTextDisplayed()
+      dummyHostApp.startVerificationFlow()
+      welcome.verifyTitle(copy)
+      welcome.continueToNextStep()
+      documentSelector.verifyTitle(copy)
+      documentSelector.clickBackArrow()
+      // clicking the SDK back button from the DocumentSelector will take you to the Welcome screen
+      welcome.verifyTitle(copy)
+      welcome.continueToNextStep()
+      documentSelector.verifyTitle(copy)
+      // clicking the browser back button from the DocumentSelector will take you to the second step of the dummyHostApp history
       driver.navigate().back()
       dummyHostApp.secondStepTextDisplayed()
-      driver.navigate().back()
-      dummyHostApp.firstStepTextDisplayed()
     })
   })
 }


### PR DESCRIPTION
# Problem
Prior to the 5.10.0 release, both the SDK back button and the browser back button would behave in the same way. From version 5.10.0, where we replaced` history/createBrowserHistory` with `history/createMemoryHistory` to fix issue #707, the browser back button and the SDK back button do not behave in the same way anymore. Clicking on the SDK back button will correctly go back through the SDK flow, while the browser back button will take you to the page previous to the SDK initialisation. This might result in the user having to repeat the SDK steps, if they click on the browser back button by mistake.

For more details see issue #1051.

# Solution
Integrators who are facing issues with the default SDK navigation, can now use the configuration option `useMemoryHistory: true` to force the SDK to use `history/createMemoryHistory`. This is intended as a workaround while we implement a more permanent fix.


## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [x] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
