### PR TITLE
Change JS SDK -> Web SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Changed
 
+- Internal: Replace all string values from `JS SDK` to `Web SDK` and `js-sdk` to `web-sdk`.
+
 ### Fixed
 
 - UI: Accessibility - Error and warning alert heading is now ARIA heading level 1

--- a/MANUAL_REGRESSION.md
+++ b/MANUAL_REGRESSION.md
@@ -1,4 +1,4 @@
-# Manual Regression Tests for JS SDK
+# Manual Regression Tests for Web SDK
 
 ## Definitions
 
@@ -666,7 +666,7 @@ Given user opened the link with `?uploadFallback=false` flag
 
 (on one browser)
 
-With JS SDK project open in Woopra
+With Web SDK project open in Woopra
 
 1. Go through the normal flow for any document
    - all events should be tracked

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,4 +1,4 @@
-# Onfido JS SDK Migration Guide
+# Onfido Web SDK Migration Guide
 
 The guides below are provided to ease the transition of existing applications using the Onfido SDK from one version to another that introduces breaking API changes.
 

--- a/README.md
+++ b/README.md
@@ -714,7 +714,7 @@ Onfido.init({
 
 Please open an issue through [GitHub](https://github.com/onfido/onfido-sdk-ui/issues). Please be as detailed as you can. Remember **not** to submit your token in the issue. Also check the closed issues to check whether it has been previously raised and answered.
 
-If you have any issues that contain sensitive information please send us an email with the ISSUE: at the start of the subject to [js-sdk@onfido.com](mailto:js-sdk@onfido.com).
+If you have any issues that contain sensitive information please send us an email with the ISSUE: at the start of the subject to [web-sdk@onfido.com](mailto:web-sdk@onfido.com).
 
 Previous version of the SDK will be supported for a month after a new major version release. Note that when the support period has expired for an SDK version, no bug fixes will be provided, but the SDK will keep functioning (until further notice).
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "onfido-sdk-ui",
   "version": "6.0.0",
   "description": "JavaScript SDK view layer for Onfido identity verification",
-  "author": "SDK Customer Support <js-sdk@onfido.com> (https://github.com/onfido)",
+  "author": "Web SDK Customer Support <web-sdk@onfido.com> (https://github.com/onfido)",
   "repository": {
     "type": "git",
     "url": "https://github.com/onfido/onfido-sdk-ui.git"

--- a/release/RELEASE_GUIDELINES.md
+++ b/release/RELEASE_GUIDELINES.md
@@ -1,4 +1,4 @@
-# Release Guidelines for the Onfido JS SDK
+# Release Guidelines for the Onfido Web SDK
 
 We follow semver for versioning. Given a version number MAJOR.MINOR.PATCH, increment the:
 

--- a/src/demo/README.md
+++ b/src/demo/README.md
@@ -1,7 +1,7 @@
-# JS SDK Demo App
+# Web SDK Demo App
 
 This Demo app gets built when running `npm run dev` - it is meant only to easily
-preview the JS SDK quickly and easily
+preview the Web SDK quickly and easily
 
 ## "Previewer" mode
 

--- a/test/TESTING_GUIDELINES.md
+++ b/test/TESTING_GUIDELINES.md
@@ -1,6 +1,6 @@
 # Testing guidelines
 
-Guide to UI tests for JS SDK.
+Guide to UI tests for Web SDK.
 
 ### Software requirements
 

--- a/test/main.js
+++ b/test/main.js
@@ -21,7 +21,7 @@ const bsCapabilitiesDefault = {
   acceptSslCerts: 'true',
   forceLocal: 'true',
   'browserstack.debug': 'true',
-  project: 'JS SDK',
+  project: 'Web SDK',
   'browserstack.user': process.env.BROWSERSTACK_USERNAME,
   'browserstack.key': process.env.BROWSERSTACK_ACCESS_KEY,
   'browserstack.selenium_version': '3.141.59',


### PR DESCRIPTION
# Problem

We want to call this as `Web SDK` rather than `JS SDK`.

# Solution

Replace all _string_ values from `JS SDK` to `Web SDK` and `js-sdk` to `web-sdk`.
Notes:
- Emails are all aliased, i.e. `js-sdk@onfido.com` and `web-sdk@onfido.com` are working interchangeably.
- Woopra values are kept for backward compatibility.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [n/a] Has the README been updated?
- [n/a] Has the CONTRIBUTING doc been updated?
- [n/a] Has the RELEASE_GUIDELINES been updated?
- [n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [n/a] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a] Have any new automated tests been implemented or the existing ones changed?
- [n/a] Have any new manual tests been written down or the existing ones changed?
- [n/a] Have any new strings been translated or the existing ones changed?
