### PR TITLE
Fix CTA button blocking instructions on iPhone SE

### DIFF
--- a/src/components/Uploader/ImageQualityGuide.js
+++ b/src/components/Uploader/ImageQualityGuide.js
@@ -13,7 +13,7 @@ import Button from '../Button'
 import CustomFileInput from '../CustomFileInput'
 
 const UploadButton = localised(({ translate }) => (
-  <Button variants={['centered', 'primary', 'lg']} className={style.passportUploadBtn}>
+  <Button variants={['centered', 'primary', 'lg']}>
     {translate('image_quality_guide.next_step')}
   </Button>
 ))
@@ -85,8 +85,8 @@ class ImageQualityGuide extends Component<Props, State> {
           title={translate('image_quality_guide.title')}
           subTitle={translate('image_quality_guide.sub_title')}
         />
-        <div className={style.uploaderWrapper}>
-          <div className={style.imageQualityGuide}>
+        <div className={style.contentWrapper}>
+          <div className={theme.scrollableContent}>
             <div className={style.imageQualityGuideRow}>
               <DocumentExample type="not_cut_off" />
               <DocumentExample type="no_blur" />

--- a/src/components/Uploader/index.js
+++ b/src/components/Uploader/index.js
@@ -13,7 +13,7 @@ import Button from '../Button'
 import UploadError from './Error'
 
 const MobileUploadArea = ({ onFileSelected, children, isPoA, translate }) =>
-  <div className={classNames(style.uploadArea, style.uploadAreaMobile)}>
+  <div className={style.uploadArea}>
     { children }
     <div className={classNames(style.buttons, { [style.poaButtons]: isPoA } )}>
       <CustomFileInput
@@ -42,7 +42,7 @@ const MobileUploadArea = ({ onFileSelected, children, isPoA, translate }) =>
   </div>
 
 const PassportMobileUploadArea = ({ nextStep, children, translate }) =>
-  <div className={classNames(style.uploadArea, style.uploadAreaMobile)}>
+  <div className={style.uploadArea}>
     { children }
     <div className={style.buttons}>
       <Button

--- a/src/components/Uploader/style.css
+++ b/src/components/Uploader/style.css
@@ -154,6 +154,7 @@
   }
 }
 
+.contentWrapper,
 .uploaderWrapper {
   display: flex;
   flex-direction: column;
@@ -184,11 +185,6 @@
   }
 }
 
-.imageQualityGuide {
-  flex: 1;
-  height: 100%;
-}
-
 .imageQualityGuideRow {
   display: flex;
   justify-content: space-between;
@@ -203,6 +199,7 @@
 .documentExampleCol {
   width: 50%;
   font-size: 14*@unit;
+  padding-bottom: 16*@unit;
 }
 
 .documentExampleImg {
@@ -234,8 +231,4 @@
 
 .documentExampleLabel {
   text-align: center;
-}
-
-.passportUploadBtn {
-  margin-bottom: 16*@unit;
 }


### PR DESCRIPTION
# Problem
On smaller iPhones, i.e. iPhone SE, the "Take a photo" CTA button on the Passport Image Guide screen partially covers the instructions.

# Solution
Make area with passport image guide scrollable on smaller/shorter screens and CTA button position is fixed to bottom on screen. This also fixes the slight inconsistency between screens for the button's position.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
