### PR TITLE
Improvement/enable image quality production tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ## [next-version]
 
+### Changed
+
+- Internal: re-enable skipped tests for image quality logic.
+
 ## [6.1.0] - 2020-10-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Changed
 
-- Internal: re-enable skipped tests for image quality logic.
+- Internal: Re-enable skipped tests for image quality logic.
 
 ## [6.1.0] - 2020-10-16
 

--- a/test/specs/scenarios/document.js
+++ b/test/specs/scenarios/document.js
@@ -198,10 +198,7 @@ export const documentScenarios = async (lang) => {
         confirm.verifyUseAnotherFileError(copy)
       })
 
-      // @TODO re-enable image-quality related test
-      // See more: https://jira.onfido.co.uk/browse/CX-5545
-      // eslint-disable-next-line jest/no-disabled-tests
-      it.skip('should return image quality message on front of doc', async () => {
+      it('should return image quality message on front of doc', async () => {
         driver.get(baseUrl)
         welcome.continueToNextStep()
         documentSelector.clickOnDrivingLicenceIcon()
@@ -237,10 +234,7 @@ export const documentScenarios = async (lang) => {
         confirm.clickConfirmButton()
       })
 
-      // @TODO re-enable image-quality related test
-      // See more: https://jira.onfido.co.uk/browse/CX-5545
-      // eslint-disable-next-line jest/no-disabled-tests
-      it.skip('should return image quality message on back of doc', async () => {
+      it('should return image quality message on back of doc', async () => {
         driver.get(baseUrl)
         welcome.continueToNextStep()
         documentSelector.clickOnDrivingLicenceIcon()


### PR DESCRIPTION
# Problem

In #1145, there were a couple of tests skipped. This was because a feature flag in the Platform (which controls the percentage of incoming requests to be processed with fail-fast logic) hadn't been enabled 100%.

# Solution

Now that feature flag is running with 100% value. This PR aims to re-enable those tests.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [n/a] Has the README been updated?
- [n/a] Has the CONTRIBUTING doc been updated?
- [n/a] Has the RELEASE_GUIDELINES been updated?
- [n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [n/a] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a] Have any new automated tests been implemented or the existing ones changed?
- [n/a] Have any new manual tests been written down or the existing ones changed?
- [n/a] Have any new strings been translated or the existing ones changed?