### PR TITLE
[Feature] Use underscore for private percent placeholder

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -5,3 +5,4 @@ rules:
   selector-class-pattern: ^[a-z0-9]+(?:[A-Z|\-|\_]{1,2}[a-z0-9]+)*$
   order/properties-alphabetical-order: null
   scss/at-mixin-pattern: ^_?[a-z]+(?:-[a-z]+)*$
+  scss/percent-placeholder-pattern: ^_?[a-z0-9]+(?:-[a-z0-9]+)*$

--- a/src/components/GenericError/style.scss
+++ b/src/components/GenericError/style.scss
@@ -1,23 +1,23 @@
 @import '../Theme/constants';
 
-%icon {
+%_icon {
   height: 144*$unit;
   background-size: contain;
   margin-top: 56*$unit;
 }
 
 .genericErrorIcon {
-  @extend %icon;
+  @extend %_icon;
   background-image: url('./assets/connection-error-large.svg');
 }
 
 .flowInterruptedIcon {
-  @extend %icon;
+  @extend %_icon;
   background-image: url('./assets/interrupted-flow.svg');
 }
 
 .unsupportedBrowserIcon {
-  @extend %icon;
+  @extend %_icon;
   background-image: url('./assets/error-cross-small.svg');
   height: 54*$unit;
 }

--- a/src/components/Overlay/style.scss
+++ b/src/components/Overlay/style.scss
@@ -1,6 +1,6 @@
 @import '../Theme/constants';
 
-%overlay {
+%_overlay {
   border: 1px solid $color-primary-500; /* Doc Autocapture border colour */
   position: absolute;
   bottom: 50%;
@@ -25,7 +25,7 @@
    */
   $height-percent: ($width-frame * $width-percent) / ($height-frame * $aspect-ratio);
 
-  @extend %overlay;
+  @extend %_overlay;
   width: $width-percent;
   height: $height-percent;
 }
@@ -37,7 +37,7 @@ $card-frame-width: 92%;
 .id1Card {
   $aspect-ratio: 1.586; /* ID1 card size - width: 85.60mm, height: 53.98mm */
 
-  @extend %overlay;
+  @extend %_overlay;
   height: $card-frame-height;
   width: $card-frame-width;
   padding-bottom: calc($card-frame-width / $aspect-ratio);
@@ -47,7 +47,7 @@ $card-frame-width: 92%;
 .id3Card {
   $aspect-ratio: 1.42;  /* ID3 card size - width: 125mm, height: 88mm */
 
-  @extend %overlay;
+  @extend %_overlay;
   height: $card-frame-height;
   width: $card-frame-width;
   padding-bottom: calc($card-frame-width / $aspect-ratio);

--- a/src/components/Uploader/style.scss
+++ b/src/components/Uploader/style.scss
@@ -93,7 +93,7 @@
   }
 }
 
-%document-icon {
+%_document-icon {
   background-image: url('./assets/cross-device-doc-icon.svg');
   background-size: 72*$unit;
   background-position: 40% 50%;
@@ -116,15 +116,15 @@
 }
 
 .icon {
-  @extend %document-icon;
+  @extend %_document-icon;
 }
 
 .identityIcon {
-  @extend %document-icon;
+  @extend %_document-icon;
 }
 
 .proofOfAddressIcon {
-  @extend %document-icon;
+  @extend %_document-icon;
 
   @media (--small-viewport) {
     height: 100%;

--- a/src/components/crossDevice/CrossDeviceLink/style.scss
+++ b/src/components/crossDevice/CrossDeviceLink/style.scss
@@ -210,7 +210,7 @@ $parent-width: 432;
   margin: 0 16*$unit;
 }
 
-%option-icon {
+%_option-icon {
   width: 22*$unit;
   height: 16*$unit;
   display: inline-block;
@@ -220,16 +220,16 @@ $parent-width: 432;
 }
 
 .smsLinkOption::before {
-  @extend %option-icon;
+  @extend %_option-icon;
   background-image: url('./assets/icon-sms.svg');
 }
 
 .qrCodeLinkOption::before {
-  @extend %option-icon;
+  @extend %_option-icon;
   background-image: url('./assets/icon-qr-code.svg');
 }
 
 .copyLinkOption::before {
-  @extend %option-icon;
+  @extend %_option-icon;
   background-image: url('./assets/icon-copy-link.svg');
 }


### PR DESCRIPTION
To follow the standard that private mixins start with underscore - this would allow private percent placeholders to start with underscore too.