### PR TITLE
Add Migration release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Public: Added `isCrossDevice` flag to user analytics events to differentiate between cross-device and non-cross-device user analytic events
 - Public: Added `DOCUMENT_TYPE_SELECT` and `FACIAL_CAPTURE` to user analytics event list
 - Public: Added option to pass a container element `containerEl` instead of a container ID string `containerId`. If `containerEl` is provided, then `containerId` will be ignored.
+- Internal: The release script and the `release/RELEASE_GUIDELINE.md` file, now include the information needed to update the `MIGRATION.md` file.
 
 ### Changed
 

--- a/release/RELEASE_GUIDELINES.md
+++ b/release/RELEASE_GUIDELINES.md
@@ -6,6 +6,12 @@ We follow semver for versioning. Given a version number MAJOR.MINOR.PATCH, incre
 - MINOR version when you add functionality in a backwards-compatible manner
 - PATCH version when you make backwards-compatible bug fixes
 
+When performing a new release, the `MIGRATION.md` file should be updated with following details:
+
+- New version number
+- All breaking changes, including code snippets whenever possible (for MAJOR versions)
+- A list of translation keys changes (for all versions)
+
 ## Prerequisite
 
 In order to perform the release you need to:

--- a/release/release.js
+++ b/release/release.js
@@ -84,6 +84,8 @@ const confirmDocumentationCorrect = async () => {
     '   - with a link to diff between last and current version (at the bottom of the file)'
   )
   console.log(' - MIGRATION.md')
+  console.log('   - with all breaking changes (for MAJOR versions)')
+  console.log('   - with  a list of translation keys changes (for all versions)')
   console.log(' - CONFLUENCE')
   console.log('   - Review and update "feature matrix", if necessary.')
   console.log(


### PR DESCRIPTION
# Task

Add details to remind developers doing the JS SDK release about updating the migration file. The reminder has been added inside the release script and inside the `RELEASE_GUIDELINES.md` file.
The manual release process file on our internal wiki and the GitHub PR checklist were already up to date

## Checklist
_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
