### PR TITLE
Include missing CHANGELOG entry for 3rd-party library licenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - UI: Accessibility - Update passport quality guide copy to be more descriptive for visually impaired users using screen readers
 - Internal: Update the Web SDK to handle `telephony` back end service's new error response format which is now consistent with API's error response format
 - Public: Improve description of `showCountrySelection` option for Document step to be more explicit about when/how it works and include example configurations.
+- Internal: Store third-party licence comments for each bundle in separate files.
 
 ### Fixed
 


### PR DESCRIPTION
# Problem
PR #1203 was merged and released in [6.2.0](https://github.com/onfido/onfido-sdk-ui/releases/tag/6.2.0) but the entry is not in the `CHANGELOG` on `master` branch.

# Solution
Release notes has been updated. This PR is to update `CHANGELOG` to include it.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
