### PR TITLE
Include isCrossDevice in capture payload sdk_metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Added
 
+- Internal: Added unit tests for Demo and App components
 - Public: Updated supported documents data to include Peru, Colombia as an issuing country option in Country Selection screen when user selects Residence Permit document type and remove Saudi Arabia option for National Identity Card document type.
+- Public: Added `CROSS_DEVICE_START` to Tracked events list
 
 ### Changed
 
@@ -18,9 +20,10 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Internal: Replace `react-modal-onfido` with version `3.11.2` of `react-modal`.
 - Internal: Refactor cross device option logic.
 
-### Added
+### Fixed
 
-- Public: Added `CROSS_DEVICE_START` to Tracked events list
+- Public: Fixed Woopra module import errors
+- Internal: Include isCrossDevice property and value in Document, Face capture payload's sdk_metadata object for data tracking
 
 ## [6.2.0] - 2020-10-19
 
@@ -36,17 +39,9 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - UI: Accessibility - Loading screen is now announced on iOS
 - Internal: Release script didn't update `BASE_32_VERSION` correctly and didn't finish at publishing tag step
 
-### Added
-
-- Internal: Added unit tests for Demo and App components
-
 ### Changed
 
 - Internal: Re-enable skipped tests for image quality logic.
-
-### Fixed
-
-- Public: Fixed Woopra module import errors
 
 ## [6.1.0] - 2020-10-16
 

--- a/src/components/Router/StepsRouter.js
+++ b/src/components/Router/StepsRouter.js
@@ -65,13 +65,14 @@ class StepsRouter extends Component {
           })}
         >
           <CurrentComponent
-            {...{
+          const passedProps = {
               ...options,
               ...globalUserOptions,
               ...otherProps,
               mobileFlow,
               back,
-            }}
+            }
+          {...passedProps}
             trackScreen={this.trackScreen}
             resetSdkFocus={this.resetSdkFocus}
           />

--- a/src/components/Router/StepsRouter.js
+++ b/src/components/Router/StepsRouter.js
@@ -32,6 +32,13 @@ class StepsRouter extends Component {
     const componentBlob = this.currentComponent()
     const CurrentComponent = componentBlob.component
     const options = componentBlob.step.options
+    const passedProps = {
+      ...options,
+      ...globalUserOptions,
+      ...otherProps,
+      mobileFlow,
+      back,
+    }
     const stepId = `onfido-step${this.props.step}` // to trigger update in NavigationBar on step change
     // This prevents the logo, cobrand UI elements from appearing late
     const hideLogoLogic = mobileFlow
@@ -65,14 +72,7 @@ class StepsRouter extends Component {
           })}
         >
           <CurrentComponent
-          const passedProps = {
-              ...options,
-              ...globalUserOptions,
-              ...otherProps,
-              mobileFlow,
-              back,
-            }
-          {...passedProps}
+            {...passedProps}
             trackScreen={this.trackScreen}
             resetSdkFocus={this.resetSdkFocus}
           />

--- a/src/components/Router/StepsRouter.js
+++ b/src/components/Router/StepsRouter.js
@@ -65,7 +65,13 @@ class StepsRouter extends Component {
           })}
         >
           <CurrentComponent
-            {...{ ...options, ...globalUserOptions, ...otherProps, back }}
+            {...{
+              ...options,
+              ...globalUserOptions,
+              ...otherProps,
+              mobileFlow,
+              back,
+            }}
             trackScreen={this.trackScreen}
             resetSdkFocus={this.resetSdkFocus}
           />


### PR DESCRIPTION
# Problem
The `sdk_metadata` payload sent to API endpoints for Document, Face captures is missing the `isCrossDevice` property. This stops us from being able to gather data for questions like performance of cross device uploads versus non cross device.

# Solution
Include `mobileFlow` property to be passed down to current component as existing `isCrossDevice` property in Document, Face capture payload of `sdk_metadata` actually relies on this property's value.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
