### PR TITLE
Add note about -LTS suffix

### DIFF
--- a/release/RELEASE_GUIDELINES.md
+++ b/release/RELEASE_GUIDELINES.md
@@ -5,6 +5,8 @@ We follow semver for versioning. Given a version number MAJOR.MINOR.PATCH, incre
 - MINOR version when you add functionality in a backwards-compatible manner
 - PATCH version when you make backwards-compatible bug fixes
 
+For LTS releases, append the "-LTS" suffix to the release version
+
 ## Prerequisite
 In order to perform the release you need to:
 


### PR DESCRIPTION
# Problem
There has been confusion around LTS process and responsibilities 

# Solution
This change is to bring greater awareness to the need to ensure that LTS releases include the "-LTS" suffix, whether the release is done by SDK or Enterprise Team. Since this doc seems very streamlined, I just added an alert to make sure people are thinking about it. More info has also been added to "Release Guidelines for the Onfido JS SDK" on Confluence.

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [n/a ] Has the CHANGELOG been updated?
- [n/a ] Has the README been updated?
- [ n/a] Has the CONTRIBUTING doc been updated?
- [ X] Has the RELEASE_GUIDELINES been updated?
- [ n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ n/a] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a ] Have any new automated tests been implemented or the existing ones changed?
- [n/a ] Have any new manual tests been written down or the existing ones changed?
- [n/a ] Have any new strings been translated or the existing ones changed?
