### PR TITLE
Remove SMS_BODY translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Changed
 
 - Internal: Changed resolution constraints for live document captures from `720` to `1080`.
+- Public: Remove `SMS_BODY` key from locale files as it's not a customisable key and does not belong to this codebase.
 
 ### Fixed
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -120,6 +120,10 @@ The following keys have been renamed:
 - `errors.server_error.instruction` => `errors.request_error.instruction`
 - `errors.server_error.message` => `errors.request_error.message`
 
+### Removed strings
+
+- `SMS_BODY`
+
 ## `5.7.0` -> `5.10.0`
 
 ### Added strings

--- a/src/locales/de_DE/de_DE.json
+++ b/src/locales/de_DE/de_DE.json
@@ -483,7 +483,6 @@
     "short_driving_licence": "Führerschein",
     "short_national_identity_card": "Karte",
     "short_passport": "Reisepass",
-    "SMS_BODY": "Fortsetzung der Nachprüfung durch klicken von",
     "utility_bill": "Utility Bill",
     "webcam_permissions": {
         "access_denied": "Kamerazugriff wird verweigert.",

--- a/src/locales/en_US/en_US.json
+++ b/src/locales/en_US/en_US.json
@@ -483,7 +483,6 @@
     "short_driving_licence": "license",
     "short_national_identity_card": "card",
     "short_passport": "passport",
-    "SMS_BODY": "Continue your identity verification by tapping",
     "utility_bill": "Utility Bill",
     "webcam_permissions": {
         "access_denied": "Camera access is denied",

--- a/src/locales/es_ES/es_ES.json
+++ b/src/locales/es_ES/es_ES.json
@@ -483,7 +483,6 @@
     "short_driving_licence": "licencia",
     "short_national_identity_card": "tarjeta",
     "short_passport": "pasaporte",
-    "SMS_BODY": "Continúe su verificación pulsando",
     "utility_bill": "Utility Bill",
     "webcam_permissions": {
         "access_denied": "Acceso a la cámara no permitido",

--- a/src/locales/fr_FR/fr_FR.json
+++ b/src/locales/fr_FR/fr_FR.json
@@ -483,7 +483,6 @@
     "short_driving_licence": "permis",
     "short_national_identity_card": "carte",
     "short_passport": "passeport",
-    "SMS_BODY": "Continuez votre vérification ici",
     "utility_bill": "Facture",
     "webcam_permissions": {
         "access_denied": "L'accès à l'appareil photo n'est pas autorisé",


### PR DESCRIPTION
# Problem

The localised copy files includes the `SMS_BODY` key copy that applies to the x-device link SMS message sent from the Onfido backend. This copy is not customisable but integrators think it is since it's present it in the JSON files.

This fixes issue #1185 

# Solution
Remove `SMS_BODY` from all translation files and from our translation service platform.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
