### PR TITLE
Regression/SDK breaks if initialised as a modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4615,9 +4615,9 @@
       "dev": true
     },
     "aggregate-error": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
-      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
       "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
@@ -6152,12 +6152,12 @@
           "dev": true
         },
         "agent-base": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+          "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
           "dev": true,
           "requires": {
-            "es6-promisify": "^5.0.0"
+            "debug": "4"
           }
         },
         "array-union": {
@@ -6173,6 +6173,15 @@
           "dev": true,
           "requires": {
             "fill-range": "^7.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
           }
         },
         "del": {
@@ -6249,13 +6258,13 @@
           }
         },
         "https-proxy-agent": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
           "dev": true,
           "requires": {
-            "agent-base": "^4.3.0",
-            "debug": "^3.1.0"
+            "agent-base": "6",
+            "debug": "4"
           }
         },
         "ignore": {
@@ -6290,6 +6299,12 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "p-map": {
@@ -7742,21 +7757,6 @@
         "is-symbol": "^1.0.2"
       }
     },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "^4.0.3"
-      }
-    },
     "escalade": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
@@ -8771,9 +8771,9 @@
           }
         },
         "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6131,16 +6131,16 @@
       }
     },
     "chromedriver": {
-      "version": "83.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-83.0.1.tgz",
-      "integrity": "sha512-51/YsLIMRF+L0ooMlM4aZjyoOpDs0gDXGlT6+/CwWEnvK53PUyef9FkotKbzknCaUeL/qUw3ic3IMmsNc+SUxg==",
+      "version": "84.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-84.0.1.tgz",
+      "integrity": "sha512-iJ6Y680yp58+KlAPS5YgYe3oePVFf8jY5k4YoczhXkT0p/mQZKfGNkGG/Xc0LjGWDQRTgZwXg66hOXoApIQecg==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",
         "axios": "^0.19.2",
         "del": "^5.1.0",
-        "extract-zip": "^2.0.0",
-        "https-proxy-agent": "^2.2.4",
+        "extract-zip": "^2.0.1",
+        "https-proxy-agent": "^5.0.0",
         "mkdirp": "^1.0.4",
         "tcp-port-used": "^1.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "bundlesize": "^0.18.0",
     "chai": "^4.2.0",
     "chalk": "^2.4.2",
-    "chromedriver": "^83.0.1",
+    "chromedriver": "^84.0.1",
     "css-loader": "^3.4.2",
     "eslint": "^6.8.0",
     "eslint-config-preact": "^1.1.1",

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -12,43 +12,42 @@ const MODAL_ANIMATION_DURATION = getCSSMilisecsValue(
 
 const Wrapper = ({ children }) => wrapWithClass(style.inner, children)
 
-const Modal = () => {
-  const {
-    translate,
-    isFullScreen,
-    containerId,
-    containerEl,
-    shouldCloseOnOverlayClick,
-  } = this.props
-
-  return (
-    <ReactModal
-      isOpen={this.props.isOpen}
-      onRequestClose={this.props.onRequestClose}
-      portalClassName={style.portal}
-      overlayClassName={style.overlay}
-      bodyClassName={style.modalBody}
-      className={style.inner}
-      shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
-      closeTimeoutMS={MODAL_ANIMATION_DURATION}
-      appElement={containerEl || document.getElementById(containerId)}
+const Modal = ({
+  translate,
+  children,
+  isOpen,
+  isFullScreen,
+  onRequestClose,
+  containerId,
+  containerEl,
+  shouldCloseOnOverlayClick,
+}) => (
+  <ReactModal
+    isOpen={isOpen}
+    onRequestClose={onRequestClose}
+    portalClassName={style.portal}
+    overlayClassName={style.overlay}
+    bodyClassName={style.modalBody}
+    className={style.inner}
+    shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
+    closeTimeoutMS={MODAL_ANIMATION_DURATION}
+    appElement={containerEl || document.getElementById(containerId)}
+  >
+    <button
+      type="button"
+      aria-label={translate('accessibility.close_sdk_screen')}
+      onClick={onRequestClose}
+      className={classNames(style.closeButton, {
+        [style.closeButtonFullScreen]: isFullScreen,
+      })}
     >
-      <button
-        type="button"
-        aria-label={translate('accessibility.close_sdk_screen')}
-        onClick={this.props.onRequestClose}
-        className={classNames(style.closeButton, {
-          [style.closeButtonFullScreen]: isFullScreen,
-        })}
-      >
-        <span className={style.closeButtonLabel} aria-hidden="true">
-          {translate('close')}
-        </span>
-      </button>
-      {this.props.children}
-    </ReactModal>
-  )
-}
+      <span className={style.closeButtonLabel} aria-hidden="true">
+        {translate('close')}
+      </span>
+    </button>
+    {children}
+  </ReactModal>
+)
 
 Modal.defaultProps = {
   shouldCloseOnOverlayClick: true,


### PR DESCRIPTION
# Problem
If initialised in modal mode, the SDK breaks and throws an error. UI tests for modal scenario in recent PRs are failing because of this.

# Solution
Use object destructuring on the props object that is now passed in to Modal component as a parameter instead of `this.props`.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [n/a] Has the CHANGELOG been updated? - dev regression, bug is not in production
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
