### PR TITLE
Regression/Unexpected UI changes in PoA Selector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6152,12 +6152,23 @@
           "dev": true
         },
         "agent-base": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+          "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
           "dev": true,
           "requires": {
-            "es6-promisify": "^5.0.0"
+            "debug": "4"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            }
           }
         },
         "array-union": {
@@ -6249,13 +6260,24 @@
           }
         },
         "https-proxy-agent": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
           "dev": true,
           "requires": {
-            "agent-base": "^4.3.0",
-            "debug": "^3.1.0"
+            "agent-base": "6",
+            "debug": "4"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            }
           }
         },
         "ignore": {
@@ -6290,6 +6312,12 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "p-map": {
@@ -7740,21 +7768,6 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
-      }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "^4.0.3"
       }
     },
     "escalade": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6131,16 +6131,16 @@
       }
     },
     "chromedriver": {
-      "version": "83.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-83.0.1.tgz",
-      "integrity": "sha512-51/YsLIMRF+L0ooMlM4aZjyoOpDs0gDXGlT6+/CwWEnvK53PUyef9FkotKbzknCaUeL/qUw3ic3IMmsNc+SUxg==",
+      "version": "84.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-84.0.1.tgz",
+      "integrity": "sha512-iJ6Y680yp58+KlAPS5YgYe3oePVFf8jY5k4YoczhXkT0p/mQZKfGNkGG/Xc0LjGWDQRTgZwXg66hOXoApIQecg==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",
         "axios": "^0.19.2",
         "del": "^5.1.0",
-        "extract-zip": "^2.0.0",
-        "https-proxy-agent": "^2.2.4",
+        "extract-zip": "^2.0.1",
+        "https-proxy-agent": "^5.0.0",
         "mkdirp": "^1.0.4",
         "tcp-port-used": "^1.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "bundlesize": "^0.18.0",
     "chai": "^4.2.0",
     "chalk": "^2.4.2",
-    "chromedriver": "^83.0.1",
+    "chromedriver": "^84.0.1",
     "css-loader": "^3.4.2",
     "eslint": "^6.8.0",
     "eslint-config-preact": "^1.1.1",

--- a/src/components/DocumentSelector/index.js
+++ b/src/components/DocumentSelector/index.js
@@ -103,20 +103,22 @@ class DocumentSelector extends Component<Props & WithDefaultOptions> {
 
 const LocalisedDocumentSelector = localised(DocumentSelector)
 
-const withDefaultOptions = (iconCopyDisplayByType: Object) => {
+const withDefaultOptions = (iconCopyDisplayOptionsByType: Object) => {
   const DefaultOptionedDocumentSelector = (props: Props) => (
     <LocalisedDocumentSelector
       {...props}
       defaultOptions={() => {
-        const typeList = Object.keys(iconCopyDisplayByType)
+        const typeList = Object.keys(iconCopyDisplayOptionsByType)
         const group = props.group
         return typeList.map((type) => {
           const {
             icon = `icon-${kebabCase(type)}`,
             hint,
             warning,
-          } = iconCopyDisplayByType[type]
+            ...other
+          } = iconCopyDisplayOptionsByType[type]
           return {
+            ...other,
             icon,
             type,
             label: props.translate(type),

--- a/src/components/DocumentSelector/index.js
+++ b/src/components/DocumentSelector/index.js
@@ -115,10 +115,12 @@ const withDefaultOptions = (iconCopyDisplayOptionsByType: Object) => {
             icon = `icon-${kebabCase(type)}`,
             hint,
             warning,
-            ...other
+            eStatementAccepted,
+            checkAvailableInCountry,
           } = iconCopyDisplayOptionsByType[type]
           return {
-            ...other,
+            eStatementAccepted,
+            checkAvailableInCountry,
             icon,
             type,
             label: props.translate(type),


### PR DESCRIPTION
# Problem
PoA Selector screen is missing the "e-statements accepted" copy for PoA documents that it applies to and Government Letter option is now visible always (should only be visible if SDK is set up for for non-UK PoA documents).

# Solution
Bring back missing properties, but this time explicitly name them rather than abstract these out into a property named `other` which is in `master` [branch's DocumentSelector component lines 115, 118](https://github.com/onfido/onfido-sdk-ui/blob/68ed7e1a07962481134adf56fc53bf91599e2f34/src/components/DocumentSelector/index.js#L118)

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [n/a] Has the CHANGELOG been updated? - dev regression, bug is not in production
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
