### PR TITLE
Blur element when country is selected

### DIFF
--- a/src/components/CountrySelector/index.js
+++ b/src/components/CountrySelector/index.js
@@ -44,7 +44,6 @@ const getCountryOptionTemplate = (country: CountryData) =>
     <span class="${style.countryLabel}">${country.name}</span>`
 
 class CountrySelection extends Component<Props, State> {
-  autocompleteEl: ?HTMLDivElement
   state = {
     showNoResultsError: false,
   }

--- a/src/components/CountrySelector/index.js
+++ b/src/components/CountrySelector/index.js
@@ -49,13 +49,13 @@ class CountrySelection extends Component<Props, State> {
     showNoResultsError: false,
   }
 
-  handleCountrySearchConfirm = async (selectedCountry: CountryData) => {
+  handleCountrySearchConfirm = (selectedCountry: CountryData) => {
     if (selectedCountry) {
       this.setState({
         showNoResultsError: false,
       })
-      await this.props.actions.setIdDocumentIssuingCountry(selectedCountry)
-      this.autocompleteEl.elementReferences[-1].blur()
+      this.props.actions.setIdDocumentIssuingCountry(selectedCountry)
+      setTimeout(() => document.getElementById('country-search').blur(), 0)
     } else if (!selectedCountry && !this.props.idDocumentIssuingCountry) {
       this.setState({
         showNoResultsError: true,
@@ -142,7 +142,6 @@ class CountrySelection extends Component<Props, State> {
             </label>
             <Autocomplete
               id="country-search"
-              ref={(el) => (this.autocompleteEl = el)}
               source={this.suggestCountries}
               minLength={2}
               placeholder={translate(`country_selection.placeholder`)}

--- a/src/components/CountrySelector/index.js
+++ b/src/components/CountrySelector/index.js
@@ -44,16 +44,18 @@ const getCountryOptionTemplate = (country: CountryData) =>
     <span class="${style.countryLabel}">${country.name}</span>`
 
 class CountrySelection extends Component<Props, State> {
+  autocompleteEl: ?HTMLDivElement
   state = {
     showNoResultsError: false,
   }
 
-  handleCountrySearchConfirm = (selectedCountry: CountryData) => {
+  handleCountrySearchConfirm = async (selectedCountry: CountryData) => {
     if (selectedCountry) {
       this.setState({
         showNoResultsError: false,
       })
-      this.props.actions.setIdDocumentIssuingCountry(selectedCountry)
+      await this.props.actions.setIdDocumentIssuingCountry(selectedCountry)
+      this.autocompleteEl.elementReferences[-1].blur()
     } else if (!selectedCountry && !this.props.idDocumentIssuingCountry) {
       this.setState({
         showNoResultsError: true,
@@ -140,6 +142,7 @@ class CountrySelection extends Component<Props, State> {
             </label>
             <Autocomplete
               id="country-search"
+              ref={(el) => (this.autocompleteEl = el)}
               source={this.suggestCountries}
               minLength={2}
               placeholder={translate(`country_selection.placeholder`)}


### PR DESCRIPTION
# Problem
As a user, when typing a country of my choice, I should be able to see the action that allows me to proceed. This happens by default on Chrome for Android, while on Safari iOS the action is covered by the virtual keyboard.

# Solution
Dismiss the mobile keyboard once a country has been selected

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
