### PR TITLE
Remove duplicated 6.0.1 CHANGELOG notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,13 +45,6 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Public: Updated supported documents data. This update includes adding Turkey as an issuing country option in Country Selection screen when user selects National Identity Card type.
 - Public: Only send `issuing_country` to the documents endpoint if `issuing_country` is present. This fixes the issue that was preventing documents upload when `showCountrySelection` was disabled and `issuing_country` was `undefined`.
 
-## [6.0.1] - 2020-10-09
-
-### Fixed
-
-- Public: Updated supported documents data. This update includes adding Turkey as an issuing country option in Country Selection screen when user selects National Identity Card type.
-- Public: Only send `issuing_country` to the documents endpoint if `issuing_country` is present. This fixes the issue that was preventing documents upload when `showCountrySelection` was disabled and `issuing_country` was `undefined`.
-
 ## [6.0.0] - 2020-09-17
 
 ### Added


### PR DESCRIPTION
# Problem
Another fallout of the post-release merge - 6.0.1 release notes have been duplicated in `CHANGELOG`.

# Solution
Remove the duplicated 6.0.1 release notes

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
