### PR TITLE
Inconsistent font style for Back button, Upload link button from rest of SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Fixed
 
 - Public: Return a generic error for unmapped Onfido API validation keys.
+- UI: Fixed inconsistent font family for non Primary, Secondary button elements.
 
 ## [5.13.0] - 2020-08-24
 

--- a/src/components/Modal/style.scss
+++ b/src/components/Modal/style.scss
@@ -61,7 +61,7 @@ $modal-animation-duration: 200ms;
   border-radius: 8 * $unit;
   border: 1px solid $color-border;
 
-  font-family: 'Open Sans', sans-serif !important;
+  font-family: $font-family !important;
   background-color: $color-background;
 
   color: $color-body-text;
@@ -108,7 +108,7 @@ $modal-animation-duration: 200ms;
   border-radius: 16 * $unit;
   border: 0;
   cursor: pointer;
-  font-family: 'Open Sans', sans-serif;
+  font-family: $font-family;
   height: 32 * $unit;
   position: absolute;
   right: 15 * $unit;

--- a/src/components/NavigationBar/style.scss
+++ b/src/components/NavigationBar/style.scss
@@ -14,6 +14,35 @@
   }
 }
 
+.back {
+  height: 32 * $unit;
+  color: $color-body-text;
+  padding: 0;
+  font-size: inherit;
+  font-family: $font-family;
+  line-height: 1;
+  border: 0;
+  background-color: $color-icon-button;
+  cursor: pointer;
+
+  @media (--small-viewport) {
+    width: auto;
+  }
+}
+
+.iconBack {
+  height: 32 * $unit;
+  width: 32 * $unit;
+  background-image: url('./assets/back-black.svg');
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  background-color: $color-transparent;
+  border-radius: 16 * $unit;
+  display: inline-block;
+  vertical-align: middle;
+}
+
 .fullScreenNav {
   /* stylelint-disable function-parentheses-space-inside */
   background: linear-gradient(
@@ -73,34 +102,6 @@
 
 .disabled {
   display: none;
-}
-
-.back {
-  height: 32 * $unit;
-  color: $color-body-text;
-  padding: 0;
-  font-size: inherit;
-  line-height: 1;
-  border: 0;
-  background-color: $color-icon-button;
-  cursor: pointer;
-
-  @media (--small-viewport) {
-    width: auto;
-  }
-}
-
-.iconBack {
-  height: 32 * $unit;
-  width: 32 * $unit;
-  background-image: url('./assets/back-black.svg');
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: contain;
-  background-color: $color-transparent;
-  border-radius: 16 * $unit;
-  display: inline-block;
-  vertical-align: middle;
 }
 
 .label {

--- a/src/components/Theme/constants.scss
+++ b/src/components/Theme/constants.scss
@@ -31,6 +31,8 @@ $font-size-x-small: 11 * $unit;
  */
 $unit-rrui: 1em;
 
+$font-family: 'Open Sans', sans-serif;
+
 $large-text-margin: 40 * $unit;
 $small-text-margin: 24 * $unit;
 $padding-lg: 16 * $unit;

--- a/src/components/Theme/style.scss
+++ b/src/components/Theme/style.scss
@@ -205,6 +205,7 @@ $cobrand-logo-width: 80 * $unit;
   cursor: pointer;
   line-height: 1.43;
   font-size: $font-size-small;
+  font-family: $font-family;
   margin: auto;
   padding: 2px;
   text-decoration: none;

--- a/src/components/crossDevice/CrossDeviceLink/style.scss
+++ b/src/components/crossDevice/CrossDeviceLink/style.scss
@@ -136,7 +136,7 @@ $parent-width: 432;
   line-height: 1.5;
   color: $color-body-text;
   white-space: nowrap;
-  font-family: 'Open Sans', sans-serif;
+  font-family: $font-family;
 }
 
 .copyToClipboard {

--- a/src/components/crossDevice/CrossDeviceLink/style.scss
+++ b/src/components/crossDevice/CrossDeviceLink/style.scss
@@ -144,6 +144,7 @@ $parent-width: 432;
   float: right;
   height: 100%;
   font-size: $font-size-small;
+  font-family: $font-family;
   margin-left: 4 * $unit-small;
   padding: 2px;
   text-decoration: none;


### PR DESCRIPTION
# Problem
We have inconsistent font style for the Back button, Upload link button when compared to the rest of the SDK.

Upload Document button, Copy Link button, Back button are using Arial font instead of the usual `"Open Sans", sans-serif` font family throughout the SDK.

# Solution
Defined a common font family Sass variable to be reused wherever font family needs to be defined. This includes setting it for a button element as the browser default is applied instead if not set.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
