### PR TITLE
Feature/bundle size limit for css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ## [next-version]
 
 ### Added
-- Internal: Added bundle size limit for `dist/style.css`.
+- Internal: Added bundle size limit check for `dist/style.css`.
 
 ### Changed
 - Public: Use `history/createBrowserHistory` as the default option to manage the SDK history. This change also gives the integrators the option to use `history/createMemoryHistory` by passing the configuration option `useMemoryHistory: true` to the SDK, in case `history/createBrowserHistory` does not behave as expected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ## [next-version]
 
 ### Added
-<!-- TODO -->
+- Internal: Added bundle size limit for `dist/style.css`.
 
 ### Changed
 - Public: Use `history/createBrowserHistory` as the default option to manage the SDK history. This change also gives the integrators the option to use `history/createMemoryHistory` by passing the configuration option `useMemoryHistory: true` to the SDK, in case `history/createBrowserHistory` does not behave as expected.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
     {
       "path": "./dist/onfido.crossDevice.min.js",
       "maxSize": "1.3 kB"
+    },
+    {
+      "path": "./dist/style.css",
+      "maxSize": "200 kB"
     }
   ],
   "devDependencies": {


### PR DESCRIPTION
# Task
Added bundle size limit for `dist/style.css`. The build will break if the file is larger than 200kb.


## Checklist
_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
