### PR TITLE
Feature/cx 5706 add cross device start to tracked events list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Internal: Replace `react-modal-onfido` with version `3.11.2` of `react-modal`.
 - Internal: Refactor cross device option logic.
 
+### Added
+
+- Public: Added `CROSS_DEVICE_START` to Tracked events list
+
 ## [6.2.0] - 2020-10-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ Below is the list of potential events currently being tracked by the hook:
 WELCOME - User reached the "Welcome" screen
 DOCUMENT_TYPE_SELECT - User reached the "Choose document" screen where the type of document to upload can be selected
 ID_DOCUMENT_COUNTRY_SELECT - User reached the "Select issuing country" screen where the the appropriate issuing country can be searched for and selected if supported
+CROSS_DEVICE_START - User reached the "document capture" screen on mobile after visiting the cross-device link
 DOCUMENT_CAPTURE_FRONT - User reached the "document capture" screen for the front side (for one-sided or two-sided document)
 DOCUMENT_CAPTURE_BACK - User reached the "document capture" screen for the back side (for two-sided document)
 DOCUMENT_CAPTURE_CONFIRMATION_FRONT - User reached the "document confirmation" screen for the front side (for one-sided or two-sided document)


### PR DESCRIPTION
# Problem

`CROSS_DEVICE_START` event was missed in Tracked events list from #1025.

# Solution

Add `CROSS_DEVICE_START` to Tracked events.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [n/a] Has the README been updated?
- [n/a] Has the CONTRIBUTING doc been updated?
- [n/a] Has the RELEASE_GUIDELINES been updated?
- [n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [n/a] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a] Have any new automated tests been implemented or the existing ones changed?
- [n/a] Have any new manual tests been written down or the existing ones changed?
- [n/a] Have any new strings been translated or the existing ones changed?
