### PR TITLE
Fix empty file is being sent to /snapshots endpoint on some browsers

### DIFF
--- a/src/components/Photo/Selfie.js
+++ b/src/components/Photo/Selfie.js
@@ -72,7 +72,7 @@ export default class SelfieCapture extends Component<Props, State> {
   }
 
 
-  setupSnapshots = () => {
+  onUserMedia = () => {
     if (this.props.useMultipleSelfieCapture) {
       // A timeout is required for this.webcam to load, else 'webcam is null' console error is displayed
       // despite an actual camera stream snapshot being captured
@@ -87,6 +87,8 @@ export default class SelfieCapture extends Component<Props, State> {
         this.takeSnapshot,
         this.props.snapshotInterval
       );
+    } else {
+      this.setState({ isCaptureButtonDisabled: false })
     }
   }
 
@@ -107,7 +109,7 @@ export default class SelfieCapture extends Component<Props, State> {
       <Camera
         {...this.props}
         webcamRef={ c => this.webcam = c }
-        onUserMedia={ this.setupSnapshots }
+        onUserMedia={ this.onUserMedia }
         onError={ this.handleCameraError }
         renderError={ hasBecomeInactive ?
           <CameraError

--- a/src/components/Photo/Selfie.js
+++ b/src/components/Photo/Selfie.js
@@ -15,7 +15,7 @@ type State = {
   snapshotBuffer: Array<{
     blob: Blob
   }>,
-  isCapturing: boolean
+  isCaptureButtonDisabled: boolean
 }
 
 type Props = {
@@ -37,12 +37,12 @@ export default class SelfieCapture extends Component<Props, State> {
     hasBecomeInactive: false,
     hasCameraError: false,
     snapshotBuffer: [],
-    isCapturing: false
+    isCaptureButtonDisabled: true
   }
 
   handleTimeout = () => this.setState({ hasBecomeInactive: true })
 
-  handleCameraError = () => this.setState({ hasCameraError: true })
+  handleCameraError = () => this.setState({ hasCameraError: true, isCaptureButtonDisabled: true })
 
   handleSelfie = (blob: Blob, sdkMetadata: Object) => {
     const selfie = { blob, sdkMetadata, filename: `applicant_selfie.${mimeType(blob)}` }
@@ -52,7 +52,7 @@ export default class SelfieCapture extends Component<Props, State> {
     const captureData = this.props.useMultipleSelfieCapture ?
       { snapshot, ...selfie } : selfie
     this.props.onCapture(captureData)
-    this.setState({ isCapturing: false })
+    this.setState({ isCaptureButtonDisabled: false })
   }
 
   handleSnapshot = (blob: Blob) => {
@@ -67,7 +67,7 @@ export default class SelfieCapture extends Component<Props, State> {
     this.webcam && screenshot(this.webcam, this.handleSnapshot)
 
   takeSelfie = () => {
-    this.setState({ isCapturing: true })
+    this.setState({ isCaptureButtonDisabled: true })
     screenshot(this.webcam, this.handleSelfie)
   }
 
@@ -79,7 +79,10 @@ export default class SelfieCapture extends Component<Props, State> {
       // 750ms is the minimum possible timeout without resulting in a null blob being sent to
       // the /snapshots endpoint in file payload on some browsers, e.g. macOS Firefox & Safari
       const initialSnapshotTimeout = 750
-      this.initialSnapshotTimeoutId = setTimeout(this.takeSnapshot, initialSnapshotTimeout)
+      this.initialSnapshotTimeoutId = setTimeout(() => {
+        this.takeSnapshot()
+        this.setState({ isCaptureButtonDisabled: false })
+      }, initialSnapshotTimeout)
       this.snapshotIntervalId = setInterval(
         this.takeSnapshot,
         this.props.snapshotInterval
@@ -98,7 +101,7 @@ export default class SelfieCapture extends Component<Props, State> {
 
   render() {
     const { trackScreen, renderFallback, inactiveError } = this.props
-    const { hasBecomeInactive, hasCameraError, isCapturing } = this.state
+    const { hasBecomeInactive, hasCameraError, isCaptureButtonDisabled } = this.state
 
     return (
       <Camera
@@ -115,7 +118,7 @@ export default class SelfieCapture extends Component<Props, State> {
         }
         buttonType="photo"
         onButtonClick={this.takeSelfie}
-        isButtonDisabled={hasCameraError || isCapturing}
+        isButtonDisabled={isCaptureButtonDisabled}
       >
         { !hasCameraError && <Timeout seconds={ 10 } onTimeout={ this.handleTimeout } /> }
         <ToggleFullScreen />


### PR DESCRIPTION
# Problem
Some users are also reporting being unable to complete the flow as they get a "Unsupported file type" error on Selfie upload Confirm step since release 5.10.0 when useMultipleSelfieCapture was enabled by default. 

This was found to be due to the snapshot endpoint being sent an empty file if users click/tap the Capture button immediately after camera stream is displayed on Selfie Capture screen.

# Solution
* Increase the initial snapshot timeout value to 750ms. This is the minimum possible timeout for a snapshot to be captured and the webcam object being ready.
* Capture button is also disabled on initial render until the stream is ready.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
