### PR TITLE
Do not merge - Poc/record video ios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Added
 
-- Public: Updated supported documents data to include Peru as an issuing country option in Country Selection screen when user selects Residence Permit document type.
+- Public: Updated supported documents data to include Peru, Colombia as an issuing country option in Country Selection screen when user selects Residence Permit document type and remove Saudi Arabia option for National Identity Card document type.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ## [next-version]
 
+### Added
+
+- Public: Updated supported documents data to include Peru as an issuing country option in Country Selection screen when user selects Residence Permit document type.
+
 ### Changed
 
 - Internal: Upgrade Preact from version `8.5.2` to `10.5.4`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,43 +39,21 @@
       }
     },
     "@babel/cli": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.8.4.tgz",
-      "integrity": "sha512-XXLgAm6LBbaNxaGhMAznXXaxtCWfuv6PIDJ9Alsy9JYTOh+j2jJz+L/162kkfU1j/pTSxK1xGmlwI4pdIMkoag==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.12.1.tgz",
+      "integrity": "sha512-eRJREyrfAJ2r42Iaxe8h3v6yyj1wu9OyosaUHW6UImjGf9ahGL9nsFNh7OCopvtcPL8WnEo7tp78wrZaZ6vG9g==",
       "dev": true,
       "requires": {
-        "chokidar": "^2.1.8",
+        "@nicolo-ribaudo/chokidar-2": "^2.1.8",
+        "chokidar": "^3.4.0",
         "commander": "^4.0.1",
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
         "glob": "^7.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.19",
         "make-dir": "^2.1.0",
         "slash": "^2.0.0",
         "source-map": "^0.5.0"
-      },
-      "dependencies": {
-        "chokidar": {
-          "version": "2.1.8",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "anymatch": "^2.0.0",
-            "async-each": "^1.0.1",
-            "braces": "^2.3.2",
-            "fsevents": "^1.2.7",
-            "glob-parent": "^3.1.0",
-            "inherits": "^2.0.3",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "normalize-path": "^3.0.0",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.2.1",
-            "upath": "^1.1.1"
-          }
-        }
       }
     },
     "@babel/code-frame": {
@@ -3723,6 +3701,39 @@
         "glob-to-regexp": "^0.3.0"
       }
     },
+    "@nicolo-ribaudo/chokidar-2": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8.tgz",
+      "integrity": "sha512-FohwULwAebCUKi/akMFyGi7jfc7JXTeMHzKxuP3umRd9mK/2Y7/SMBSI2jX+YLopPXi+PF9l307NmpfxTdCegA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chokidar": "2.1.8"
+      },
+      "dependencies": {
+        "chokidar": {
+          "version": "2.1.8",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -6908,12 +6919,11 @@
       }
     },
     "create-react-class": {
-      "version": "15.6.3",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
-      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.7.0.tgz",
+      "integrity": "sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.9",
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
       }
@@ -16941,6 +16951,12 @@
         "renderkid": "^2.0.1",
         "utila": "~0.4"
       }
+    },
+    "pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=",
+      "dev": true
     },
     "prettycli": {
       "version": "1.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3006,6 +3006,11 @@
         "minimist": "^1.2.0"
       }
     },
+    "@fortawesome/fontawesome-free": {
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.1.tgz",
+      "integrity": "sha512-OEdH7SyC1suTdhBGW91/zBfR6qaIhThbcN8PUXtXilY4GYnSBbVqOntdHbC1vXwsDnX0Qix2m2+DSU1J51ybOQ=="
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -9073,6 +9078,11 @@
       "requires": {
         "pend": "~1.2.0"
       }
+    },
+    "ffmpeg.js": {
+      "version": "4.2.9003",
+      "resolved": "https://registry.npmjs.org/ffmpeg.js/-/ffmpeg.js-4.2.9003.tgz",
+      "integrity": "sha512-l1JBr8HwnnJEaSwg5p8K3Ifbom8O2IDHsZp7UVyr6MzQ7gc32tt/2apoOuQAr/j76c+uDOjla799VSsBnRvSTg=="
     },
     "figgy-pudding": {
       "version": "3.5.2",

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "custom-event-polyfill": "^1.0.7",
     "enumerate-devices": "^1.1.0",
     "eventemitter2": "~2.1.3",
+    "ffmpeg.js": "^4.2.9003",
     "history": "~4.5.1",
     "hoist-non-react-statics": "^3.3.2",
     "node-polyglot": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     }
   ],
   "devDependencies": {
-    "@babel/cli": "^7.8.4",
+    "@babel/cli": "^7.12.1",
     "@babel/core": "^7.8.7",
     "@babel/node": "^7.8.7",
     "@babel/plugin-proposal-class-properties": "^7.8.3",

--- a/src/components/Confirm/CaptureViewer/CaptureVideoViewer.js
+++ b/src/components/Confirm/CaptureViewer/CaptureVideoViewer.js
@@ -2,15 +2,22 @@ import { h } from 'preact'
 import { withBlobPreviewUrl } from './hocs'
 import style from './style.scss'
 
-const CaptureVideoViewer = ({ ariaLabel, previewUrl }) => (
-  <div className={style.videoWrapper}>
-    <video
-      aria-label={ariaLabel}
-      className={style.video}
-      src={previewUrl}
-      controls
-    />
-  </div>
-)
+const CaptureVideoViewer = ({ ariaLabel, previewUrl, snapshotsVideoUrl }) => {
+  const url = snapshotsVideoUrl ? snapshotsVideoUrl : previewUrl
+  return (
+    <div className={style.videoWrapper}>
+      <video
+        aria-label={ariaLabel}
+        className={style.video}
+        src={url}
+        controls
+      />
+      {/* {temporarily add this link to preview video as safari does not support webm playback} */}
+      <a href={url} download="output.webm">
+        Download video to preview
+      </a>
+    </div>
+  )
+}
 
 export default withBlobPreviewUrl(CaptureVideoViewer)

--- a/src/components/Confirm/CaptureViewer/index.js
+++ b/src/components/Confirm/CaptureViewer/index.js
@@ -5,15 +5,22 @@ import CaptureImageViewer from './CaptureImageViewer'
 import CaptureVideoViewer from './CaptureVideoViewer'
 
 const CaptureViewer = ({
-  capture: { blob, id, variant, isPreviewCropped },
+  capture: { blob, id, variant, isPreviewCropped, snapshotsVideoUrl },
   method,
   isFullScreen,
   imageAltTag,
   videoAriaLabel,
+  useSnapshotsVideo,
 }) => {
   if (isOfMimeType(['pdf'], blob)) return <PdfViewer blob={blob} />
-  else if (variant === 'video')
-    return <CaptureVideoViewer ariaLabel={videoAriaLabel} blob={blob} />
+  else if (variant === 'video' || useSnapshotsVideo)
+    return (
+      <CaptureVideoViewer
+        ariaLabel={videoAriaLabel}
+        blob={blob}
+        snapshotsVideoUrl={snapshotsVideoUrl}
+      />
+    )
 
   return (
     <CaptureImageViewer

--- a/src/components/Confirm/CaptureViewer/style.scss
+++ b/src/components/Confirm/CaptureViewer/style.scss
@@ -20,6 +20,7 @@
   position: relative;
   min-height: 90 * $unit;
   margin: 0 48 * $unit;
+  flex-direction: column;
 
   @media (--small-viewport) {
     margin: 0 $small-text-margin;

--- a/src/components/Confirm/Confirm.js
+++ b/src/components/Confirm/Confirm.js
@@ -267,6 +267,7 @@ class Confirm extends Component {
           (error.type === 'warn' &&
             imageQualityRetries < MAX_RETRIES_FOR_IMAGE_QUALITY)
         }
+        useSnapshotsVideo={this.props.useSnapshotsVideo}
       />
     )
   }

--- a/src/components/Confirm/Previews.js
+++ b/src/components/Confirm/Previews.js
@@ -62,6 +62,7 @@ const Previews = localised(
     isFullScreen,
     isUploading,
     forceRetake,
+    useSnapshotsVideo,
   }) => {
     const methodNamespace = getNamespace(method, capture.variant)
     /**
@@ -108,7 +109,14 @@ const Previews = localised(
           <PageTitle title={title} smaller={true} className={style.title} />
         )}
         <CaptureViewer
-          {...{ capture, method, isFullScreen, imageAltTag, videoAriaLabel }}
+          {...{
+            capture,
+            method,
+            isFullScreen,
+            imageAltTag,
+            videoAriaLabel,
+            useSnapshotsVideo,
+          }}
         />
         {!isFullScreen && (
           <div>

--- a/src/components/utils/blob.js
+++ b/src/components/utils/blob.js
@@ -51,6 +51,18 @@ const decodeBase64 = (image) => {
   return { integerArray, mimeString }
 }
 
+export const convertDataURIToBinary = (dataURI) => {
+  const base64 = dataURI.replace(/^data[^,]+,/, '')
+  const raw = window.atob(base64)
+  const rawLength = raw.length
+
+  const array = new Uint8Array(new ArrayBuffer(rawLength))
+  for (let i = 0; i < rawLength; i++) {
+    array[i] = raw.charCodeAt(i)
+  }
+  return array
+}
+
 const base64toBlob = (image) => {
   const base64Data = decodeBase64(image)
   return new Blob([base64Data.integerArray], { type: base64Data.mimeString })

--- a/src/components/utils/camera.js
+++ b/src/components/utils/camera.js
@@ -1,4 +1,4 @@
-import { canvasToBlob } from './blob'
+import { canvasToBlob, convertDataURIToBinary } from './blob'
 
 export const screenshot = (webcam, callback, mimeType) => {
   if (!webcam) {
@@ -12,6 +12,21 @@ export const screenshot = (webcam, callback, mimeType) => {
   }
   const sdkMetadata = getDeviceInfo(webcam.stream)
   canvasToBlob(canvas, (blob) => callback(blob, sdkMetadata), mimeType)
+}
+
+export const getScreenshotBinaryForVideo = (webcam, callback) => {
+  // Could we just reuse the Blobs returned in the screenshot() function above and get rid of this one?
+  if (!webcam) {
+    console.error('webcam is null')
+    return
+  }
+  const dataUrl = webcam && webcam.getScreenshot()
+  if (!dataUrl) {
+    console.error('screenshot dataUrl is null')
+    return
+  }
+  const binary = convertDataURIToBinary(dataUrl)
+  callback(binary)
 }
 
 export const getRecordedVideo = (webcam, callback) => {

--- a/src/demo/demoUtils.js
+++ b/src/demo/demoUtils.js
@@ -43,7 +43,7 @@ export const getInitSdkOptions = () => {
   const steps = [
     'welcome',
     queryParamToValueString.poa === 'true' && { type: 'poa' },
-    {
+    queryParamToValueString.useSnapshotsVideo !== 'true' && {
       type: 'document',
       options: {
         useLiveDocumentCapture:
@@ -59,6 +59,7 @@ export const getInitSdkOptions = () => {
     {
       type: 'face',
       options: {
+        useSnapshotsVideo: queryParamToValueString.useSnapshotsVideo === 'true',
         requestedVariant:
           queryParamToValueString.liveness === 'true' ? 'video' : 'standard',
         useUploader: queryParamToValueString.useUploader === 'true',

--- a/src/supported-documents/supported-docs-driving_licence.json
+++ b/src/supported-documents/supported-docs-driving_licence.json
@@ -3,6 +3,6360 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
+      "country": "Albania | Shqipëria",
+      "country_alpha2": "AL",
+      "country_alpha3": "ALB",
+      "document_type": "DLD",
+      "id": 2919,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2005"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Albania | Shqipëria",
+      "country_alpha2": "AL",
+      "country_alpha3": "ALB",
+      "document_type": "DLD",
+      "id": 5996,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "American Samoa",
+      "country_alpha2": "AS",
+      "country_alpha3": "ASM",
+      "document_type": "DLD",
+      "id": 5590,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1997"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "American Samoa",
+      "country_alpha2": "AS",
+      "country_alpha3": "ASM",
+      "document_type": "DLD",
+      "id": 5591,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "American Samoa",
+      "country_alpha2": "AS",
+      "country_alpha3": "ASM",
+      "document_type": "DLD",
+      "id": 5592,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003-2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Andorra",
+      "country_alpha2": "AD",
+      "country_alpha3": "AND",
+      "document_type": "DLD",
+      "id": 2925,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1990"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Andorra",
+      "country_alpha2": "AD",
+      "country_alpha3": "AND",
+      "document_type": "DLD",
+      "id": 7019,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007 "
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 5044,
+      "region_iso": "S",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 8131,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 8133,
+      "region_iso": "L",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 8135,
+      "region_iso": "A",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 8127,
+      "region_iso": "X",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 8128,
+      "region_iso": "B",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 8129,
+      "region_iso": "B",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 8130,
+      "region_iso": "B",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 8134,
+      "region_iso": "Q",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 8136,
+      "region_iso": "H",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Armenia | Հայաստան",
+      "country_alpha2": "AM",
+      "country_alpha3": "ARM",
+      "document_type": "DLD",
+      "id": 2942,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2005"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Armenia | Հայաստան",
+      "country_alpha2": "AM",
+      "country_alpha3": "ARM",
+      "document_type": "DLD",
+      "id": 2943,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Australia",
+      "country_alpha2": "AU",
+      "country_alpha3": "AUS",
+      "document_type": "DLD",
+      "id": 5043,
+      "region_iso": "WA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Australia",
+      "country_alpha2": "AU",
+      "country_alpha3": "AUS",
+      "document_type": "DLD",
+      "id": 6002,
+      "region_iso": "WA",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Australia",
+      "country_alpha2": "AU",
+      "country_alpha3": "AUS",
+      "document_type": "DLD",
+      "id": 2948,
+      "region_iso": "ACT",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2001"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Australia",
+      "country_alpha2": "AU",
+      "country_alpha3": "AUS",
+      "document_type": "DLD",
+      "id": 2949,
+      "region_iso": "NSW",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2002"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Australia",
+      "country_alpha2": "AU",
+      "country_alpha3": "AUS",
+      "document_type": "DLD",
+      "id": 2951,
+      "region_iso": "QLD",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Australia",
+      "country_alpha2": "AU",
+      "country_alpha3": "AUS",
+      "document_type": "DLD",
+      "id": 2952,
+      "region_iso": "ACT",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2001"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Australia",
+      "country_alpha2": "AU",
+      "country_alpha3": "AUS",
+      "document_type": "DLD",
+      "id": 4244,
+      "region_iso": "QLD",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Australia",
+      "country_alpha2": "AU",
+      "country_alpha3": "AUS",
+      "document_type": "DLD",
+      "id": 5041,
+      "region_iso": "SA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Australia",
+      "country_alpha2": "AU",
+      "country_alpha3": "AUS",
+      "document_type": "DLD",
+      "id": 5042,
+      "region_iso": "VIC",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Australia",
+      "country_alpha2": "AU",
+      "country_alpha3": "AUS",
+      "document_type": "DLD",
+      "id": 5998,
+      "region_iso": "NT",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Australia",
+      "country_alpha2": "AU",
+      "country_alpha3": "AUS",
+      "document_type": "DLD",
+      "id": 5999,
+      "region_iso": "TAS",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Australia",
+      "country_alpha2": "AU",
+      "country_alpha3": "AUS",
+      "document_type": "DLD",
+      "id": 6000,
+      "region_iso": "TAS",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Australia",
+      "country_alpha2": "AU",
+      "country_alpha3": "AUS",
+      "document_type": "DLD",
+      "id": 6001,
+      "region_iso": "SA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Austria | Österreich",
+      "country_alpha2": "AT",
+      "country_alpha3": "AUT",
+      "document_type": "DLD",
+      "id": 4643,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Austria | Österreich",
+      "country_alpha2": "AT",
+      "country_alpha3": "AUT",
+      "document_type": "DLD",
+      "id": 2975,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2006"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Austria | Österreich",
+      "country_alpha2": "AT",
+      "country_alpha3": "AUT",
+      "document_type": "DLD",
+      "id": 4636,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Austria | Österreich",
+      "country_alpha2": "AT",
+      "country_alpha3": "AUT",
+      "document_type": "DLD",
+      "id": 4582,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Austria | Österreich",
+      "country_alpha2": "AT",
+      "country_alpha3": "AUT",
+      "document_type": "DLD",
+      "id": 4789,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Austria | Österreich",
+      "country_alpha2": "AT",
+      "country_alpha3": "AUT",
+      "document_type": "DLD",
+      "id": 4644,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1997"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Azerbaijan | Azərbaycan",
+      "country_alpha2": "AZ",
+      "country_alpha3": "AZE",
+      "document_type": "DLD",
+      "id": 2989,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Azerbaijan | Azərbaycan",
+      "country_alpha2": "AZ",
+      "country_alpha3": "AZE",
+      "document_type": "DLD",
+      "id": 2990,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2002"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Azerbaijan | Azərbaycan",
+      "country_alpha2": "AZ",
+      "country_alpha3": "AZE",
+      "document_type": "DLD",
+      "id": 5869,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2001"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Azerbaijan | Azərbaycan",
+      "country_alpha2": "AZ",
+      "country_alpha3": "AZE",
+      "document_type": "DLD",
+      "id": 5870,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Bahamas",
+      "country_alpha2": "BS",
+      "country_alpha3": "BHS",
+      "document_type": "DLD",
+      "id": 5190,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Bahamas",
+      "country_alpha2": "BS",
+      "country_alpha3": "BHS",
+      "document_type": "DLD",
+      "id": 5524,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Bangladesh | বাংলাদেশ",
+      "country_alpha2": "BD",
+      "country_alpha3": "BGD",
+      "document_type": "DLD",
+      "id": 5142,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Bangladesh | বাংলাদেশ",
+      "country_alpha2": "BD",
+      "country_alpha3": "BGD",
+      "document_type": "DLD",
+      "id": 5875,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012-1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Bangladesh | বাংলাদেশ",
+      "country_alpha2": "BD",
+      "country_alpha3": "BGD",
+      "document_type": "DLD",
+      "id": 5876,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013-2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Barbados",
+      "country_alpha2": "BB",
+      "country_alpha3": "BRB",
+      "document_type": "DLD",
+      "id": 5191,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1999"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Belarus | Беларусь",
+      "country_alpha2": "BY",
+      "country_alpha3": "BLR",
+      "document_type": "DLD",
+      "id": 3015,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Belarus | Беларусь",
+      "country_alpha2": "BY",
+      "country_alpha3": "BLR",
+      "document_type": "DLD",
+      "id": 3016,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1995"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Belarus | Беларусь",
+      "country_alpha2": "BY",
+      "country_alpha3": "BLR",
+      "document_type": "DLD",
+      "id": 3013,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Belarus | Беларусь",
+      "country_alpha2": "BY",
+      "country_alpha3": "BLR",
+      "document_type": "DLD",
+      "id": 3014,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "DLD",
+      "id": 7713,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2000"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "DLD",
+      "id": 8124,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "DLD",
+      "id": 4810,
+      "region_iso": "WAL",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "DLD",
+      "id": 3022,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "DLD",
+      "id": 4811,
+      "region_iso": "VLG",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "DLD",
+      "id": 8200,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "DLD",
+      "id": 8201,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Bermuda",
+      "country_alpha2": "BM",
+      "country_alpha3": "BMU",
+      "document_type": "DLD",
+      "id": 5192,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": ""
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Bolivia (Plurinational State of) | Bolivia",
+      "country_alpha2": "BO",
+      "country_alpha3": "BOL",
+      "document_type": "DLD",
+      "id": 5188,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Bolivia (Plurinational State of) | Bolivia",
+      "country_alpha2": "BO",
+      "country_alpha3": "BOL",
+      "document_type": "DLD",
+      "id": 5800,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Bosnia and Herzegovina | Bosna i Hercegovina",
+      "country_alpha2": "BA",
+      "country_alpha3": "BIH",
+      "document_type": "DLD",
+      "id": 838,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Bosnia and Herzegovina | Bosna i Hercegovina",
+      "country_alpha2": "BA",
+      "country_alpha3": "BIH",
+      "document_type": "DLD",
+      "id": 6022,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Botswana",
+      "country_alpha2": "BW",
+      "country_alpha3": "BWA",
+      "document_type": "DLD",
+      "id": 5471,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Botswana",
+      "country_alpha2": "BW",
+      "country_alpha3": "BWA",
+      "document_type": "DLD",
+      "id": 3058,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2006"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "DLD",
+      "id": 760,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "DLD",
+      "id": 761,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "DLD",
+      "id": 5047,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "DLD",
+      "id": 7715,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brunei Darussalam | بروني",
+      "country_alpha2": "BN",
+      "country_alpha3": "BRN",
+      "document_type": "DLD",
+      "id": 7745,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brunei Darussalam | بروني",
+      "country_alpha2": "BN",
+      "country_alpha3": "BRN",
+      "document_type": "DLD",
+      "id": 5144,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Bulgaria | България",
+      "country_alpha2": "BG",
+      "country_alpha3": "BGR",
+      "document_type": "DLD",
+      "id": 3072,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Bulgaria | България",
+      "country_alpha2": "BG",
+      "country_alpha3": "BGR",
+      "document_type": "DLD",
+      "id": 3073,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Bulgaria | България",
+      "country_alpha2": "BG",
+      "country_alpha3": "BGR",
+      "document_type": "DLD",
+      "id": 3074,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Bulgaria | България",
+      "country_alpha2": "BG",
+      "country_alpha3": "BGR",
+      "document_type": "DLD",
+      "id": 4840,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Bulgaria | България",
+      "country_alpha2": "BG",
+      "country_alpha3": "BGR",
+      "document_type": "DLD",
+      "id": 4841,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Cameroon",
+      "country_alpha2": "CM",
+      "country_alpha3": "CMR",
+      "document_type": "DLD",
+      "id": 4986,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 4216,
+      "region_iso": "BC",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 5064,
+      "region_iso": "NS",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 3121,
+      "region_iso": "QC",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 4213,
+      "region_iso": "AB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 4218,
+      "region_iso": "NB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 4221,
+      "region_iso": "PE",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 4222,
+      "region_iso": "QC",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 4223,
+      "region_iso": "SK",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 4224,
+      "region_iso": "SK",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 4935,
+      "region_iso": "ON",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 5057,
+      "region_iso": "YT",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 5058,
+      "region_iso": "NU",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 5063,
+      "region_iso": "NT",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 5194,
+      "region_iso": "MB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 5271,
+      "region_iso": "NS",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 5531,
+      "region_iso": "BC",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 5545,
+      "region_iso": "NL",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Chile",
+      "country_alpha2": "CL",
+      "country_alpha3": "CHL",
+      "document_type": "DLD",
+      "id": 3139,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Chile",
+      "country_alpha2": "CL",
+      "country_alpha3": "CHL",
+      "document_type": "DLD",
+      "id": 7151,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003 2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Chile",
+      "country_alpha2": "CL",
+      "country_alpha3": "CHL",
+      "document_type": "DLD",
+      "id": 7184,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003 1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "China | 中国",
+      "country_alpha2": "CN",
+      "country_alpha3": "CHN",
+      "document_type": "DLD",
+      "id": 3151,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "China | 中国",
+      "country_alpha2": "CN",
+      "country_alpha3": "CHN",
+      "document_type": "DLD",
+      "id": 3152,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "China | 中国",
+      "country_alpha2": "CN",
+      "country_alpha3": "CHN",
+      "document_type": "DLD",
+      "id": 3153,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Colombia",
+      "country_alpha2": "CO",
+      "country_alpha3": "COL",
+      "document_type": "DLD",
+      "id": 4890,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Colombia",
+      "country_alpha2": "CO",
+      "country_alpha3": "COL",
+      "document_type": "DLD",
+      "id": 5803,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Colombia",
+      "country_alpha2": "CO",
+      "country_alpha3": "COL",
+      "document_type": "DLD",
+      "id": 5804,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Colombia",
+      "country_alpha2": "CO",
+      "country_alpha3": "COL",
+      "document_type": "DLD",
+      "id": 5805,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Costa Rica",
+      "country_alpha2": "CR",
+      "country_alpha3": "CRI",
+      "document_type": "DLD",
+      "id": 5070,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Costa Rica",
+      "country_alpha2": "CR",
+      "country_alpha3": "CRI",
+      "document_type": "DLD",
+      "id": 6024,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Côte d'Ivoire | Côte d'Ivoire",
+      "country_alpha2": "CI",
+      "country_alpha3": "CIV",
+      "document_type": "DLD",
+      "id": 4988,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Côte d'Ivoire | Côte d'Ivoire",
+      "country_alpha2": "CI",
+      "country_alpha3": "CIV",
+      "document_type": "DLD",
+      "id": 5487,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Croatia | Hrvatska",
+      "country_alpha2": "HR",
+      "country_alpha3": "HRV",
+      "document_type": "DLD",
+      "id": 3178,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Cyprus | Κύπρος",
+      "country_alpha2": "CY",
+      "country_alpha3": "CYP",
+      "document_type": "DLD",
+      "id": 8177,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Cyprus | Κύπρος",
+      "country_alpha2": "CY",
+      "country_alpha3": "CYP",
+      "document_type": "DLD",
+      "id": 5124,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "",
+      "country": "Cyprus | Κύπρος",
+      "country_alpha2": "CY",
+      "country_alpha3": "CYP",
+      "document_type": "DLD",
+      "id": 6027,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Czech Republic | Česko",
+      "country_alpha2": "CZ",
+      "country_alpha3": "CZE",
+      "document_type": "DLD",
+      "id": 3200,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Czech Republic | Česko",
+      "country_alpha2": "CZ",
+      "country_alpha3": "CZE",
+      "document_type": "DLD",
+      "id": 3201,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Denmark | Danmark",
+      "country_alpha2": "DK",
+      "country_alpha3": "DNK",
+      "document_type": "DLD",
+      "id": 3225,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1997"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Denmark | Danmark",
+      "country_alpha2": "DK",
+      "country_alpha3": "DNK",
+      "document_type": "DLD",
+      "id": 3226,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Denmark | Danmark",
+      "country_alpha2": "DK",
+      "country_alpha3": "DNK",
+      "document_type": "DLD",
+      "id": 4812,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Dominican Republic | República Dominicana",
+      "country_alpha2": "DO",
+      "country_alpha3": "DOM",
+      "document_type": "DLD",
+      "id": 5197,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Ecuador",
+      "country_alpha2": "EC",
+      "country_alpha3": "ECU",
+      "document_type": "DLD",
+      "id": 5049,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Ecuador",
+      "country_alpha2": "EC",
+      "country_alpha3": "ECU",
+      "document_type": "DLD",
+      "id": 7284,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Egypt | مصر",
+      "country_alpha2": "EG",
+      "country_alpha3": "EGY",
+      "document_type": "DLD",
+      "id": 4991,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "El Salvador",
+      "country_alpha2": "SV",
+      "country_alpha3": "SLV",
+      "document_type": "DLD",
+      "id": 3250,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "El Salvador",
+      "country_alpha2": "SV",
+      "country_alpha3": "SLV",
+      "document_type": "DLD",
+      "id": 5553,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2006"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "El Salvador",
+      "country_alpha2": "SV",
+      "country_alpha3": "SLV",
+      "document_type": "DLD",
+      "id": 5554,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Estonia | Eesti",
+      "country_alpha2": "EE",
+      "country_alpha3": "EST",
+      "document_type": "DLD",
+      "id": 3260,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Estonia | Eesti",
+      "country_alpha2": "EE",
+      "country_alpha3": "EST",
+      "document_type": "DLD",
+      "id": 3261,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Estonia | Eesti",
+      "country_alpha2": "EE",
+      "country_alpha3": "EST",
+      "document_type": "DLD",
+      "id": 4627,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Estonia | Eesti",
+      "country_alpha2": "EE",
+      "country_alpha3": "EST",
+      "document_type": "DLD",
+      "id": 4628,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Estonia | Eesti",
+      "country_alpha2": "EE",
+      "country_alpha3": "EST",
+      "document_type": "DLD",
+      "id": 4564,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Faroe Islands | Føroyar",
+      "country_alpha2": "FO",
+      "country_alpha3": "FRO",
+      "document_type": "DLD",
+      "id": 8207,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Faroe Islands | Føroyar",
+      "country_alpha2": "FO",
+      "country_alpha3": "FRO",
+      "document_type": "DLD",
+      "id": 8208,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Fiji | Viti",
+      "country_alpha2": "FJ",
+      "country_alpha3": "FJI",
+      "document_type": "DLD",
+      "id": 5039,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Finland | Suomi",
+      "country_alpha2": "FI",
+      "country_alpha3": "FIN",
+      "document_type": "DLD",
+      "id": 3282,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1998"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Finland | Suomi",
+      "country_alpha2": "FI",
+      "country_alpha3": "FIN",
+      "document_type": "DLD",
+      "id": 3283,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Finland | Suomi",
+      "country_alpha2": "FI",
+      "country_alpha3": "FIN",
+      "document_type": "DLD",
+      "id": 3284,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Finland | Suomi",
+      "country_alpha2": "FI",
+      "country_alpha3": "FIN",
+      "document_type": "DLD",
+      "id": 3285,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2000"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Finland | Suomi",
+      "country_alpha2": "FI",
+      "country_alpha3": "FIN",
+      "document_type": "DLD",
+      "id": 4802,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Finland | Suomi",
+      "country_alpha2": "FI",
+      "country_alpha3": "FIN",
+      "document_type": "DLD",
+      "id": 6039,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1992"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Finland | Suomi",
+      "country_alpha2": "FI",
+      "country_alpha3": "FIN",
+      "document_type": "DLD",
+      "id": 6040,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2019"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "France",
+      "country_alpha2": "FR",
+      "country_alpha3": "FRA",
+      "document_type": "DLD",
+      "id": 3302,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "France",
+      "country_alpha2": "FR",
+      "country_alpha3": "FRA",
+      "document_type": "DLD",
+      "id": 4286,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1994"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "France",
+      "country_alpha2": "FR",
+      "country_alpha3": "FRA",
+      "document_type": "DLD",
+      "id": 4108,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "France",
+      "country_alpha2": "FR",
+      "country_alpha3": "FRA",
+      "document_type": "DLD",
+      "id": 6064,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013-2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "French Polynesia | Polynésie française",
+      "country_alpha2": "PF",
+      "country_alpha3": "PYF",
+      "document_type": "DLD",
+      "id": 5018,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Georgia | საქართველო",
+      "country_alpha2": "GE",
+      "country_alpha3": "GEO",
+      "document_type": "DLD",
+      "id": 6065,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Georgia | საქართველო",
+      "country_alpha2": "GE",
+      "country_alpha3": "GEO",
+      "document_type": "DLD",
+      "id": 3314,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2000"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Georgia | საქართველო",
+      "country_alpha2": "GE",
+      "country_alpha3": "GEO",
+      "document_type": "DLD",
+      "id": 3315,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2006"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Georgia | საქართველო",
+      "country_alpha2": "GE",
+      "country_alpha3": "GEO",
+      "document_type": "DLD",
+      "id": 6062,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1990"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Georgia | საქართველო",
+      "country_alpha2": "GE",
+      "country_alpha3": "GEO",
+      "document_type": "DLD",
+      "id": 6066,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Germany | Deutschland",
+      "country_alpha2": "DE",
+      "country_alpha3": "DEU",
+      "document_type": "DLD",
+      "id": 4114,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1986"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Germany | Deutschland",
+      "country_alpha2": "DE",
+      "country_alpha3": "DEU",
+      "document_type": "DLD",
+      "id": 4315,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015 1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Germany | Deutschland",
+      "country_alpha2": "DE",
+      "country_alpha3": "DEU",
+      "document_type": "DLD",
+      "id": 4312,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2001"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Germany | Deutschland",
+      "country_alpha2": "DE",
+      "country_alpha3": "DEU",
+      "document_type": "DLD",
+      "id": 4313,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Germany | Deutschland",
+      "country_alpha2": "DE",
+      "country_alpha3": "DEU",
+      "document_type": "DLD",
+      "id": 4314,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Germany | Deutschland",
+      "country_alpha2": "DE",
+      "country_alpha3": "DEU",
+      "document_type": "DLD",
+      "id": 887,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Germany | Deutschland",
+      "country_alpha2": "DE",
+      "country_alpha3": "DEU",
+      "document_type": "DLD",
+      "id": 4301,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1982"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Germany | Deutschland",
+      "country_alpha2": "DE",
+      "country_alpha3": "DEU",
+      "document_type": "DLD",
+      "id": 6069,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2005"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Germany | Deutschland",
+      "country_alpha2": "DE",
+      "country_alpha3": "DEU",
+      "document_type": "DLD",
+      "id": 6070,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Ghana",
+      "country_alpha2": "GH",
+      "country_alpha3": "GHA",
+      "document_type": "DLD",
+      "id": 4995,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017 2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Ghana",
+      "country_alpha2": "GH",
+      "country_alpha3": "GHA",
+      "document_type": "DLD",
+      "id": 8015,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Ghana",
+      "country_alpha2": "GH",
+      "country_alpha3": "GHA",
+      "document_type": "DLD",
+      "id": 8014,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017 "
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Gibraltar",
+      "country_alpha2": "GI",
+      "country_alpha3": "GIB",
+      "document_type": "DLD",
+      "id": 5128,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Greece | Ελλάδα",
+      "country_alpha2": "GR",
+      "country_alpha3": "GRC",
+      "document_type": "DLD",
+      "id": 3355,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Greece | Ελλάδα",
+      "country_alpha2": "GR",
+      "country_alpha3": "GRC",
+      "document_type": "DLD",
+      "id": 3356,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Guam | Guåhån",
+      "country_alpha2": "GU",
+      "country_alpha3": "GUM",
+      "document_type": "DLD",
+      "id": 5106,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Guam | Guåhån",
+      "country_alpha2": "GU",
+      "country_alpha3": "GUM",
+      "document_type": "DLD",
+      "id": 5607,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2002"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Guam | Guåhån",
+      "country_alpha2": "GU",
+      "country_alpha3": "GUM",
+      "document_type": "DLD",
+      "id": 5608,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Guam | Guåhån",
+      "country_alpha2": "GU",
+      "country_alpha3": "GUM",
+      "document_type": "DLD",
+      "id": 5609,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2005"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Guam | Guåhån",
+      "country_alpha2": "GU",
+      "country_alpha3": "GUM",
+      "document_type": "DLD",
+      "id": 5610,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Guatemala",
+      "country_alpha2": "GT",
+      "country_alpha3": "GTM",
+      "document_type": "DLD",
+      "id": 7779,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": ""
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Guatemala",
+      "country_alpha2": "GT",
+      "country_alpha3": "GTM",
+      "document_type": "DLD",
+      "id": 5200,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Guatemala",
+      "country_alpha2": "GT",
+      "country_alpha3": "GTM",
+      "document_type": "DLD",
+      "id": 5556,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Guernsey",
+      "country_alpha2": "GG",
+      "country_alpha3": "GGY",
+      "document_type": "DLD",
+      "id": 3373,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1996"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Guernsey",
+      "country_alpha2": "GG",
+      "country_alpha3": "GGY",
+      "document_type": "DLD",
+      "id": 3374,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1998"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Guernsey",
+      "country_alpha2": "GG",
+      "country_alpha3": "GGY",
+      "document_type": "DLD",
+      "id": 7415,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Hong Kong | 香港",
+      "country_alpha2": "HK",
+      "country_alpha3": "HKG",
+      "document_type": "DLD",
+      "id": 5148,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Hong Kong | 香港",
+      "country_alpha2": "HK",
+      "country_alpha3": "HKG",
+      "document_type": "DLD",
+      "id": 5881,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2005"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
+      "document_type": "DLD",
+      "id": 4821,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
+      "document_type": "DLD",
+      "id": 4823,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
+      "document_type": "DLD",
+      "id": 4822,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Iceland | Ísland",
+      "country_alpha2": "IS",
+      "country_alpha3": "ISL",
+      "document_type": "DLD",
+      "id": 3394,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Iceland | Ísland",
+      "country_alpha2": "IS",
+      "country_alpha3": "ISL",
+      "document_type": "DLD",
+      "id": 6087,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2001"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Indonesia",
+      "country_alpha2": "ID",
+      "country_alpha3": "IDN",
+      "document_type": "DLD",
+      "id": 4127,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2019"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Indonesia",
+      "country_alpha2": "ID",
+      "country_alpha3": "IDN",
+      "document_type": "DLD",
+      "id": 4128,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Indonesia",
+      "country_alpha2": "ID",
+      "country_alpha3": "IDN",
+      "document_type": "DLD",
+      "id": 4130,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Indonesia",
+      "country_alpha2": "ID",
+      "country_alpha3": "IDN",
+      "document_type": "DLD",
+      "id": 4131,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Ireland | Éire",
+      "country_alpha2": "IE",
+      "country_alpha3": "IRL",
+      "document_type": "DLD",
+      "id": 4339,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2005"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "paper",
+      "country": "Ireland | Éire",
+      "country_alpha2": "IE",
+      "country_alpha3": "IRL",
+      "document_type": "DLD",
+      "id": 6090,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Ireland | Éire",
+      "country_alpha2": "IE",
+      "country_alpha3": "IRL",
+      "document_type": "DLD",
+      "id": 7451,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": ""
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Ireland | Éire",
+      "country_alpha2": "IE",
+      "country_alpha3": "IRL",
+      "document_type": "DLD",
+      "id": 3420,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Isle of Man",
+      "country_alpha2": "IM",
+      "country_alpha3": "IMN",
+      "document_type": "DLD",
+      "id": 7481,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Isle of Man",
+      "country_alpha2": "IM",
+      "country_alpha3": "IMN",
+      "document_type": "DLD",
+      "id": 7482,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Israel | ישראל",
+      "country_alpha2": "IL",
+      "country_alpha3": "ISR",
+      "document_type": "DLD",
+      "id": 3433,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Israel | ישראל",
+      "country_alpha2": "IL",
+      "country_alpha3": "ISR",
+      "document_type": "DLD",
+      "id": 6092,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Italy | Italia",
+      "country_alpha2": "IT",
+      "country_alpha3": "ITA",
+      "document_type": "DLD",
+      "id": 3445,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2002"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Italy | Italia",
+      "country_alpha2": "IT",
+      "country_alpha3": "ITA",
+      "document_type": "DLD",
+      "id": 4138,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1999"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Italy | Italia",
+      "country_alpha2": "IT",
+      "country_alpha3": "ITA",
+      "document_type": "DLD",
+      "id": 4348,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Italy | Italia",
+      "country_alpha2": "IT",
+      "country_alpha3": "ITA",
+      "document_type": "DLD",
+      "id": 4141,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Jamaica",
+      "country_alpha2": "JM",
+      "country_alpha3": "JAM",
+      "document_type": "DLD",
+      "id": 5203,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Japan | 日本",
+      "country_alpha2": "JP",
+      "country_alpha3": "JPN",
+      "document_type": "DLD",
+      "id": 5898,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Jersey",
+      "country_alpha2": "JE",
+      "country_alpha3": "JEY",
+      "document_type": "DLD",
+      "id": 3464,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Jordan | الأردن",
+      "country_alpha2": "JO",
+      "country_alpha3": "JOR",
+      "document_type": "DLD",
+      "id": 5155,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Jordan | الأردن",
+      "country_alpha2": "JO",
+      "country_alpha3": "JOR",
+      "document_type": "DLD",
+      "id": 5900,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "4"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Jordan | الأردن",
+      "country_alpha2": "JO",
+      "country_alpha3": "JOR",
+      "document_type": "DLD",
+      "id": 5901,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "3"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Jordan | الأردن",
+      "country_alpha2": "JO",
+      "country_alpha3": "JOR",
+      "document_type": "DLD",
+      "id": 5902,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Kazakhstan | Қазақстан",
+      "country_alpha2": "KZ",
+      "country_alpha3": "KAZ",
+      "document_type": "DLD",
+      "id": 3468,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Kenya",
+      "country_alpha2": "KE",
+      "country_alpha3": "KEN",
+      "document_type": "DLD",
+      "id": 4997,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Korea (Republic of) | 한국",
+      "country_alpha2": "KR",
+      "country_alpha3": "KOR",
+      "document_type": "DLD",
+      "id": 6392,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Korea (Republic of) | 한국",
+      "country_alpha2": "KR",
+      "country_alpha3": "KOR",
+      "document_type": "DLD",
+      "id": 6458,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Korea (Republic of) | 한국",
+      "country_alpha2": "KR",
+      "country_alpha3": "KOR",
+      "document_type": "DLD",
+      "id": 8143,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2020"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Kosovo, Republic of",
+      "country_alpha2": "XK",
+      "country_alpha3": "RKS",
+      "document_type": "DLD",
+      "id": 6096,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Kosovo, Republic of",
+      "country_alpha2": "XK",
+      "country_alpha3": "RKS",
+      "document_type": "DLD",
+      "id": 6097,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Kuwait | دولة الكويت",
+      "country_alpha2": "KW",
+      "country_alpha3": "KWT",
+      "document_type": "DLD",
+      "id": 5905,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Kuwait | دولة الكويت",
+      "country_alpha2": "KW",
+      "country_alpha3": "KWT",
+      "document_type": "DLD",
+      "id": 5157,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1996"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Kuwait | دولة الكويت",
+      "country_alpha2": "KW",
+      "country_alpha3": "KWT",
+      "document_type": "DLD",
+      "id": 5906,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "3"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Latvia | Latvija",
+      "country_alpha2": "LV",
+      "country_alpha3": "LVA",
+      "document_type": "DLD",
+      "id": 4591,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Latvia | Latvija",
+      "country_alpha2": "LV",
+      "country_alpha3": "LVA",
+      "document_type": "DLD",
+      "id": 3513,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2006"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Latvia | Latvija",
+      "country_alpha2": "LV",
+      "country_alpha3": "LVA",
+      "document_type": "DLD",
+      "id": 3514,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Latvia | Latvija",
+      "country_alpha2": "LV",
+      "country_alpha3": "LVA",
+      "document_type": "DLD",
+      "id": 7813,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Liechtenstein",
+      "country_alpha2": "LI",
+      "country_alpha3": "LIE",
+      "document_type": "DLD",
+      "id": 6102,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2019"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Liechtenstein",
+      "country_alpha2": "LI",
+      "country_alpha3": "LIE",
+      "document_type": "DLD",
+      "id": 3540,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Liechtenstein",
+      "country_alpha2": "LI",
+      "country_alpha3": "LIE",
+      "document_type": "DLD",
+      "id": 3541,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "DLD",
+      "id": 4149,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "DLD",
+      "id": 3545,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "DLD",
+      "id": 4386,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "DLD",
+      "id": 4387,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "DLD",
+      "id": 6105,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013-2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "DLD",
+      "id": 6106,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016-2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "DLD",
+      "id": 3544,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "DLD",
+      "id": 4148,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "DLD",
+      "id": 4153,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Luxembourg | Luxemburg",
+      "country_alpha2": "LU",
+      "country_alpha3": "LUX",
+      "document_type": "DLD",
+      "id": 3565,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Macao | 澳門",
+      "country_alpha2": "MO",
+      "country_alpha3": "MAC",
+      "document_type": "DLD",
+      "id": 3579,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Macedonia (the former Yugoslav Republic of) | Македонија",
+      "country_alpha2": "MK",
+      "country_alpha3": "MKD",
+      "document_type": "DLD",
+      "id": 3583,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Malaysia",
+      "country_alpha2": "MY",
+      "country_alpha3": "MYS",
+      "document_type": "DLD",
+      "id": 3593,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Malaysia",
+      "country_alpha2": "MY",
+      "country_alpha3": "MYS",
+      "document_type": "DLD",
+      "id": 5911,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Malaysia",
+      "country_alpha2": "MY",
+      "country_alpha3": "MYS",
+      "document_type": "DLD",
+      "id": 5912,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "3"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Malaysia",
+      "country_alpha2": "MY",
+      "country_alpha3": "MYS",
+      "document_type": "DLD",
+      "id": 5913,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "4"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Malta",
+      "country_alpha2": "MT",
+      "country_alpha3": "MLT",
+      "document_type": "DLD",
+      "id": 7945,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013 2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Malta",
+      "country_alpha2": "MT",
+      "country_alpha3": "MLT",
+      "document_type": "DLD",
+      "id": 3608,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Malta",
+      "country_alpha2": "MT",
+      "country_alpha3": "MLT",
+      "document_type": "DLD",
+      "id": 3609,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5082,
+      "region_iso": "MEX",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5084,
+      "region_iso": "GRO",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5073,
+      "region_iso": "AGU",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5074,
+      "region_iso": "BCN",
+      "usecases": [
+        "verify"
+      ],
+      "version": ""
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5075,
+      "region_iso": "BCS",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5076,
+      "region_iso": "CAM",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5077,
+      "region_iso": "CHH",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5078,
+      "region_iso": "COA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5079,
+      "region_iso": "COL",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5081,
+      "region_iso": "DUR",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5083,
+      "region_iso": "GUA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5085,
+      "region_iso": "HID",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5086,
+      "region_iso": "JAL",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5087,
+      "region_iso": "MIC",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5088,
+      "region_iso": "MOR",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5089,
+      "region_iso": "NAY",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5091,
+      "region_iso": "PUE",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5092,
+      "region_iso": "QUE",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5095,
+      "region_iso": "SIN",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5096,
+      "region_iso": "SON",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5097,
+      "region_iso": "TAB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5098,
+      "region_iso": "TAM",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5099,
+      "region_iso": "TLA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5100,
+      "region_iso": "VER",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5101,
+      "region_iso": "YUC",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5102,
+      "region_iso": "ZAC",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5204,
+      "region_iso": "CHP",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5205,
+      "region_iso": "CHH",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5206,
+      "region_iso": "GRO",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5207,
+      "region_iso": "NLE",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5208,
+      "region_iso": "OAX",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5209,
+      "region_iso": "ROO",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5210,
+      "region_iso": "SLP",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 5276,
+      "region_iso": "CMX",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 8108,
+      "region_iso": "HID",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 8570,
+      "region_iso": "CMX",
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Moldova (Republic of)",
+      "country_alpha2": "MD",
+      "country_alpha3": "MDA",
+      "document_type": "DLD",
+      "id": 3625,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Moldova (Republic of)",
+      "country_alpha2": "MD",
+      "country_alpha3": "MDA",
+      "document_type": "DLD",
+      "id": 3626,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Moldova (Republic of)",
+      "country_alpha2": "MD",
+      "country_alpha3": "MDA",
+      "document_type": "DLD",
+      "id": 3627,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1997"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Moldova (Republic of)",
+      "country_alpha2": "MD",
+      "country_alpha3": "MDA",
+      "document_type": "DLD",
+      "id": 6113,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1995"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Mongolia | Монгол улс",
+      "country_alpha2": "MN",
+      "country_alpha3": "MNG",
+      "document_type": "DLD",
+      "id": 5160,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Montenegro | Crna Gora",
+      "country_alpha2": "ME",
+      "country_alpha3": "MNE",
+      "document_type": "DLD",
+      "id": 5135,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Morocco | المغرب",
+      "country_alpha2": "MA",
+      "country_alpha3": "MAR",
+      "document_type": "DLD",
+      "id": 5499,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Morocco | المغرب",
+      "country_alpha2": "MA",
+      "country_alpha3": "MAR",
+      "document_type": "DLD",
+      "id": 3658,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Morocco | المغرب",
+      "country_alpha2": "MA",
+      "country_alpha3": "MAR",
+      "document_type": "DLD",
+      "id": 5494,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Morocco | المغرب",
+      "country_alpha2": "MA",
+      "country_alpha3": "MAR",
+      "document_type": "DLD",
+      "id": 5498,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Namibia",
+      "country_alpha2": "NA",
+      "country_alpha3": "NAM",
+      "document_type": "DLD",
+      "id": 5496,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Netherlands | Nederland",
+      "country_alpha2": "NL",
+      "country_alpha3": "NLD",
+      "document_type": "DLD",
+      "id": 3675,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Netherlands | Nederland",
+      "country_alpha2": "NL",
+      "country_alpha3": "NLD",
+      "document_type": "DLD",
+      "id": 3676,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Netherlands | Nederland",
+      "country_alpha2": "NL",
+      "country_alpha3": "NLD",
+      "document_type": "DLD",
+      "id": 4164,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "New Zealand | Aotearoa",
+      "country_alpha2": "NZ",
+      "country_alpha3": "NZL",
+      "document_type": "DLD",
+      "id": 7382,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "New Zealand | Aotearoa",
+      "country_alpha2": "NZ",
+      "country_alpha3": "NZL",
+      "document_type": "DLD",
+      "id": 5040,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2006"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "New Zealand | Aotearoa",
+      "country_alpha2": "NZ",
+      "country_alpha3": "NZL",
+      "document_type": "DLD",
+      "id": 7349,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Nigeria | Nijeriya",
+      "country_alpha2": "NG",
+      "country_alpha3": "NGA",
+      "document_type": "DLD",
+      "id": 3720,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Nigeria | Nijeriya",
+      "country_alpha2": "NG",
+      "country_alpha3": "NGA",
+      "document_type": "DLD",
+      "id": 4818,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Northern Mariana Islands | Notte Mariånas",
+      "country_alpha2": "MP",
+      "country_alpha3": "MNP",
+      "document_type": "DLD",
+      "id": 5690,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Northern Mariana Islands | Notte Mariånas",
+      "country_alpha2": "MP",
+      "country_alpha3": "MNP",
+      "document_type": "DLD",
+      "id": 5689,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Norway | Norge",
+      "country_alpha2": "NO",
+      "country_alpha3": "NOR",
+      "document_type": "DLD",
+      "id": 3725,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Norway | Norge",
+      "country_alpha2": "NO",
+      "country_alpha3": "NOR",
+      "document_type": "DLD",
+      "id": 4557,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Norway | Norge",
+      "country_alpha2": "NO",
+      "country_alpha3": "NOR",
+      "document_type": "DLD",
+      "id": 4558,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Norway | Norge",
+      "country_alpha2": "NO",
+      "country_alpha3": "NOR",
+      "document_type": "DLD",
+      "id": 4559,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Oman | عمان",
+      "country_alpha2": "OM",
+      "country_alpha3": "OMN",
+      "document_type": "DLD",
+      "id": 3742,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2006"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Oman | عمان",
+      "country_alpha2": "OM",
+      "country_alpha3": "OMN",
+      "document_type": "DLD",
+      "id": 5917,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Pakistan | پاکستان",
+      "country_alpha2": "PK",
+      "country_alpha3": "PAK",
+      "document_type": "DLD",
+      "id": 5161,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": ""
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Paraguay | Paraguái",
+      "country_alpha2": "PY",
+      "country_alpha3": "PRY",
+      "document_type": "DLD",
+      "id": 5050,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Peru | Perú",
+      "country_alpha2": "PE",
+      "country_alpha3": "PER",
+      "document_type": "DLD",
+      "id": 5052,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": ""
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Peru | Perú",
+      "country_alpha2": "PE",
+      "country_alpha3": "PER",
+      "document_type": "DLD",
+      "id": 5814,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1992"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Peru | Perú",
+      "country_alpha2": "PE",
+      "country_alpha3": "PER",
+      "document_type": "DLD",
+      "id": 5815,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Peru | Perú",
+      "country_alpha2": "PE",
+      "country_alpha3": "PER",
+      "document_type": "DLD",
+      "id": 5816,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Philippines | Pilipinas",
+      "country_alpha2": "PH",
+      "country_alpha3": "PHL",
+      "document_type": "DLD",
+      "id": 4168,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Philippines | Pilipinas",
+      "country_alpha2": "PH",
+      "country_alpha3": "PHL",
+      "document_type": "DLD",
+      "id": 4169,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Philippines | Pilipinas",
+      "country_alpha2": "PH",
+      "country_alpha3": "PHL",
+      "document_type": "DLD",
+      "id": 5924,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "DLD",
+      "id": 4401,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "DLD",
+      "id": 4404,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "DLD",
+      "id": 3775,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1999"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "DLD",
+      "id": 4172,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Portugal",
+      "country_alpha2": "PT",
+      "country_alpha3": "PRT",
+      "document_type": "DLD",
+      "id": 3792,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1999"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Portugal",
+      "country_alpha2": "PT",
+      "country_alpha3": "PRT",
+      "document_type": "DLD",
+      "id": 3793,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Puerto Rico",
+      "country_alpha2": "PR",
+      "country_alpha3": "PRI",
+      "document_type": "DLD",
+      "id": 5570,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2019"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Qatar | قطر",
+      "country_alpha2": "QA",
+      "country_alpha3": "QAT",
+      "document_type": "DLD",
+      "id": 5169,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Romania | România",
+      "country_alpha2": "RO",
+      "country_alpha3": "ROU",
+      "document_type": "DLD",
+      "id": 4181,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Romania | România",
+      "country_alpha2": "RO",
+      "country_alpha3": "ROU",
+      "document_type": "DLD",
+      "id": 4182,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Russian Federation | Россия",
+      "country_alpha2": "RU",
+      "country_alpha3": "RUS",
+      "document_type": "DLD",
+      "id": 3811,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Russian Federation | Россия",
+      "country_alpha2": "RU",
+      "country_alpha3": "RUS",
+      "document_type": "DLD",
+      "id": 4183,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1996"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Russian Federation | Россия",
+      "country_alpha2": "RU",
+      "country_alpha3": "RUS",
+      "document_type": "DLD",
+      "id": 3812,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Russian Federation | Россия",
+      "country_alpha2": "RU",
+      "country_alpha3": "RUS",
+      "document_type": "DLD",
+      "id": 3810,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1999"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Russian Federation | Россия",
+      "country_alpha2": "RU",
+      "country_alpha3": "RUS",
+      "document_type": "DLD",
+      "id": 4185,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Russian Federation | Россия",
+      "country_alpha2": "RU",
+      "country_alpha3": "RUS",
+      "document_type": "DLD",
+      "id": 4186,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Russian Federation | Россия",
+      "country_alpha2": "RU",
+      "country_alpha3": "RUS",
+      "document_type": "DLD",
+      "id": 4184,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Rwanda",
+      "country_alpha2": "RW",
+      "country_alpha3": "RWA",
+      "document_type": "DLD",
+      "id": 5005,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": ""
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Saint Barthélemy | Saint-Barthélemy",
+      "country_alpha2": "BL",
+      "country_alpha3": "BLM",
+      "document_type": "DLD",
+      "id": 5573,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Saint Martin (French part)",
+      "country_alpha2": "MF",
+      "country_alpha3": "MAF",
+      "document_type": "DLD",
+      "id": 5211,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2019"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "San Marino",
+      "country_alpha2": "SM",
+      "country_alpha3": "SMR",
+      "document_type": "DLD",
+      "id": 3827,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Saudi Arabia | السعودية",
+      "country_alpha2": "SA",
+      "country_alpha3": "SAU",
+      "document_type": "DLD",
+      "id": 5171,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Saudi Arabia | السعودية",
+      "country_alpha2": "SA",
+      "country_alpha3": "SAU",
+      "document_type": "DLD",
+      "id": 5933,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Saudi Arabia | السعودية",
+      "country_alpha2": "SA",
+      "country_alpha3": "SAU",
+      "document_type": "DLD",
+      "id": 5934,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "3"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Saudi Arabia | السعودية",
+      "country_alpha2": "SA",
+      "country_alpha3": "SAU",
+      "document_type": "DLD",
+      "id": 5935,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "4"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Serbia | Србија",
+      "country_alpha2": "RS",
+      "country_alpha3": "SRB",
+      "document_type": "DLD",
+      "id": 3837,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Singapore",
+      "country_alpha2": "SG",
+      "country_alpha3": "SGP",
+      "document_type": "DLD",
+      "id": 5173,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Singapore",
+      "country_alpha2": "SG",
+      "country_alpha3": "SGP",
+      "document_type": "DLD",
+      "id": 5939,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Slovakia | Slovensko",
+      "country_alpha2": "SK",
+      "country_alpha3": "SVK",
+      "document_type": "DLD",
+      "id": 3853,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Slovakia | Slovensko",
+      "country_alpha2": "SK",
+      "country_alpha3": "SVK",
+      "document_type": "DLD",
+      "id": 3854,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Slovakia | Slovensko",
+      "country_alpha2": "SK",
+      "country_alpha3": "SVK",
+      "document_type": "DLD",
+      "id": 3855,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Slovakia | Slovensko",
+      "country_alpha2": "SK",
+      "country_alpha3": "SVK",
+      "document_type": "DLD",
+      "id": 6130,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Slovenia | Slovenija",
+      "country_alpha2": "SI",
+      "country_alpha3": "SVN",
+      "document_type": "DLD",
+      "id": 3869,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "South Africa | Suid-Afrika",
+      "country_alpha2": "ZA",
+      "country_alpha3": "ZAF",
+      "document_type": "DLD",
+      "id": 3885,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2001"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "South Africa | Suid-Afrika",
+      "country_alpha2": "ZA",
+      "country_alpha3": "ZAF",
+      "document_type": "DLD",
+      "id": 5508,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "South Africa | Suid-Afrika",
+      "country_alpha2": "ZA",
+      "country_alpha3": "ZAF",
+      "document_type": "DLD",
+      "id": 5509,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Spain | España",
+      "country_alpha2": "ES",
+      "country_alpha3": "ESP",
+      "document_type": "DLD",
+      "id": 4190,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Spain | España",
+      "country_alpha2": "ES",
+      "country_alpha3": "ESP",
+      "document_type": "DLD",
+      "id": 3894,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Sri Lanka | ශ්‍රී ලංකාව",
+      "country_alpha2": "LK",
+      "country_alpha3": "LKA",
+      "document_type": "DLD",
+      "id": 5176,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Sri Lanka | ශ්‍රී ලංකාව",
+      "country_alpha2": "LK",
+      "country_alpha3": "LKA",
+      "document_type": "DLD",
+      "id": 5947,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2000"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Sweden | Sverige",
+      "country_alpha2": "SE",
+      "country_alpha3": "SWE",
+      "document_type": "DLD",
+      "id": 3908,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Sweden | Sverige",
+      "country_alpha2": "SE",
+      "country_alpha3": "SWE",
+      "document_type": "DLD",
+      "id": 4192,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1997"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Sweden | Sverige",
+      "country_alpha2": "SE",
+      "country_alpha3": "SWE",
+      "document_type": "DLD",
+      "id": 4193,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Sweden | Sverige",
+      "country_alpha2": "SE",
+      "country_alpha3": "SWE",
+      "document_type": "DLD",
+      "id": 4194,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Sweden | Sverige",
+      "country_alpha2": "SE",
+      "country_alpha3": "SWE",
+      "document_type": "DLD",
+      "id": 4195,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Sweden | Sverige",
+      "country_alpha2": "SE",
+      "country_alpha3": "SWE",
+      "document_type": "DLD",
+      "id": 4196,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Switzerland | Schweiz",
+      "country_alpha2": "CH",
+      "country_alpha3": "CHE",
+      "document_type": "DLD",
+      "id": 8339,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Switzerland | Schweiz",
+      "country_alpha2": "CH",
+      "country_alpha3": "CHE",
+      "document_type": "DLD",
+      "id": 3916,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Taiwan, Province of China | 中華民國",
+      "country_alpha2": "TW",
+      "country_alpha3": "TWN",
+      "document_type": "DLD",
+      "id": 5177,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Tajikistan | Тоҷикистон",
+      "country_alpha2": "TJ",
+      "country_alpha3": "TJK",
+      "document_type": "DLD",
+      "id": 3940,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Tanzania, United Republic of",
+      "country_alpha2": "TZ",
+      "country_alpha3": "TZA",
+      "document_type": "DLD",
+      "id": 3941,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Thailand | ประเทศไทย",
+      "country_alpha2": "TH",
+      "country_alpha3": "THA",
+      "document_type": "DLD",
+      "id": 3942,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2001"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Thailand | ประเทศไทย",
+      "country_alpha2": "TH",
+      "country_alpha3": "THA",
+      "document_type": "DLD",
+      "id": 3943,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Thailand | ประเทศไทย",
+      "country_alpha2": "TH",
+      "country_alpha3": "THA",
+      "document_type": "DLD",
+      "id": 3944,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Thailand | ประเทศไทย",
+      "country_alpha2": "TH",
+      "country_alpha3": "THA",
+      "document_type": "DLD",
+      "id": 5953,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Thailand | ประเทศไทย",
+      "country_alpha2": "TH",
+      "country_alpha3": "THA",
+      "document_type": "DLD",
+      "id": 5954,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Trinidad and Tobago",
+      "country_alpha2": "TT",
+      "country_alpha3": "TTO",
+      "document_type": "DLD",
+      "id": 5212,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Trinidad and Tobago",
+      "country_alpha2": "TT",
+      "country_alpha3": "TTO",
+      "document_type": "DLD",
+      "id": 5577,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2000"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Tunisia | تونس",
+      "country_alpha2": "TN",
+      "country_alpha3": "TUN",
+      "document_type": "DLD",
+      "id": 5012,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2005"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Tunisia | تونس",
+      "country_alpha2": "TN",
+      "country_alpha3": "TUN",
+      "document_type": "DLD",
+      "id": 5514,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2006"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Tunisia | تونس",
+      "country_alpha2": "TN",
+      "country_alpha3": "TUN",
+      "document_type": "DLD",
+      "id": 5515,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Turkey | Türkiye",
+      "country_alpha2": "TR",
+      "country_alpha3": "TUR",
+      "document_type": "DLD",
+      "id": 3956,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Turkey | Türkiye",
+      "country_alpha2": "TR",
+      "country_alpha3": "TUR",
+      "document_type": "DLD",
+      "id": 6690,
+      "region_iso": null,
+      "usecases": [
+        "verify",
+        "driving_information"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Uganda",
+      "country_alpha2": "UG",
+      "country_alpha3": "UGA",
+      "document_type": "DLD",
+      "id": 5013,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Ukraine | Ukraїna",
+      "country_alpha2": "UA",
+      "country_alpha3": "UKR",
+      "document_type": "DLD",
+      "id": 3964,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2006"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Ukraine | Ukraїna",
+      "country_alpha2": "UA",
+      "country_alpha3": "UKR",
+      "document_type": "DLD",
+      "id": 3963,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2005"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Ukraine | Ukraїna",
+      "country_alpha2": "UA",
+      "country_alpha3": "UKR",
+      "document_type": "DLD",
+      "id": 4630,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Ukraine | Ukraїna",
+      "country_alpha2": "UA",
+      "country_alpha3": "UKR",
+      "document_type": "DLD",
+      "id": 4569,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United Arab Emirates | الإمارات العربية المتحدة",
+      "country_alpha2": "AE",
+      "country_alpha3": "ARE",
+      "document_type": "DLD",
+      "id": 5180,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United Arab Emirates | الإمارات العربية المتحدة",
+      "country_alpha2": "AE",
+      "country_alpha3": "ARE",
+      "document_type": "DLD",
+      "id": 5957,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United Arab Emirates | الإمارات العربية المتحدة",
+      "country_alpha2": "AE",
+      "country_alpha3": "ARE",
+      "document_type": "DLD",
+      "id": 5958,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United Arab Emirates | الإمارات العربية المتحدة",
+      "country_alpha2": "AE",
+      "country_alpha3": "ARE",
+      "document_type": "DLD",
+      "id": 5959,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United Kingdom of Great Britain and Northern Ireland",
+      "country_alpha2": "GB",
+      "country_alpha3": "GBR",
+      "document_type": "DLD",
+      "id": 3979,
+      "region_iso": "WAL",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United Kingdom of Great Britain and Northern Ireland",
+      "country_alpha2": "GB",
+      "country_alpha3": "GBR",
+      "document_type": "DLD",
+      "id": 4205,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United Kingdom of Great Britain and Northern Ireland",
+      "country_alpha2": "GB",
+      "country_alpha3": "GBR",
+      "document_type": "DLD",
+      "id": 4206,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United Kingdom of Great Britain and Northern Ireland",
+      "country_alpha2": "GB",
+      "country_alpha3": "GBR",
+      "document_type": "DLD",
+      "id": 6138,
+      "region_iso": "NIR",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United Kingdom of Great Britain and Northern Ireland",
+      "country_alpha2": "GB",
+      "country_alpha3": "GBR",
+      "document_type": "DLD",
+      "id": 6139,
+      "region_iso": "NIR",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United Kingdom of Great Britain and Northern Ireland",
+      "country_alpha2": "GB",
+      "country_alpha3": "GBR",
+      "document_type": "DLD",
+      "id": 6140,
+      "region_iso": "NIR",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United Kingdom of Great Britain and Northern Ireland",
+      "country_alpha2": "GB",
+      "country_alpha3": "GBR",
+      "document_type": "DLD",
+      "id": 6141,
+      "region_iso": "NIR",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United Kingdom of Great Britain and Northern Ireland",
+      "country_alpha2": "GB",
+      "country_alpha3": "GBR",
+      "document_type": "DLD",
+      "id": 3974,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1998"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United Kingdom of Great Britain and Northern Ireland",
+      "country_alpha2": "GB",
+      "country_alpha3": "GBR",
+      "document_type": "DLD",
+      "id": 3976,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United Kingdom of Great Britain and Northern Ireland",
+      "country_alpha2": "GB",
+      "country_alpha3": "GBR",
+      "document_type": "DLD",
+      "id": 3977,
+      "region_iso": null,
+      "usecases": [
+        "verify",
+        "driving_information"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United Kingdom of Great Britain and Northern Ireland",
+      "country_alpha2": "GB",
+      "country_alpha3": "GBR",
+      "document_type": "DLD",
+      "id": 3978,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
       "country": "United States of America",
       "country_alpha2": "US",
       "country_alpha3": "USA",
@@ -147,358 +6501,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Belarus | Беларусь",
-      "country_alpha2": "BY",
-      "country_alpha3": "BLR",
-      "document_type": "DLD",
-      "id": 3015,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Ukraine | Ukraїna",
-      "country_alpha2": "UA",
-      "country_alpha3": "UKR",
-      "document_type": "DLD",
-      "id": 3964,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Austria | Österreich",
-      "country_alpha2": "AT",
-      "country_alpha3": "AUT",
-      "document_type": "DLD",
-      "id": 4643,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Saudi Arabia | السعودية",
-      "country_alpha2": "SA",
-      "country_alpha3": "SAU",
-      "document_type": "DLD",
-      "id": 5171,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Japan | 日本",
-      "country_alpha2": "JP",
-      "country_alpha3": "JPN",
-      "document_type": "DLD",
-      "id": 5898,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Georgia | საქართველო",
-      "country_alpha2": "GE",
-      "country_alpha3": "GEO",
-      "document_type": "DLD",
-      "id": 6065,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Korea (Republic of) | 한국",
-      "country_alpha2": "KR",
-      "country_alpha3": "KOR",
-      "document_type": "DLD",
-      "id": 6392,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Korea (Republic of) | 한국",
-      "country_alpha2": "KR",
-      "country_alpha3": "KOR",
-      "document_type": "DLD",
-      "id": 6458,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Albania | Shqipëria",
-      "country_alpha2": "AL",
-      "country_alpha3": "ALB",
-      "document_type": "DLD",
-      "id": 2919,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2005"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Austria | Österreich",
-      "country_alpha2": "AT",
-      "country_alpha3": "AUT",
-      "document_type": "DLD",
-      "id": 2975,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Denmark | Danmark",
-      "country_alpha2": "DK",
-      "country_alpha3": "DNK",
-      "document_type": "DLD",
-      "id": 3225,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1997"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "France",
-      "country_alpha2": "FR",
-      "country_alpha3": "FRA",
-      "document_type": "DLD",
-      "id": 3302,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Slovakia | Slovensko",
-      "country_alpha2": "SK",
-      "country_alpha3": "SVK",
-      "document_type": "DLD",
-      "id": 3853,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Slovakia | Slovensko",
-      "country_alpha2": "SK",
-      "country_alpha3": "SVK",
-      "document_type": "DLD",
-      "id": 3854,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Ukraine | Ukraїna",
-      "country_alpha2": "UA",
-      "country_alpha3": "UKR",
-      "document_type": "DLD",
-      "id": 3963,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2005"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United Kingdom of Great Britain and Northern Ireland",
-      "country_alpha2": "GB",
-      "country_alpha3": "GBR",
-      "document_type": "DLD",
-      "id": 3979,
-      "region_iso": "WAL",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 4216,
-      "region_iso": "BC",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Austria | Österreich",
-      "country_alpha2": "AT",
-      "country_alpha3": "AUT",
-      "document_type": "DLD",
-      "id": 4636,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Uruguay",
-      "country_alpha2": "UY",
-      "country_alpha3": "URY",
-      "document_type": "DLD",
-      "id": 5053,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "v1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 5064,
-      "region_iso": "NS",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Hong Kong | 香港",
-      "country_alpha2": "HK",
-      "country_alpha3": "HKG",
-      "document_type": "DLD",
-      "id": 5148,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Botswana",
-      "country_alpha2": "BW",
-      "country_alpha3": "BWA",
-      "document_type": "DLD",
-      "id": 5471,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "United States of America",
       "country_alpha2": "US",
       "country_alpha3": "USA",
@@ -509,22 +6511,6 @@
         "verify"
       ],
       "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Kuwait | دولة الكويت",
-      "country_alpha2": "KW",
-      "country_alpha3": "KWT",
-      "document_type": "DLD",
-      "id": 5905,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
     }
   },
   {
@@ -565,268 +6551,12 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "DLD",
-      "id": 4149,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Austria | Österreich",
-      "country_alpha2": "AT",
-      "country_alpha3": "AUT",
-      "document_type": "DLD",
-      "id": 4582,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "DLD",
-      "id": 7713,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2000"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brunei Darussalam | بروني",
-      "country_alpha2": "BN",
-      "country_alpha3": "BRN",
-      "document_type": "DLD",
-      "id": 7745,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Morocco | المغرب",
-      "country_alpha2": "MA",
-      "country_alpha3": "MAR",
-      "document_type": "DLD",
-      "id": 5499,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Croatia | Hrvatska",
-      "country_alpha2": "HR",
-      "country_alpha3": "HRV",
-      "document_type": "DLD",
-      "id": 3178,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "New Zealand | Aotearoa",
-      "country_alpha2": "NZ",
-      "country_alpha3": "NZL",
-      "document_type": "DLD",
-      "id": 7382,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Guatemala",
-      "country_alpha2": "GT",
-      "country_alpha3": "GTM",
-      "document_type": "DLD",
-      "id": 7779,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": ""
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Iceland | Ísland",
-      "country_alpha2": "IS",
-      "country_alpha3": "ISL",
-      "document_type": "DLD",
-      "id": 3394,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Malta",
-      "country_alpha2": "MT",
-      "country_alpha3": "MLT",
-      "document_type": "DLD",
-      "id": 7945,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013 2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "United States of America",
       "country_alpha2": "US",
       "country_alpha3": "USA",
       "document_type": "DLD",
       "id": 7910,
       "region_iso": "CO",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Germany | Deutschland",
-      "country_alpha2": "DE",
-      "country_alpha3": "DEU",
-      "document_type": "DLD",
-      "id": 4114,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1986"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "France",
-      "country_alpha2": "FR",
-      "country_alpha3": "FRA",
-      "document_type": "DLD",
-      "id": 4286,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1994"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Germany | Deutschland",
-      "country_alpha2": "DE",
-      "country_alpha3": "DEU",
-      "document_type": "DLD",
-      "id": 4315,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015 1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Ghana",
-      "country_alpha2": "GH",
-      "country_alpha3": "GHA",
-      "document_type": "DLD",
-      "id": 4995,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017 2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5082,
-      "region_iso": "MEX",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5084,
-      "region_iso": "GRO",
       "usecases": [
         "verify"
       ],
@@ -847,22 +6577,6 @@
         "verify"
       ],
       "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Ghana",
-      "country_alpha2": "GH",
-      "country_alpha3": "GHA",
-      "document_type": "DLD",
-      "id": 8015,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
     }
   },
   {
@@ -1109,44 +6823,12 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "DLD",
-      "id": 8124,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "United States of America",
       "country_alpha2": "US",
       "country_alpha3": "USA",
       "document_type": "DLD",
       "id": 8176,
       "region_iso": "HI",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Cyprus | Κύπρος",
-      "country_alpha2": "CY",
-      "country_alpha3": "CYP",
-      "document_type": "DLD",
-      "id": 8177,
-      "region_iso": null,
       "usecases": [
         "verify"
       ],
@@ -1237,1318 +6919,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Belarus | Беларусь",
-      "country_alpha2": "BY",
-      "country_alpha3": "BLR",
-      "document_type": "DLD",
-      "id": 3016,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1995"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Italy | Italia",
-      "country_alpha2": "IT",
-      "country_alpha3": "ITA",
-      "document_type": "DLD",
-      "id": 3445,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2002"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Russian Federation | Россия",
-      "country_alpha2": "RU",
-      "country_alpha3": "RUS",
-      "document_type": "DLD",
-      "id": 3811,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Italy | Italia",
-      "country_alpha2": "IT",
-      "country_alpha3": "ITA",
-      "document_type": "DLD",
-      "id": 4138,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1999"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Russian Federation | Россия",
-      "country_alpha2": "RU",
-      "country_alpha3": "RUS",
-      "document_type": "DLD",
-      "id": 4183,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1996"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Spain | España",
-      "country_alpha2": "ES",
-      "country_alpha3": "ESP",
-      "document_type": "DLD",
-      "id": 4190,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Germany | Deutschland",
-      "country_alpha2": "DE",
-      "country_alpha3": "DEU",
-      "document_type": "DLD",
-      "id": 4312,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2001"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Germany | Deutschland",
-      "country_alpha2": "DE",
-      "country_alpha3": "DEU",
-      "document_type": "DLD",
-      "id": 4313,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Germany | Deutschland",
-      "country_alpha2": "DE",
-      "country_alpha3": "DEU",
-      "document_type": "DLD",
-      "id": 4314,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Ukraine | Ukraїna",
-      "country_alpha2": "UA",
-      "country_alpha3": "UKR",
-      "document_type": "DLD",
-      "id": 4630,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "DLD",
-      "id": 4810,
-      "region_iso": "WAL",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "DLD",
-      "id": 4821,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "DLD",
-      "id": 4823,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Australia",
-      "country_alpha2": "AU",
-      "country_alpha3": "AUS",
-      "document_type": "DLD",
-      "id": 5043,
-      "region_iso": "WA",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Paraguay | Paraguái",
-      "country_alpha2": "PY",
-      "country_alpha3": "PRY",
-      "document_type": "DLD",
-      "id": 5050,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Gibraltar",
-      "country_alpha2": "GI",
-      "country_alpha3": "GIB",
-      "document_type": "DLD",
-      "id": 5128,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Australia",
-      "country_alpha2": "AU",
-      "country_alpha3": "AUS",
-      "document_type": "DLD",
-      "id": 6002,
-      "region_iso": "WA",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Bosnia and Herzegovina | Bosna i Hercegovina",
-      "country_alpha2": "BA",
-      "country_alpha3": "BIH",
-      "document_type": "DLD",
-      "id": 838,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Germany | Deutschland",
-      "country_alpha2": "DE",
-      "country_alpha3": "DEU",
-      "document_type": "DLD",
-      "id": 887,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Andorra",
-      "country_alpha2": "AD",
-      "country_alpha3": "AND",
-      "document_type": "DLD",
-      "id": 2925,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1990"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Armenia | Հայաստան",
-      "country_alpha2": "AM",
-      "country_alpha3": "ARM",
-      "document_type": "DLD",
-      "id": 2942,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2005"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Armenia | Հայաստան",
-      "country_alpha2": "AM",
-      "country_alpha3": "ARM",
-      "document_type": "DLD",
-      "id": 2943,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Australia",
-      "country_alpha2": "AU",
-      "country_alpha3": "AUS",
-      "document_type": "DLD",
-      "id": 2948,
-      "region_iso": "ACT",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2001"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Australia",
-      "country_alpha2": "AU",
-      "country_alpha3": "AUS",
-      "document_type": "DLD",
-      "id": 2949,
-      "region_iso": "NSW",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2002"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Australia",
-      "country_alpha2": "AU",
-      "country_alpha3": "AUS",
-      "document_type": "DLD",
-      "id": 2951,
-      "region_iso": "QLD",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Australia",
-      "country_alpha2": "AU",
-      "country_alpha3": "AUS",
-      "document_type": "DLD",
-      "id": 2952,
-      "region_iso": "ACT",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2001"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Azerbaijan | Azərbaycan",
-      "country_alpha2": "AZ",
-      "country_alpha3": "AZE",
-      "document_type": "DLD",
-      "id": 2989,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Azerbaijan | Azərbaycan",
-      "country_alpha2": "AZ",
-      "country_alpha3": "AZE",
-      "document_type": "DLD",
-      "id": 2990,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2002"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Belarus | Беларусь",
-      "country_alpha2": "BY",
-      "country_alpha3": "BLR",
-      "document_type": "DLD",
-      "id": 3013,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Belarus | Беларусь",
-      "country_alpha2": "BY",
-      "country_alpha3": "BLR",
-      "document_type": "DLD",
-      "id": 3014,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "DLD",
-      "id": 3022,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Botswana",
-      "country_alpha2": "BW",
-      "country_alpha3": "BWA",
-      "document_type": "DLD",
-      "id": 3058,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Bulgaria | България",
-      "country_alpha2": "BG",
-      "country_alpha3": "BGR",
-      "document_type": "DLD",
-      "id": 3072,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Bulgaria | България",
-      "country_alpha2": "BG",
-      "country_alpha3": "BGR",
-      "document_type": "DLD",
-      "id": 3073,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Bulgaria | България",
-      "country_alpha2": "BG",
-      "country_alpha3": "BGR",
-      "document_type": "DLD",
-      "id": 3074,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Chile",
-      "country_alpha2": "CL",
-      "country_alpha3": "CHL",
-      "document_type": "DLD",
-      "id": 3139,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "China | 中国",
-      "country_alpha2": "CN",
-      "country_alpha3": "CHN",
-      "document_type": "DLD",
-      "id": 3151,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "China | 中国",
-      "country_alpha2": "CN",
-      "country_alpha3": "CHN",
-      "document_type": "DLD",
-      "id": 3152,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "China | 中国",
-      "country_alpha2": "CN",
-      "country_alpha3": "CHN",
-      "document_type": "DLD",
-      "id": 3153,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Czech Republic | Česko",
-      "country_alpha2": "CZ",
-      "country_alpha3": "CZE",
-      "document_type": "DLD",
-      "id": 3200,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Czech Republic | Česko",
-      "country_alpha2": "CZ",
-      "country_alpha3": "CZE",
-      "document_type": "DLD",
-      "id": 3201,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Denmark | Danmark",
-      "country_alpha2": "DK",
-      "country_alpha3": "DNK",
-      "document_type": "DLD",
-      "id": 3226,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "El Salvador",
-      "country_alpha2": "SV",
-      "country_alpha3": "SLV",
-      "document_type": "DLD",
-      "id": 3250,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Estonia | Eesti",
-      "country_alpha2": "EE",
-      "country_alpha3": "EST",
-      "document_type": "DLD",
-      "id": 3260,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Estonia | Eesti",
-      "country_alpha2": "EE",
-      "country_alpha3": "EST",
-      "document_type": "DLD",
-      "id": 3261,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Finland | Suomi",
-      "country_alpha2": "FI",
-      "country_alpha3": "FIN",
-      "document_type": "DLD",
-      "id": 3282,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1998"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Finland | Suomi",
-      "country_alpha2": "FI",
-      "country_alpha3": "FIN",
-      "document_type": "DLD",
-      "id": 3283,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Finland | Suomi",
-      "country_alpha2": "FI",
-      "country_alpha3": "FIN",
-      "document_type": "DLD",
-      "id": 3284,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Finland | Suomi",
-      "country_alpha2": "FI",
-      "country_alpha3": "FIN",
-      "document_type": "DLD",
-      "id": 3285,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2000"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Georgia | საქართველო",
-      "country_alpha2": "GE",
-      "country_alpha3": "GEO",
-      "document_type": "DLD",
-      "id": 3314,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2000"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Georgia | საქართველო",
-      "country_alpha2": "GE",
-      "country_alpha3": "GEO",
-      "document_type": "DLD",
-      "id": 3315,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Greece | Ελλάδα",
-      "country_alpha2": "GR",
-      "country_alpha3": "GRC",
-      "document_type": "DLD",
-      "id": 3355,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Greece | Ελλάδα",
-      "country_alpha2": "GR",
-      "country_alpha3": "GRC",
-      "document_type": "DLD",
-      "id": 3356,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Guernsey",
-      "country_alpha2": "GG",
-      "country_alpha3": "GGY",
-      "document_type": "DLD",
-      "id": 3373,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1996"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Guernsey",
-      "country_alpha2": "GG",
-      "country_alpha3": "GGY",
-      "document_type": "DLD",
-      "id": 3374,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1998"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Israel | ישראל",
-      "country_alpha2": "IL",
-      "country_alpha3": "ISR",
-      "document_type": "DLD",
-      "id": 3433,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Kazakhstan | Қазақстан",
-      "country_alpha2": "KZ",
-      "country_alpha3": "KAZ",
-      "document_type": "DLD",
-      "id": 3468,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "DLD",
-      "id": 3545,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Macao | 澳門",
-      "country_alpha2": "MO",
-      "country_alpha3": "MAC",
-      "document_type": "DLD",
-      "id": 3579,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Macedonia (the former Yugoslav Republic of) | Македонија",
-      "country_alpha2": "MK",
-      "country_alpha3": "MKD",
-      "document_type": "DLD",
-      "id": 3583,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Malaysia",
-      "country_alpha2": "MY",
-      "country_alpha3": "MYS",
-      "document_type": "DLD",
-      "id": 3593,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Malta",
-      "country_alpha2": "MT",
-      "country_alpha3": "MLT",
-      "document_type": "DLD",
-      "id": 3608,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Malta",
-      "country_alpha2": "MT",
-      "country_alpha3": "MLT",
-      "document_type": "DLD",
-      "id": 3609,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Moldova (Republic of)",
-      "country_alpha2": "MD",
-      "country_alpha3": "MDA",
-      "document_type": "DLD",
-      "id": 3625,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Moldova (Republic of)",
-      "country_alpha2": "MD",
-      "country_alpha3": "MDA",
-      "document_type": "DLD",
-      "id": 3626,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Moldova (Republic of)",
-      "country_alpha2": "MD",
-      "country_alpha3": "MDA",
-      "document_type": "DLD",
-      "id": 3627,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1997"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Morocco | المغرب",
-      "country_alpha2": "MA",
-      "country_alpha3": "MAR",
-      "document_type": "DLD",
-      "id": 3658,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Nigeria | Nijeriya",
-      "country_alpha2": "NG",
-      "country_alpha3": "NGA",
-      "document_type": "DLD",
-      "id": 3720,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Norway | Norge",
-      "country_alpha2": "NO",
-      "country_alpha3": "NOR",
-      "document_type": "DLD",
-      "id": 3725,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Oman | عمان",
-      "country_alpha2": "OM",
-      "country_alpha3": "OMN",
-      "document_type": "DLD",
-      "id": 3742,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Russian Federation | Россия",
-      "country_alpha2": "RU",
-      "country_alpha3": "RUS",
-      "document_type": "DLD",
-      "id": 3812,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "San Marino",
-      "country_alpha2": "SM",
-      "country_alpha3": "SMR",
-      "document_type": "DLD",
-      "id": 3827,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Serbia | Србија",
-      "country_alpha2": "RS",
-      "country_alpha3": "SRB",
-      "document_type": "DLD",
-      "id": 3837,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Slovakia | Slovensko",
-      "country_alpha2": "SK",
-      "country_alpha3": "SVK",
-      "document_type": "DLD",
-      "id": 3855,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "South Africa | Suid-Afrika",
-      "country_alpha2": "ZA",
-      "country_alpha3": "ZAF",
-      "document_type": "DLD",
-      "id": 3885,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2001"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Sweden | Sverige",
-      "country_alpha2": "SE",
-      "country_alpha3": "SWE",
-      "document_type": "DLD",
-      "id": 3908,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Tajikistan | Тоҷикистон",
-      "country_alpha2": "TJ",
-      "country_alpha3": "TJK",
-      "document_type": "DLD",
-      "id": 3940,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Tanzania, United Republic of",
-      "country_alpha2": "TZ",
-      "country_alpha3": "TZA",
-      "document_type": "DLD",
-      "id": 3941,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Thailand | ประเทศไทย",
-      "country_alpha2": "TH",
-      "country_alpha3": "THA",
-      "document_type": "DLD",
-      "id": 3942,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2001"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Thailand | ประเทศไทย",
-      "country_alpha2": "TH",
-      "country_alpha3": "THA",
-      "document_type": "DLD",
-      "id": 3943,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Thailand | ประเทศไทย",
-      "country_alpha2": "TH",
-      "country_alpha3": "THA",
-      "document_type": "DLD",
-      "id": 3944,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Turkey | Türkiye",
-      "country_alpha2": "TR",
-      "country_alpha3": "TUR",
-      "document_type": "DLD",
-      "id": 3956,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "United States of America",
       "country_alpha2": "US",
       "country_alpha3": "USA",
@@ -2559,262 +6929,6 @@
         "verify"
       ],
       "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "France",
-      "country_alpha2": "FR",
-      "country_alpha3": "FRA",
-      "document_type": "DLD",
-      "id": 4108,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Indonesia",
-      "country_alpha2": "ID",
-      "country_alpha3": "IDN",
-      "document_type": "DLD",
-      "id": 4127,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2019"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Indonesia",
-      "country_alpha2": "ID",
-      "country_alpha3": "IDN",
-      "document_type": "DLD",
-      "id": 4128,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Indonesia",
-      "country_alpha2": "ID",
-      "country_alpha3": "IDN",
-      "document_type": "DLD",
-      "id": 4130,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Indonesia",
-      "country_alpha2": "ID",
-      "country_alpha3": "IDN",
-      "document_type": "DLD",
-      "id": 4131,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Philippines | Pilipinas",
-      "country_alpha2": "PH",
-      "country_alpha3": "PHL",
-      "document_type": "DLD",
-      "id": 4168,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Philippines | Pilipinas",
-      "country_alpha2": "PH",
-      "country_alpha3": "PHL",
-      "document_type": "DLD",
-      "id": 4169,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Romania | România",
-      "country_alpha2": "RO",
-      "country_alpha3": "ROU",
-      "document_type": "DLD",
-      "id": 4181,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Romania | România",
-      "country_alpha2": "RO",
-      "country_alpha3": "ROU",
-      "document_type": "DLD",
-      "id": 4182,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Sweden | Sverige",
-      "country_alpha2": "SE",
-      "country_alpha3": "SWE",
-      "document_type": "DLD",
-      "id": 4192,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1997"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Sweden | Sverige",
-      "country_alpha2": "SE",
-      "country_alpha3": "SWE",
-      "document_type": "DLD",
-      "id": 4193,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Sweden | Sverige",
-      "country_alpha2": "SE",
-      "country_alpha3": "SWE",
-      "document_type": "DLD",
-      "id": 4194,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Sweden | Sverige",
-      "country_alpha2": "SE",
-      "country_alpha3": "SWE",
-      "document_type": "DLD",
-      "id": 4195,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Sweden | Sverige",
-      "country_alpha2": "SE",
-      "country_alpha3": "SWE",
-      "document_type": "DLD",
-      "id": 4196,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Viet Nam | Việt Nam",
-      "country_alpha2": "VN",
-      "country_alpha3": "VNM",
-      "document_type": "DLD",
-      "id": 4208,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Viet Nam | Việt Nam",
-      "country_alpha2": "VN",
-      "country_alpha3": "VNM",
-      "document_type": "DLD",
-      "id": 4209,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
     }
   },
   {
@@ -3039,374 +7153,6 @@
         "verify"
       ],
       "version": "2000"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Australia",
-      "country_alpha2": "AU",
-      "country_alpha3": "AUS",
-      "document_type": "DLD",
-      "id": 4244,
-      "region_iso": "QLD",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Germany | Deutschland",
-      "country_alpha2": "DE",
-      "country_alpha3": "DEU",
-      "document_type": "DLD",
-      "id": 4301,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1982"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Ireland | Éire",
-      "country_alpha2": "IE",
-      "country_alpha3": "IRL",
-      "document_type": "DLD",
-      "id": 4339,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2005"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Italy | Italia",
-      "country_alpha2": "IT",
-      "country_alpha3": "ITA",
-      "document_type": "DLD",
-      "id": 4348,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "DLD",
-      "id": 4386,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "DLD",
-      "id": 4387,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "DLD",
-      "id": 4401,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "DLD",
-      "id": 4404,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Norway | Norge",
-      "country_alpha2": "NO",
-      "country_alpha3": "NOR",
-      "document_type": "DLD",
-      "id": 4557,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Norway | Norge",
-      "country_alpha2": "NO",
-      "country_alpha3": "NOR",
-      "document_type": "DLD",
-      "id": 4558,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Latvia | Latvija",
-      "country_alpha2": "LV",
-      "country_alpha3": "LVA",
-      "document_type": "DLD",
-      "id": 4591,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Estonia | Eesti",
-      "country_alpha2": "EE",
-      "country_alpha3": "EST",
-      "document_type": "DLD",
-      "id": 4627,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Estonia | Eesti",
-      "country_alpha2": "EE",
-      "country_alpha3": "EST",
-      "document_type": "DLD",
-      "id": 4628,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Venezuela (Bolivarian Republic of)",
-      "country_alpha2": "VE",
-      "country_alpha3": "VEN",
-      "document_type": "DLD",
-      "id": 4743,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Venezuela (Bolivarian Republic of)",
-      "country_alpha2": "VE",
-      "country_alpha3": "VEN",
-      "document_type": "DLD",
-      "id": 4744,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Austria | Österreich",
-      "country_alpha2": "AT",
-      "country_alpha3": "AUT",
-      "document_type": "DLD",
-      "id": 4789,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Finland | Suomi",
-      "country_alpha2": "FI",
-      "country_alpha3": "FIN",
-      "document_type": "DLD",
-      "id": 4802,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "DLD",
-      "id": 4811,
-      "region_iso": "VLG",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Nigeria | Nijeriya",
-      "country_alpha2": "NG",
-      "country_alpha3": "NGA",
-      "document_type": "DLD",
-      "id": 4818,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "DLD",
-      "id": 4822,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Bulgaria | България",
-      "country_alpha2": "BG",
-      "country_alpha3": "BGR",
-      "document_type": "DLD",
-      "id": 4840,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Bulgaria | България",
-      "country_alpha2": "BG",
-      "country_alpha3": "BGR",
-      "document_type": "DLD",
-      "id": 4841,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Colombia",
-      "country_alpha2": "CO",
-      "country_alpha3": "COL",
-      "document_type": "DLD",
-      "id": 4890,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
     }
   },
   {
@@ -3987,678 +7733,6 @@
   },
   {
     "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Cameroon",
-      "country_alpha2": "CM",
-      "country_alpha3": "CMR",
-      "document_type": "DLD",
-      "id": 4986,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Côte d'Ivoire | Côte d'Ivoire",
-      "country_alpha2": "CI",
-      "country_alpha3": "CIV",
-      "document_type": "DLD",
-      "id": 4988,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Egypt | مصر",
-      "country_alpha2": "EG",
-      "country_alpha3": "EGY",
-      "document_type": "DLD",
-      "id": 4991,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Kenya",
-      "country_alpha2": "KE",
-      "country_alpha3": "KEN",
-      "document_type": "DLD",
-      "id": 4997,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Rwanda",
-      "country_alpha2": "RW",
-      "country_alpha3": "RWA",
-      "document_type": "DLD",
-      "id": 5005,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": ""
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Tunisia | تونس",
-      "country_alpha2": "TN",
-      "country_alpha3": "TUN",
-      "document_type": "DLD",
-      "id": 5012,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2005"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Uganda",
-      "country_alpha2": "UG",
-      "country_alpha3": "UGA",
-      "document_type": "DLD",
-      "id": 5013,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Zambia",
-      "country_alpha2": "ZM",
-      "country_alpha3": "ZMB",
-      "document_type": "DLD",
-      "id": 5016,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "French Polynesia | Polynésie française",
-      "country_alpha2": "PF",
-      "country_alpha3": "PYF",
-      "document_type": "DLD",
-      "id": 5018,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Fiji | Viti",
-      "country_alpha2": "FJ",
-      "country_alpha3": "FJI",
-      "document_type": "DLD",
-      "id": 5039,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "New Zealand | Aotearoa",
-      "country_alpha2": "NZ",
-      "country_alpha3": "NZL",
-      "document_type": "DLD",
-      "id": 5040,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Australia",
-      "country_alpha2": "AU",
-      "country_alpha3": "AUS",
-      "document_type": "DLD",
-      "id": 5041,
-      "region_iso": "SA",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Australia",
-      "country_alpha2": "AU",
-      "country_alpha3": "AUS",
-      "document_type": "DLD",
-      "id": 5042,
-      "region_iso": "VIC",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 5044,
-      "region_iso": "S",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Ecuador",
-      "country_alpha2": "EC",
-      "country_alpha3": "ECU",
-      "document_type": "DLD",
-      "id": 5049,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Peru | Perú",
-      "country_alpha2": "PE",
-      "country_alpha3": "PER",
-      "document_type": "DLD",
-      "id": 5052,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": ""
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Costa Rica",
-      "country_alpha2": "CR",
-      "country_alpha3": "CRI",
-      "document_type": "DLD",
-      "id": 5070,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5073,
-      "region_iso": "AGU",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5074,
-      "region_iso": "BCN",
-      "usecases": [
-        "verify"
-      ],
-      "version": ""
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5075,
-      "region_iso": "BCS",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5076,
-      "region_iso": "CAM",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5077,
-      "region_iso": "CHH",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5078,
-      "region_iso": "COA",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5079,
-      "region_iso": "COL",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5081,
-      "region_iso": "DUR",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5083,
-      "region_iso": "GUA",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5085,
-      "region_iso": "HID",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5086,
-      "region_iso": "JAL",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5087,
-      "region_iso": "MIC",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5088,
-      "region_iso": "MOR",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5089,
-      "region_iso": "NAY",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5091,
-      "region_iso": "PUE",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5092,
-      "region_iso": "QUE",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5095,
-      "region_iso": "SIN",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5096,
-      "region_iso": "SON",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5097,
-      "region_iso": "TAB",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5098,
-      "region_iso": "TAM",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5099,
-      "region_iso": "TLA",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5100,
-      "region_iso": "VER",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5101,
-      "region_iso": "YUC",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5102,
-      "region_iso": "ZAC",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Guam | Guåhån",
-      "country_alpha2": "GU",
-      "country_alpha3": "GUM",
-      "document_type": "DLD",
-      "id": 5106,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
       "back_required": false,
       "common_name": null,
       "country": "United States of America",
@@ -4687,470 +7761,6 @@
         "verify"
       ],
       "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Cyprus | Κύπρος",
-      "country_alpha2": "CY",
-      "country_alpha3": "CYP",
-      "document_type": "DLD",
-      "id": 5124,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Bangladesh | বাংলাদেশ",
-      "country_alpha2": "BD",
-      "country_alpha3": "BGD",
-      "document_type": "DLD",
-      "id": 5142,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brunei Darussalam | بروني",
-      "country_alpha2": "BN",
-      "country_alpha3": "BRN",
-      "document_type": "DLD",
-      "id": 5144,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Jordan | الأردن",
-      "country_alpha2": "JO",
-      "country_alpha3": "JOR",
-      "document_type": "DLD",
-      "id": 5155,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Kuwait | دولة الكويت",
-      "country_alpha2": "KW",
-      "country_alpha3": "KWT",
-      "document_type": "DLD",
-      "id": 5157,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1996"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Mongolia | Монгол улс",
-      "country_alpha2": "MN",
-      "country_alpha3": "MNG",
-      "document_type": "DLD",
-      "id": 5160,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Pakistan | پاکستان",
-      "country_alpha2": "PK",
-      "country_alpha3": "PAK",
-      "document_type": "DLD",
-      "id": 5161,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": ""
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Qatar | قطر",
-      "country_alpha2": "QA",
-      "country_alpha3": "QAT",
-      "document_type": "DLD",
-      "id": 5169,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Singapore",
-      "country_alpha2": "SG",
-      "country_alpha3": "SGP",
-      "document_type": "DLD",
-      "id": 5173,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Sri Lanka | ශ්‍රී ලංකාව",
-      "country_alpha2": "LK",
-      "country_alpha3": "LKA",
-      "document_type": "DLD",
-      "id": 5176,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Taiwan, Province of China | 中華民國",
-      "country_alpha2": "TW",
-      "country_alpha3": "TWN",
-      "document_type": "DLD",
-      "id": 5177,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United Arab Emirates | الإمارات العربية المتحدة",
-      "country_alpha2": "AE",
-      "country_alpha3": "ARE",
-      "document_type": "DLD",
-      "id": 5180,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Yemen | اليمن",
-      "country_alpha2": "YE",
-      "country_alpha3": "YEM",
-      "document_type": "DLD",
-      "id": 5183,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Bolivia (Plurinational State of) | Bolivia",
-      "country_alpha2": "BO",
-      "country_alpha3": "BOL",
-      "document_type": "DLD",
-      "id": 5188,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Bahamas",
-      "country_alpha2": "BS",
-      "country_alpha3": "BHS",
-      "document_type": "DLD",
-      "id": 5190,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Barbados",
-      "country_alpha2": "BB",
-      "country_alpha3": "BRB",
-      "document_type": "DLD",
-      "id": 5191,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1999"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Bermuda",
-      "country_alpha2": "BM",
-      "country_alpha3": "BMU",
-      "document_type": "DLD",
-      "id": 5192,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": ""
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Dominican Republic | República Dominicana",
-      "country_alpha2": "DO",
-      "country_alpha3": "DOM",
-      "document_type": "DLD",
-      "id": 5197,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Guatemala",
-      "country_alpha2": "GT",
-      "country_alpha3": "GTM",
-      "document_type": "DLD",
-      "id": 5200,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Jamaica",
-      "country_alpha2": "JM",
-      "country_alpha3": "JAM",
-      "document_type": "DLD",
-      "id": 5203,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5204,
-      "region_iso": "CHP",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5205,
-      "region_iso": "CHH",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5206,
-      "region_iso": "GRO",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5207,
-      "region_iso": "NLE",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5208,
-      "region_iso": "OAX",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5209,
-      "region_iso": "ROO",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5210,
-      "region_iso": "SLP",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Saint Martin (French part)",
-      "country_alpha2": "MF",
-      "country_alpha3": "MAF",
-      "document_type": "DLD",
-      "id": 5211,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2019"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Trinidad and Tobago",
-      "country_alpha2": "TT",
-      "country_alpha3": "TTO",
-      "document_type": "DLD",
-      "id": 5212,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
     }
   },
   {
@@ -5477,262 +8087,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 5276,
-      "region_iso": "CMX",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Côte d'Ivoire | Côte d'Ivoire",
-      "country_alpha2": "CI",
-      "country_alpha3": "CIV",
-      "document_type": "DLD",
-      "id": 5487,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Morocco | المغرب",
-      "country_alpha2": "MA",
-      "country_alpha3": "MAR",
-      "document_type": "DLD",
-      "id": 5494,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Namibia",
-      "country_alpha2": "NA",
-      "country_alpha3": "NAM",
-      "document_type": "DLD",
-      "id": 5496,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Morocco | المغرب",
-      "country_alpha2": "MA",
-      "country_alpha3": "MAR",
-      "document_type": "DLD",
-      "id": 5498,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "South Africa | Suid-Afrika",
-      "country_alpha2": "ZA",
-      "country_alpha3": "ZAF",
-      "document_type": "DLD",
-      "id": 5508,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "South Africa | Suid-Afrika",
-      "country_alpha2": "ZA",
-      "country_alpha3": "ZAF",
-      "document_type": "DLD",
-      "id": 5509,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Tunisia | تونس",
-      "country_alpha2": "TN",
-      "country_alpha3": "TUN",
-      "document_type": "DLD",
-      "id": 5514,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Tunisia | تونس",
-      "country_alpha2": "TN",
-      "country_alpha3": "TUN",
-      "document_type": "DLD",
-      "id": 5515,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Bahamas",
-      "country_alpha2": "BS",
-      "country_alpha3": "BHS",
-      "document_type": "DLD",
-      "id": 5524,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "El Salvador",
-      "country_alpha2": "SV",
-      "country_alpha3": "SLV",
-      "document_type": "DLD",
-      "id": 5553,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "El Salvador",
-      "country_alpha2": "SV",
-      "country_alpha3": "SLV",
-      "document_type": "DLD",
-      "id": 5554,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Guatemala",
-      "country_alpha2": "GT",
-      "country_alpha3": "GTM",
-      "document_type": "DLD",
-      "id": 5556,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Puerto Rico",
-      "country_alpha2": "PR",
-      "country_alpha3": "PRI",
-      "document_type": "DLD",
-      "id": 5570,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2019"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Saint Barthélemy | Saint-Barthélemy",
-      "country_alpha2": "BL",
-      "country_alpha3": "BLM",
-      "document_type": "DLD",
-      "id": 5573,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Trinidad and Tobago",
-      "country_alpha2": "TT",
-      "country_alpha3": "TTO",
-      "document_type": "DLD",
-      "id": 5577,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2000"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "United States of America",
       "country_alpha2": "US",
       "country_alpha3": "USA",
@@ -5759,54 +8113,6 @@
         "verify"
       ],
       "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "American Samoa",
-      "country_alpha2": "AS",
-      "country_alpha3": "ASM",
-      "document_type": "DLD",
-      "id": 5590,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1997"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "American Samoa",
-      "country_alpha2": "AS",
-      "country_alpha3": "ASM",
-      "document_type": "DLD",
-      "id": 5591,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "American Samoa",
-      "country_alpha2": "AS",
-      "country_alpha3": "ASM",
-      "document_type": "DLD",
-      "id": 5592,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003-2"
     }
   },
   {
@@ -5983,70 +8289,6 @@
         "verify"
       ],
       "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Guam | Guåhån",
-      "country_alpha2": "GU",
-      "country_alpha3": "GUM",
-      "document_type": "DLD",
-      "id": 5607,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2002"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Guam | Guåhån",
-      "country_alpha2": "GU",
-      "country_alpha3": "GUM",
-      "document_type": "DLD",
-      "id": 5608,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Guam | Guåhån",
-      "country_alpha2": "GU",
-      "country_alpha3": "GUM",
-      "document_type": "DLD",
-      "id": 5609,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2005"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Guam | Guåhån",
-      "country_alpha2": "GU",
-      "country_alpha3": "GUM",
-      "document_type": "DLD",
-      "id": 5610,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
     }
   },
   {
@@ -7125,22 +9367,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Northern Mariana Islands | Notte Mariånas",
-      "country_alpha2": "MP",
-      "country_alpha3": "MNP",
-      "document_type": "DLD",
-      "id": 5690,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "United States of America",
       "country_alpha2": "US",
       "country_alpha3": "USA",
@@ -7871,903 +10097,6 @@
         "verify"
       ],
       "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Bolivia (Plurinational State of) | Bolivia",
-      "country_alpha2": "BO",
-      "country_alpha3": "BOL",
-      "document_type": "DLD",
-      "id": 5800,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Colombia",
-      "country_alpha2": "CO",
-      "country_alpha3": "COL",
-      "document_type": "DLD",
-      "id": 5803,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Colombia",
-      "country_alpha2": "CO",
-      "country_alpha3": "COL",
-      "document_type": "DLD",
-      "id": 5804,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Colombia",
-      "country_alpha2": "CO",
-      "country_alpha3": "COL",
-      "document_type": "DLD",
-      "id": 5805,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Peru | Perú",
-      "country_alpha2": "PE",
-      "country_alpha3": "PER",
-      "document_type": "DLD",
-      "id": 5814,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1992"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Peru | Perú",
-      "country_alpha2": "PE",
-      "country_alpha3": "PER",
-      "document_type": "DLD",
-      "id": 5815,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Peru | Perú",
-      "country_alpha2": "PE",
-      "country_alpha3": "PER",
-      "document_type": "DLD",
-      "id": 5816,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Uruguay",
-      "country_alpha2": "UY",
-      "country_alpha3": "URY",
-      "document_type": "DLD",
-      "id": 5818,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Uruguay",
-      "country_alpha2": "UY",
-      "country_alpha3": "URY",
-      "document_type": "DLD",
-      "id": 5820,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2019"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Uruguay",
-      "country_alpha2": "UY",
-      "country_alpha3": "URY",
-      "document_type": "DLD",
-      "id": 5821,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Azerbaijan | Azərbaycan",
-      "country_alpha2": "AZ",
-      "country_alpha3": "AZE",
-      "document_type": "DLD",
-      "id": 5869,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2001"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Azerbaijan | Azərbaycan",
-      "country_alpha2": "AZ",
-      "country_alpha3": "AZE",
-      "document_type": "DLD",
-      "id": 5870,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Bangladesh | বাংলাদেশ",
-      "country_alpha2": "BD",
-      "country_alpha3": "BGD",
-      "document_type": "DLD",
-      "id": 5875,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012-1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Bangladesh | বাংলাদেশ",
-      "country_alpha2": "BD",
-      "country_alpha3": "BGD",
-      "document_type": "DLD",
-      "id": 5876,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013-2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Hong Kong | 香港",
-      "country_alpha2": "HK",
-      "country_alpha3": "HKG",
-      "document_type": "DLD",
-      "id": 5881,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2005"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Jordan | الأردن",
-      "country_alpha2": "JO",
-      "country_alpha3": "JOR",
-      "document_type": "DLD",
-      "id": 5900,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "4"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Jordan | الأردن",
-      "country_alpha2": "JO",
-      "country_alpha3": "JOR",
-      "document_type": "DLD",
-      "id": 5901,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "3"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Jordan | الأردن",
-      "country_alpha2": "JO",
-      "country_alpha3": "JOR",
-      "document_type": "DLD",
-      "id": 5902,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Kuwait | دولة الكويت",
-      "country_alpha2": "KW",
-      "country_alpha3": "KWT",
-      "document_type": "DLD",
-      "id": 5906,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "3"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Malaysia",
-      "country_alpha2": "MY",
-      "country_alpha3": "MYS",
-      "document_type": "DLD",
-      "id": 5911,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Malaysia",
-      "country_alpha2": "MY",
-      "country_alpha3": "MYS",
-      "document_type": "DLD",
-      "id": 5912,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "3"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Malaysia",
-      "country_alpha2": "MY",
-      "country_alpha3": "MYS",
-      "document_type": "DLD",
-      "id": 5913,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "4"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Oman | عمان",
-      "country_alpha2": "OM",
-      "country_alpha3": "OMN",
-      "document_type": "DLD",
-      "id": 5917,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Philippines | Pilipinas",
-      "country_alpha2": "PH",
-      "country_alpha3": "PHL",
-      "document_type": "DLD",
-      "id": 5924,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Saudi Arabia | السعودية",
-      "country_alpha2": "SA",
-      "country_alpha3": "SAU",
-      "document_type": "DLD",
-      "id": 5933,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Saudi Arabia | السعودية",
-      "country_alpha2": "SA",
-      "country_alpha3": "SAU",
-      "document_type": "DLD",
-      "id": 5934,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "3"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Saudi Arabia | السعودية",
-      "country_alpha2": "SA",
-      "country_alpha3": "SAU",
-      "document_type": "DLD",
-      "id": 5935,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "4"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Singapore",
-      "country_alpha2": "SG",
-      "country_alpha3": "SGP",
-      "document_type": "DLD",
-      "id": 5939,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Sri Lanka | ශ්‍රී ලංකාව",
-      "country_alpha2": "LK",
-      "country_alpha3": "LKA",
-      "document_type": "DLD",
-      "id": 5947,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2000"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Thailand | ประเทศไทย",
-      "country_alpha2": "TH",
-      "country_alpha3": "THA",
-      "document_type": "DLD",
-      "id": 5953,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Thailand | ประเทศไทย",
-      "country_alpha2": "TH",
-      "country_alpha3": "THA",
-      "document_type": "DLD",
-      "id": 5954,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United Arab Emirates | الإمارات العربية المتحدة",
-      "country_alpha2": "AE",
-      "country_alpha3": "ARE",
-      "document_type": "DLD",
-      "id": 5957,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United Arab Emirates | الإمارات العربية المتحدة",
-      "country_alpha2": "AE",
-      "country_alpha3": "ARE",
-      "document_type": "DLD",
-      "id": 5958,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United Arab Emirates | الإمارات العربية المتحدة",
-      "country_alpha2": "AE",
-      "country_alpha3": "ARE",
-      "document_type": "DLD",
-      "id": 5959,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Australia",
-      "country_alpha2": "AU",
-      "country_alpha3": "AUS",
-      "document_type": "DLD",
-      "id": 5998,
-      "region_iso": "NT",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Australia",
-      "country_alpha2": "AU",
-      "country_alpha3": "AUS",
-      "document_type": "DLD",
-      "id": 5999,
-      "region_iso": "TAS",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Australia",
-      "country_alpha2": "AU",
-      "country_alpha3": "AUS",
-      "document_type": "DLD",
-      "id": 6000,
-      "region_iso": "TAS",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Australia",
-      "country_alpha2": "AU",
-      "country_alpha3": "AUS",
-      "document_type": "DLD",
-      "id": 6001,
-      "region_iso": "SA",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Costa Rica",
-      "country_alpha2": "CR",
-      "country_alpha3": "CRI",
-      "document_type": "DLD",
-      "id": 6024,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "",
-      "country": "Cyprus | Κύπρος",
-      "country_alpha2": "CY",
-      "country_alpha3": "CYP",
-      "document_type": "DLD",
-      "id": 6027,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Finland | Suomi",
-      "country_alpha2": "FI",
-      "country_alpha3": "FIN",
-      "document_type": "DLD",
-      "id": 6039,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1992"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Finland | Suomi",
-      "country_alpha2": "FI",
-      "country_alpha3": "FIN",
-      "document_type": "DLD",
-      "id": 6040,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2019"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Georgia | საქართველო",
-      "country_alpha2": "GE",
-      "country_alpha3": "GEO",
-      "document_type": "DLD",
-      "id": 6062,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1990"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "France",
-      "country_alpha2": "FR",
-      "country_alpha3": "FRA",
-      "document_type": "DLD",
-      "id": 6064,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013-2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Georgia | საქართველო",
-      "country_alpha2": "GE",
-      "country_alpha3": "GEO",
-      "document_type": "DLD",
-      "id": 6066,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Iceland | Ísland",
-      "country_alpha2": "IS",
-      "country_alpha3": "ISL",
-      "document_type": "DLD",
-      "id": 6087,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2001"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "paper",
-      "country": "Ireland | Éire",
-      "country_alpha2": "IE",
-      "country_alpha3": "IRL",
-      "document_type": "DLD",
-      "id": 6090,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Israel | ישראל",
-      "country_alpha2": "IL",
-      "country_alpha3": "ISR",
-      "document_type": "DLD",
-      "id": 6092,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Kosovo, Republic of",
-      "country_alpha2": "XK",
-      "country_alpha3": "RKS",
-      "document_type": "DLD",
-      "id": 6096,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Kosovo, Republic of",
-      "country_alpha2": "XK",
-      "country_alpha3": "RKS",
-      "document_type": "DLD",
-      "id": 6097,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Liechtenstein",
-      "country_alpha2": "LI",
-      "country_alpha3": "LIE",
-      "document_type": "DLD",
-      "id": 6102,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2019"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "DLD",
-      "id": 6105,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013-2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "DLD",
-      "id": 6106,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016-2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Moldova (Republic of)",
-      "country_alpha2": "MD",
-      "country_alpha3": "MDA",
-      "document_type": "DLD",
-      "id": 6113,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1995"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Slovakia | Slovensko",
-      "country_alpha2": "SK",
-      "country_alpha3": "SVK",
-      "document_type": "DLD",
-      "id": 6130,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Turkey | Türkiye",
-      "country_alpha2": "TR",
-      "country_alpha3": "TUR",
-      "document_type": "DLD",
-      "id": 6690,
-      "region_iso": null,
-      "usecases": [
-        "verify",
-        "driving_information"
-      ],
-      "version": "2016"
     }
   },
   {
@@ -9542,503 +10871,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Andorra",
-      "country_alpha2": "AD",
-      "country_alpha3": "AND",
-      "document_type": "DLD",
-      "id": 7019,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007 "
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Chile",
-      "country_alpha2": "CL",
-      "country_alpha3": "CHL",
-      "document_type": "DLD",
-      "id": 7151,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003 2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Chile",
-      "country_alpha2": "CL",
-      "country_alpha3": "CHL",
-      "document_type": "DLD",
-      "id": 7184,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003 1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Venezuela (Bolivarian Republic of)",
-      "country_alpha2": "VE",
-      "country_alpha3": "VEN",
-      "document_type": "DLD",
-      "id": 7217,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Ecuador",
-      "country_alpha2": "EC",
-      "country_alpha3": "ECU",
-      "document_type": "DLD",
-      "id": 7284,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "New Zealand | Aotearoa",
-      "country_alpha2": "NZ",
-      "country_alpha3": "NZL",
-      "document_type": "DLD",
-      "id": 7349,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Guernsey",
-      "country_alpha2": "GG",
-      "country_alpha3": "GGY",
-      "document_type": "DLD",
-      "id": 7415,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Ireland | Éire",
-      "country_alpha2": "IE",
-      "country_alpha3": "IRL",
-      "document_type": "DLD",
-      "id": 7451,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": ""
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Isle of Man",
-      "country_alpha2": "IM",
-      "country_alpha3": "IMN",
-      "document_type": "DLD",
-      "id": 7481,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Ghana",
-      "country_alpha2": "GH",
-      "country_alpha3": "GHA",
-      "document_type": "DLD",
-      "id": 8014,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017 "
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Uruguay",
-      "country_alpha2": "UY",
-      "country_alpha3": "URY",
-      "document_type": "DLD",
-      "id": 5819,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United Kingdom of Great Britain and Northern Ireland",
-      "country_alpha2": "GB",
-      "country_alpha3": "GBR",
-      "document_type": "DLD",
-      "id": 4205,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United Kingdom of Great Britain and Northern Ireland",
-      "country_alpha2": "GB",
-      "country_alpha3": "GBR",
-      "document_type": "DLD",
-      "id": 4206,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United Kingdom of Great Britain and Northern Ireland",
-      "country_alpha2": "GB",
-      "country_alpha3": "GBR",
-      "document_type": "DLD",
-      "id": 6138,
-      "region_iso": "NIR",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United Kingdom of Great Britain and Northern Ireland",
-      "country_alpha2": "GB",
-      "country_alpha3": "GBR",
-      "document_type": "DLD",
-      "id": 6139,
-      "region_iso": "NIR",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United Kingdom of Great Britain and Northern Ireland",
-      "country_alpha2": "GB",
-      "country_alpha3": "GBR",
-      "document_type": "DLD",
-      "id": 6140,
-      "region_iso": "NIR",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United Kingdom of Great Britain and Northern Ireland",
-      "country_alpha2": "GB",
-      "country_alpha3": "GBR",
-      "document_type": "DLD",
-      "id": 6141,
-      "region_iso": "NIR",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Switzerland | Schweiz",
-      "country_alpha2": "CH",
-      "country_alpha3": "CHE",
-      "document_type": "DLD",
-      "id": 8339,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Ireland | Éire",
-      "country_alpha2": "IE",
-      "country_alpha3": "IRL",
-      "document_type": "DLD",
-      "id": 3420,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "DLD",
-      "id": 3544,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Netherlands | Nederland",
-      "country_alpha2": "NL",
-      "country_alpha3": "NLD",
-      "document_type": "DLD",
-      "id": 3675,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Netherlands | Nederland",
-      "country_alpha2": "NL",
-      "country_alpha3": "NLD",
-      "document_type": "DLD",
-      "id": 3676,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "DLD",
-      "id": 3775,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1999"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Portugal",
-      "country_alpha2": "PT",
-      "country_alpha3": "PRT",
-      "document_type": "DLD",
-      "id": 3792,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1999"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Portugal",
-      "country_alpha2": "PT",
-      "country_alpha3": "PRT",
-      "document_type": "DLD",
-      "id": 3793,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Spain | España",
-      "country_alpha2": "ES",
-      "country_alpha3": "ESP",
-      "document_type": "DLD",
-      "id": 3894,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Switzerland | Schweiz",
-      "country_alpha2": "CH",
-      "country_alpha3": "CHE",
-      "document_type": "DLD",
-      "id": 3916,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United Kingdom of Great Britain and Northern Ireland",
-      "country_alpha2": "GB",
-      "country_alpha3": "GBR",
-      "document_type": "DLD",
-      "id": 3974,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1998"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United Kingdom of Great Britain and Northern Ireland",
-      "country_alpha2": "GB",
-      "country_alpha3": "GBR",
-      "document_type": "DLD",
-      "id": 3976,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United Kingdom of Great Britain and Northern Ireland",
-      "country_alpha2": "GB",
-      "country_alpha3": "GBR",
-      "document_type": "DLD",
-      "id": 3977,
-      "region_iso": null,
-      "usecases": [
-        "verify",
-        "driving_information"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United Kingdom of Great Britain and Northern Ireland",
-      "country_alpha2": "GB",
-      "country_alpha3": "GBR",
-      "document_type": "DLD",
-      "id": 3978,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "United States of America",
       "country_alpha2": "US",
       "country_alpha3": "USA",
@@ -10081,358 +10913,6 @@
         "verify"
       ],
       "version": "2000"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Denmark | Danmark",
-      "country_alpha2": "DK",
-      "country_alpha3": "DNK",
-      "document_type": "DLD",
-      "id": 4812,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 3121,
-      "region_iso": "QC",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 4213,
-      "region_iso": "AB",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 4218,
-      "region_iso": "NB",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 4221,
-      "region_iso": "PE",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 4222,
-      "region_iso": "QC",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 4223,
-      "region_iso": "SK",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 4224,
-      "region_iso": "SK",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 4935,
-      "region_iso": "ON",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 5057,
-      "region_iso": "YT",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 5058,
-      "region_iso": "NU",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 5063,
-      "region_iso": "NT",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 5194,
-      "region_iso": "MB",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 5271,
-      "region_iso": "NS",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 5531,
-      "region_iso": "BC",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 5545,
-      "region_iso": "NL",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 8108,
-      "region_iso": "HID",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Austria | Österreich",
-      "country_alpha2": "AT",
-      "country_alpha3": "AUT",
-      "document_type": "DLD",
-      "id": 4644,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1997"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 8131,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 8133,
-      "region_iso": "L",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 8135,
-      "region_iso": "A",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Korea (Republic of) | 한국",
-      "country_alpha2": "KR",
-      "country_alpha3": "KOR",
-      "document_type": "DLD",
-      "id": 8143,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2020"
     }
   },
   {
@@ -10513,102 +10993,6 @@
         "verify"
       ],
       "version": "2002"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 8127,
-      "region_iso": "X",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 8128,
-      "region_iso": "B",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 8129,
-      "region_iso": "B",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 8130,
-      "region_iso": "B",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 8134,
-      "region_iso": "Q",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 8136,
-      "region_iso": "H",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
     }
   },
   {
@@ -10725,358 +11109,6 @@
   },
   {
     "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Russian Federation | Россия",
-      "country_alpha2": "RU",
-      "country_alpha3": "RUS",
-      "document_type": "DLD",
-      "id": 3810,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1999"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Latvia | Latvija",
-      "country_alpha2": "LV",
-      "country_alpha3": "LVA",
-      "document_type": "DLD",
-      "id": 3513,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Liechtenstein",
-      "country_alpha2": "LI",
-      "country_alpha3": "LIE",
-      "document_type": "DLD",
-      "id": 3540,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Liechtenstein",
-      "country_alpha2": "LI",
-      "country_alpha3": "LIE",
-      "document_type": "DLD",
-      "id": 3541,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Luxembourg | Luxemburg",
-      "country_alpha2": "LU",
-      "country_alpha3": "LUX",
-      "document_type": "DLD",
-      "id": 3565,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Italy | Italia",
-      "country_alpha2": "IT",
-      "country_alpha3": "ITA",
-      "document_type": "DLD",
-      "id": 4141,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Russian Federation | Россия",
-      "country_alpha2": "RU",
-      "country_alpha3": "RUS",
-      "document_type": "DLD",
-      "id": 4185,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Russian Federation | Россия",
-      "country_alpha2": "RU",
-      "country_alpha3": "RUS",
-      "document_type": "DLD",
-      "id": 4186,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Norway | Norge",
-      "country_alpha2": "NO",
-      "country_alpha3": "NOR",
-      "document_type": "DLD",
-      "id": 4559,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Estonia | Eesti",
-      "country_alpha2": "EE",
-      "country_alpha3": "EST",
-      "document_type": "DLD",
-      "id": 4564,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Germany | Deutschland",
-      "country_alpha2": "DE",
-      "country_alpha3": "DEU",
-      "document_type": "DLD",
-      "id": 6069,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2005"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Germany | Deutschland",
-      "country_alpha2": "DE",
-      "country_alpha3": "DEU",
-      "document_type": "DLD",
-      "id": 6070,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "DLD",
-      "id": 760,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "DLD",
-      "id": 761,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Jersey",
-      "country_alpha2": "JE",
-      "country_alpha3": "JEY",
-      "document_type": "DLD",
-      "id": 3464,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Latvia | Latvija",
-      "country_alpha2": "LV",
-      "country_alpha3": "LVA",
-      "document_type": "DLD",
-      "id": 3514,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Slovenia | Slovenija",
-      "country_alpha2": "SI",
-      "country_alpha3": "SVN",
-      "document_type": "DLD",
-      "id": 3869,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "DLD",
-      "id": 4148,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "DLD",
-      "id": 4153,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Netherlands | Nederland",
-      "country_alpha2": "NL",
-      "country_alpha3": "NLD",
-      "document_type": "DLD",
-      "id": 4164,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "DLD",
-      "id": 4172,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Russian Federation | Россия",
-      "country_alpha2": "RU",
-      "country_alpha3": "RUS",
-      "document_type": "DLD",
-      "id": 4184,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
       "back_required": true,
       "common_name": null,
       "country": "United States of America",
@@ -11101,22 +11133,6 @@
       "document_type": "DLD",
       "id": 4242,
       "region_iso": "ND",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Ukraine | Ukraїna",
-      "country_alpha2": "UA",
-      "country_alpha3": "UKR",
-      "document_type": "DLD",
-      "id": 4569,
-      "region_iso": null,
       "usecases": [
         "verify"
       ],
@@ -11173,38 +11189,6 @@
   },
   {
     "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "DLD",
-      "id": 5047,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Montenegro | Crna Gora",
-      "country_alpha2": "ME",
-      "country_alpha3": "MNE",
-      "document_type": "DLD",
-      "id": 5135,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
       "back_required": true,
       "common_name": null,
       "country": "United States of America",
@@ -11229,54 +11213,6 @@
       "document_type": "DLD",
       "id": 5646,
       "region_iso": "MI",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Northern Mariana Islands | Notte Mariånas",
-      "country_alpha2": "MP",
-      "country_alpha3": "MNP",
-      "document_type": "DLD",
-      "id": 5689,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Albania | Shqipëria",
-      "country_alpha2": "AL",
-      "country_alpha3": "ALB",
-      "document_type": "DLD",
-      "id": 5996,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Bosnia and Herzegovina | Bosna i Hercegovina",
-      "country_alpha2": "BA",
-      "country_alpha3": "BIH",
-      "document_type": "DLD",
-      "id": 6022,
-      "region_iso": null,
       "usecases": [
         "verify"
       ],
@@ -11325,54 +11261,6 @@
       "document_type": "DLD",
       "id": 6858,
       "region_iso": "OH",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Isle of Man",
-      "country_alpha2": "IM",
-      "country_alpha3": "IMN",
-      "document_type": "DLD",
-      "id": 7482,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "DLD",
-      "id": 7715,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Latvia | Latvija",
-      "country_alpha2": "LV",
-      "country_alpha3": "LVA",
-      "document_type": "DLD",
-      "id": 7813,
-      "region_iso": null,
       "usecases": [
         "verify"
       ],
@@ -11461,86 +11349,6 @@
   },
   {
     "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "DLD",
-      "id": 8200,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "DLD",
-      "id": 8201,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Faroe Islands | Føroyar",
-      "country_alpha2": "FO",
-      "country_alpha3": "FRO",
-      "document_type": "DLD",
-      "id": 8207,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Faroe Islands | Føroyar",
-      "country_alpha2": "FO",
-      "country_alpha3": "FRO",
-      "document_type": "DLD",
-      "id": 8208,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 8570,
-      "region_iso": "CMX",
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
       "back_required": true,
       "common_name": null,
       "country": "United States of America",
@@ -11569,6 +11377,198 @@
         "verify"
       ],
       "version": "2019"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Uruguay",
+      "country_alpha2": "UY",
+      "country_alpha3": "URY",
+      "document_type": "DLD",
+      "id": 5053,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "v1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Uruguay",
+      "country_alpha2": "UY",
+      "country_alpha3": "URY",
+      "document_type": "DLD",
+      "id": 5818,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Uruguay",
+      "country_alpha2": "UY",
+      "country_alpha3": "URY",
+      "document_type": "DLD",
+      "id": 5820,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2019"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Uruguay",
+      "country_alpha2": "UY",
+      "country_alpha3": "URY",
+      "document_type": "DLD",
+      "id": 5821,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Uruguay",
+      "country_alpha2": "UY",
+      "country_alpha3": "URY",
+      "document_type": "DLD",
+      "id": 5819,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Venezuela (Bolivarian Republic of)",
+      "country_alpha2": "VE",
+      "country_alpha3": "VEN",
+      "document_type": "DLD",
+      "id": 4743,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Venezuela (Bolivarian Republic of)",
+      "country_alpha2": "VE",
+      "country_alpha3": "VEN",
+      "document_type": "DLD",
+      "id": 4744,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Venezuela (Bolivarian Republic of)",
+      "country_alpha2": "VE",
+      "country_alpha3": "VEN",
+      "document_type": "DLD",
+      "id": 7217,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Viet Nam | Việt Nam",
+      "country_alpha2": "VN",
+      "country_alpha3": "VNM",
+      "document_type": "DLD",
+      "id": 4208,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Viet Nam | Việt Nam",
+      "country_alpha2": "VN",
+      "country_alpha3": "VNM",
+      "document_type": "DLD",
+      "id": 4209,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Yemen | اليمن",
+      "country_alpha2": "YE",
+      "country_alpha3": "YEM",
+      "document_type": "DLD",
+      "id": 5183,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Zambia",
+      "country_alpha2": "ZM",
+      "country_alpha3": "ZMB",
+      "document_type": "DLD",
+      "id": 5016,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
     }
   }
 ]

--- a/src/supported-documents/supported-docs-driving_licence.json
+++ b/src/supported-documents/supported-docs-driving_licence.json
@@ -661,22 +661,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Austria | Österreich",
-      "country_alpha2": "AT",
-      "country_alpha3": "AUT",
-      "document_type": "DLD",
-      "id": 4644,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1997"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "New Zealand | Aotearoa",
       "country_alpha2": "NZ",
       "country_alpha3": "NZL",
@@ -1141,278 +1125,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 8127,
-      "region_iso": "X",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 8128,
-      "region_iso": "B",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 8129,
-      "region_iso": "B",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 8130,
-      "region_iso": "B",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 8131,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 8133,
-      "region_iso": "L",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 8134,
-      "region_iso": "Q",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 8135,
-      "region_iso": "A",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "DLD",
-      "id": 8136,
-      "region_iso": "H",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Korea (Republic of) | 한국",
-      "country_alpha2": "KR",
-      "country_alpha3": "KOR",
-      "document_type": "DLD",
-      "id": 8143,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 8144,
-      "region_iso": "AR",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 8145,
-      "region_iso": "AR",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 8147,
-      "region_iso": "DC",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 8148,
-      "region_iso": "DC",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 8149,
-      "region_iso": "DC",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 8150,
-      "region_iso": "DC",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 8175,
-      "region_iso": "HI",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "United States of America",
       "country_alpha2": "US",
       "country_alpha3": "USA",
@@ -1451,118 +1163,6 @@
       "document_type": "DLD",
       "id": 8179,
       "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 8180,
-      "region_iso": "ME",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 8181,
-      "region_iso": "MI",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 8182,
-      "region_iso": "OR",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 8183,
-      "region_iso": "OR",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 8184,
-      "region_iso": "OR",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 8185,
-      "region_iso": "PA",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 8186,
-      "region_iso": "WA",
       "usecases": [
         "verify"
       ],
@@ -1637,38 +1237,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "DLD",
-      "id": 8200,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "DLD",
-      "id": 8201,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "Belarus | Беларусь",
       "country_alpha2": "BY",
       "country_alpha3": "BLR",
@@ -1699,54 +1267,6 @@
   },
   {
     "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Liechtenstein",
-      "country_alpha2": "LI",
-      "country_alpha3": "LIE",
-      "document_type": "DLD",
-      "id": 3540,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Liechtenstein",
-      "country_alpha2": "LI",
-      "country_alpha3": "LIE",
-      "document_type": "DLD",
-      "id": 3541,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Russian Federation | Россия",
-      "country_alpha2": "RU",
-      "country_alpha3": "RUS",
-      "document_type": "DLD",
-      "id": 3810,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1999"
-    }
-  },
-  {
-    "sourceData": {
       "back_required": false,
       "common_name": null,
       "country": "Russian Federation | Россия",
@@ -1759,22 +1279,6 @@
         "verify"
       ],
       "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Slovenia | Slovenija",
-      "country_alpha2": "SI",
-      "country_alpha3": "SVN",
-      "document_type": "DLD",
-      "id": 3869,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
     }
   },
   {
@@ -1807,54 +1311,6 @@
         "verify"
       ],
       "version": "1996"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Russian Federation | Россия",
-      "country_alpha2": "RU",
-      "country_alpha3": "RUS",
-      "document_type": "DLD",
-      "id": 4184,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Russian Federation | Россия",
-      "country_alpha2": "RU",
-      "country_alpha3": "RUS",
-      "document_type": "DLD",
-      "id": 4185,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Russian Federation | Россия",
-      "country_alpha2": "RU",
-      "country_alpha3": "RUS",
-      "document_type": "DLD",
-      "id": 4186,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
     }
   },
   {
@@ -1919,22 +1375,6 @@
         "verify"
       ],
       "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Ukraine | Ukraїna",
-      "country_alpha2": "UA",
-      "country_alpha3": "UKR",
-      "document_type": "DLD",
-      "id": 4569,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
     }
   },
   {
@@ -2063,38 +1503,6 @@
         "verify"
       ],
       "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Germany | Deutschland",
-      "country_alpha2": "DE",
-      "country_alpha3": "DEU",
-      "document_type": "DLD",
-      "id": 6069,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2005"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Germany | Deutschland",
-      "country_alpha2": "DE",
-      "country_alpha3": "DEU",
-      "document_type": "DLD",
-      "id": 6070,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
     }
   },
   {
@@ -2383,22 +1791,6 @@
         "verify"
       ],
       "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 3121,
-      "region_iso": "QC",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
     }
   },
   {
@@ -2741,22 +2133,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Jersey",
-      "country_alpha2": "JE",
-      "country_alpha3": "JEY",
-      "document_type": "DLD",
-      "id": 3464,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "Kazakhstan | Қазақстан",
       "country_alpha2": "KZ",
       "country_alpha3": "KAZ",
@@ -2771,38 +2147,6 @@
   },
   {
     "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Latvia | Latvija",
-      "country_alpha2": "LV",
-      "country_alpha3": "LVA",
-      "document_type": "DLD",
-      "id": 3513,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Latvia | Latvija",
-      "country_alpha2": "LV",
-      "country_alpha3": "LVA",
-      "document_type": "DLD",
-      "id": 3514,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
       "back_required": true,
       "common_name": null,
       "country": "Lithuania | Lietuva",
@@ -2810,22 +2154,6 @@
       "country_alpha3": "LTU",
       "document_type": "DLD",
       "id": 3545,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Luxembourg | Luxemburg",
-      "country_alpha2": "LU",
-      "country_alpha3": "LUX",
-      "document_type": "DLD",
-      "id": 3565,
       "region_iso": null,
       "usecases": [
         "verify"
@@ -3317,70 +2645,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Italy | Italia",
-      "country_alpha2": "IT",
-      "country_alpha3": "ITA",
-      "document_type": "DLD",
-      "id": 4141,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "DLD",
-      "id": 4148,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2005"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "DLD",
-      "id": 4153,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Netherlands | Nederland",
-      "country_alpha2": "NL",
-      "country_alpha3": "NLD",
-      "document_type": "DLD",
-      "id": 4164,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "Philippines | Pilipinas",
       "country_alpha2": "PH",
       "country_alpha3": "PHL",
@@ -3407,22 +2671,6 @@
         "verify"
       ],
       "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "DLD",
-      "id": 4172,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
     }
   },
   {
@@ -3567,102 +2815,6 @@
         "verify"
       ],
       "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 4213,
-      "region_iso": "AB",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 4218,
-      "region_iso": "NB",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 4221,
-      "region_iso": "PE",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 4222,
-      "region_iso": "QC",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 4223,
-      "region_iso": "SK",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 4224,
-      "region_iso": "SK",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
     }
   },
   {
@@ -3875,38 +3027,6 @@
   },
   {
     "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 4241,
-      "region_iso": "NM",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 4242,
-      "region_iso": "ND",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
       "back_required": false,
       "common_name": null,
       "country": "United States of America",
@@ -4085,38 +3205,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Norway | Norge",
-      "country_alpha2": "NO",
-      "country_alpha3": "NOR",
-      "document_type": "DLD",
-      "id": 4559,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Estonia | Eesti",
-      "country_alpha2": "EE",
-      "country_alpha3": "EST",
-      "document_type": "DLD",
-      "id": 4564,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "Latvia | Latvija",
       "country_alpha2": "LV",
       "country_alpha3": "LVA",
@@ -4245,22 +3333,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Denmark | Danmark",
-      "country_alpha2": "DK",
-      "country_alpha3": "DNK",
-      "document_type": "DLD",
-      "id": 4812,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "Nigeria | Nijeriya",
       "country_alpha2": "NG",
       "country_alpha3": "NGA",
@@ -4345,22 +3417,6 @@
       "country_alpha2": "US",
       "country_alpha3": "USA",
       "document_type": "DLD",
-      "id": 4896,
-      "region_iso": "FL",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
       "id": 4897,
       "region_iso": "FL",
       "usecases": [
@@ -4383,22 +3439,6 @@
         "verify"
       ],
       "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 4900,
-      "region_iso": "FL",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
     }
   },
   {
@@ -4522,22 +3562,6 @@
       "country_alpha3": "USA",
       "document_type": "DLD",
       "id": 4911,
-      "region_iso": "WA",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 4912,
       "region_iso": "WA",
       "usecases": [
         "verify"
@@ -4863,22 +3887,6 @@
         "verify"
       ],
       "version": "2005"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 4935,
-      "region_iso": "ON",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
     }
   },
   {
@@ -5231,54 +4239,6 @@
         "verify"
       ],
       "version": ""
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 5057,
-      "region_iso": "YT",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 5058,
-      "region_iso": "NU",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 5063,
-      "region_iso": "NT",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
     }
   },
   {
@@ -5705,22 +4665,6 @@
       "country_alpha2": "US",
       "country_alpha3": "USA",
       "document_type": "DLD",
-      "id": 5109,
-      "region_iso": "AK",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
       "id": 5110,
       "region_iso": "AR",
       "usecases": [
@@ -5759,22 +4703,6 @@
         "verify"
       ],
       "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Montenegro | Crna Gora",
-      "country_alpha2": "ME",
-      "country_alpha3": "MNE",
-      "document_type": "DLD",
-      "id": 5135,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
     }
   },
   {
@@ -6031,22 +4959,6 @@
         "verify"
       ],
       "version": ""
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 5194,
-      "region_iso": "MB",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
     }
   },
   {
@@ -6435,22 +5347,6 @@
   },
   {
     "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 5246,
-      "region_iso": "OR",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
       "back_required": false,
       "common_name": null,
       "country": "United States of America",
@@ -6575,22 +5471,6 @@
         "verify"
       ],
       "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 5271,
-      "region_iso": "NS",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
     }
   },
   {
@@ -6757,38 +5637,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 5531,
-      "region_iso": "BC",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "DLD",
-      "id": 5545,
-      "region_iso": "NL",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "El Salvador",
       "country_alpha2": "SV",
       "country_alpha3": "SLV",
@@ -6911,22 +5759,6 @@
         "verify"
       ],
       "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 5587,
-      "region_iso": "AK",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
     }
   },
   {
@@ -7683,22 +6515,6 @@
   },
   {
     "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 5646,
-      "region_iso": "MI",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
       "back_required": true,
       "common_name": null,
       "country": "United States of America",
@@ -8303,22 +7119,6 @@
         "verify"
       ],
       "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Northern Mariana Islands | Notte Mariånas",
-      "country_alpha2": "MP",
-      "country_alpha3": "MNP",
-      "document_type": "DLD",
-      "id": 5689,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2005"
     }
   },
   {
@@ -9621,22 +8421,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Albania | Shqipëria",
-      "country_alpha2": "AL",
-      "country_alpha3": "ALB",
-      "document_type": "DLD",
-      "id": 5996,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "Australia",
       "country_alpha2": "AU",
       "country_alpha3": "AUS",
@@ -9695,22 +8479,6 @@
         "verify"
       ],
       "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Bosnia and Herzegovina | Bosna i Hercegovina",
-      "country_alpha2": "BA",
-      "country_alpha3": "BIH",
-      "document_type": "DLD",
-      "id": 6022,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
     }
   },
   {
@@ -10196,38 +8964,6 @@
   },
   {
     "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 6790,
-      "region_iso": "IA",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 6792,
-      "region_iso": "IA",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
       "back_required": false,
       "common_name": null,
       "country": "United States of America",
@@ -10544,22 +9280,6 @@
         "verify"
       ],
       "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "DLD",
-      "id": 6858,
-      "region_iso": "OH",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
     }
   },
   {
@@ -10966,38 +9686,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Isle of Man",
-      "country_alpha2": "IM",
-      "country_alpha3": "IMN",
-      "document_type": "DLD",
-      "id": 7482,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Latvia | Latvija",
-      "country_alpha2": "LV",
-      "country_alpha3": "LVA",
-      "document_type": "DLD",
-      "id": 7813,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "Ghana",
       "country_alpha2": "GH",
       "country_alpha3": "GHA",
@@ -11008,38 +9696,6 @@
         "verify"
       ],
       "version": "2017 "
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Faroe Islands | Føroyar",
-      "country_alpha2": "FO",
-      "country_alpha3": "FRO",
-      "document_type": "DLD",
-      "id": 8207,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Faroe Islands | Føroyar",
-      "country_alpha2": "FO",
-      "country_alpha3": "FRO",
-      "document_type": "DLD",
-      "id": 8208,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
     }
   },
   {
@@ -11056,22 +9712,6 @@
         "verify"
       ],
       "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "DLD",
-      "id": 761,
-      "region_iso": "SP",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
     }
   },
   {
@@ -11100,22 +9740,6 @@
       "document_type": "DLD",
       "id": 4206,
       "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "DLD",
-      "id": 5047,
-      "region_iso": "SP",
       "usecases": [
         "verify"
       ],
@@ -11190,22 +9814,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Mexico | México",
-      "country_alpha2": "MX",
-      "country_alpha3": "MEX",
-      "document_type": "DLD",
-      "id": 8108,
-      "region_iso": "HID",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "Switzerland | Schweiz",
       "country_alpha2": "CH",
       "country_alpha3": "CHE",
@@ -11216,22 +9824,6 @@
         "verify"
       ],
       "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "DLD",
-      "id": 760,
-      "region_iso": "RJ",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2002"
     }
   },
   {
@@ -11495,6 +10087,614 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
+      "country": "Denmark | Danmark",
+      "country_alpha2": "DK",
+      "country_alpha3": "DNK",
+      "document_type": "DLD",
+      "id": 4812,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 3121,
+      "region_iso": "QC",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 4213,
+      "region_iso": "AB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 4218,
+      "region_iso": "NB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 4221,
+      "region_iso": "PE",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 4222,
+      "region_iso": "QC",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 4223,
+      "region_iso": "SK",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 4224,
+      "region_iso": "SK",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 4935,
+      "region_iso": "ON",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 5057,
+      "region_iso": "YT",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 5058,
+      "region_iso": "NU",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 5063,
+      "region_iso": "NT",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 5194,
+      "region_iso": "MB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 5271,
+      "region_iso": "NS",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 5531,
+      "region_iso": "BC",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "DLD",
+      "id": 5545,
+      "region_iso": "NL",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 8108,
+      "region_iso": "HID",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Austria | Österreich",
+      "country_alpha2": "AT",
+      "country_alpha3": "AUT",
+      "document_type": "DLD",
+      "id": 4644,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1997"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 8131,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 8133,
+      "region_iso": "L",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 8135,
+      "region_iso": "A",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Korea (Republic of) | 한국",
+      "country_alpha2": "KR",
+      "country_alpha3": "KOR",
+      "document_type": "DLD",
+      "id": 8143,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2020"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 8144,
+      "region_iso": "AR",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2006"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 8145,
+      "region_iso": "AR",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2002"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 8148,
+      "region_iso": "DC",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2002"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 8149,
+      "region_iso": "DC",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2002"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 8150,
+      "region_iso": "DC",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2002"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 8127,
+      "region_iso": "X",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 8128,
+      "region_iso": "B",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 8129,
+      "region_iso": "B",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 8130,
+      "region_iso": "B",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 8134,
+      "region_iso": "Q",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "DLD",
+      "id": 8136,
+      "region_iso": "H",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 8147,
+      "region_iso": "DC",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013-2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 8175,
+      "region_iso": "HI",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 8180,
+      "region_iso": "ME",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 5109,
+      "region_iso": "AK",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 5587,
+      "region_iso": "AK",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
       "country": "United States of America",
       "country_alpha2": "US",
       "country_alpha3": "USA",
@@ -11504,7 +10704,871 @@
       "usecases": [
         "verify"
       ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 8181,
+      "region_iso": "MI",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2000"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Russian Federation | Россия",
+      "country_alpha2": "RU",
+      "country_alpha3": "RUS",
+      "document_type": "DLD",
+      "id": 3810,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1999"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Latvia | Latvija",
+      "country_alpha2": "LV",
+      "country_alpha3": "LVA",
+      "document_type": "DLD",
+      "id": 3513,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2006"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Liechtenstein",
+      "country_alpha2": "LI",
+      "country_alpha3": "LIE",
+      "document_type": "DLD",
+      "id": 3540,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Liechtenstein",
+      "country_alpha2": "LI",
+      "country_alpha3": "LIE",
+      "document_type": "DLD",
+      "id": 3541,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Luxembourg | Luxemburg",
+      "country_alpha2": "LU",
+      "country_alpha3": "LUX",
+      "document_type": "DLD",
+      "id": 3565,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Italy | Italia",
+      "country_alpha2": "IT",
+      "country_alpha3": "ITA",
+      "document_type": "DLD",
+      "id": 4141,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Russian Federation | Россия",
+      "country_alpha2": "RU",
+      "country_alpha3": "RUS",
+      "document_type": "DLD",
+      "id": 4185,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Russian Federation | Россия",
+      "country_alpha2": "RU",
+      "country_alpha3": "RUS",
+      "document_type": "DLD",
+      "id": 4186,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Norway | Norge",
+      "country_alpha2": "NO",
+      "country_alpha3": "NOR",
+      "document_type": "DLD",
+      "id": 4559,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Estonia | Eesti",
+      "country_alpha2": "EE",
+      "country_alpha3": "EST",
+      "document_type": "DLD",
+      "id": 4564,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Germany | Deutschland",
+      "country_alpha2": "DE",
+      "country_alpha3": "DEU",
+      "document_type": "DLD",
+      "id": 6069,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2005"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Germany | Deutschland",
+      "country_alpha2": "DE",
+      "country_alpha3": "DEU",
+      "document_type": "DLD",
+      "id": 6070,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "DLD",
+      "id": 760,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
       "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "DLD",
+      "id": 761,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Jersey",
+      "country_alpha2": "JE",
+      "country_alpha3": "JEY",
+      "document_type": "DLD",
+      "id": 3464,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Latvia | Latvija",
+      "country_alpha2": "LV",
+      "country_alpha3": "LVA",
+      "document_type": "DLD",
+      "id": 3514,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Slovenia | Slovenija",
+      "country_alpha2": "SI",
+      "country_alpha3": "SVN",
+      "document_type": "DLD",
+      "id": 3869,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "DLD",
+      "id": 4148,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "DLD",
+      "id": 4153,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Netherlands | Nederland",
+      "country_alpha2": "NL",
+      "country_alpha3": "NLD",
+      "document_type": "DLD",
+      "id": 4164,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "DLD",
+      "id": 4172,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Russian Federation | Россия",
+      "country_alpha2": "RU",
+      "country_alpha3": "RUS",
+      "document_type": "DLD",
+      "id": 4184,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 4241,
+      "region_iso": "NM",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 4242,
+      "region_iso": "ND",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Ukraine | Ukraїna",
+      "country_alpha2": "UA",
+      "country_alpha3": "UKR",
+      "document_type": "DLD",
+      "id": 4569,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 4896,
+      "region_iso": "FL",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 4900,
+      "region_iso": "FL",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 4912,
+      "region_iso": "WA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "DLD",
+      "id": 5047,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Montenegro | Crna Gora",
+      "country_alpha2": "ME",
+      "country_alpha3": "MNE",
+      "document_type": "DLD",
+      "id": 5135,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 5246,
+      "region_iso": "OR",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 5646,
+      "region_iso": "MI",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Northern Mariana Islands | Notte Mariånas",
+      "country_alpha2": "MP",
+      "country_alpha3": "MNP",
+      "document_type": "DLD",
+      "id": 5689,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Albania | Shqipëria",
+      "country_alpha2": "AL",
+      "country_alpha3": "ALB",
+      "document_type": "DLD",
+      "id": 5996,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Bosnia and Herzegovina | Bosna i Hercegovina",
+      "country_alpha2": "BA",
+      "country_alpha3": "BIH",
+      "document_type": "DLD",
+      "id": 6022,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 6790,
+      "region_iso": "IA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 6792,
+      "region_iso": "IA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 6858,
+      "region_iso": "OH",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Isle of Man",
+      "country_alpha2": "IM",
+      "country_alpha3": "IMN",
+      "document_type": "DLD",
+      "id": 7482,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "DLD",
+      "id": 7715,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Latvia | Latvija",
+      "country_alpha2": "LV",
+      "country_alpha3": "LVA",
+      "document_type": "DLD",
+      "id": 7813,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 8182,
+      "region_iso": "OR",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 8183,
+      "region_iso": "OR",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 8184,
+      "region_iso": "OR",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 8185,
+      "region_iso": "PA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 8186,
+      "region_iso": "WA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "DLD",
+      "id": 8200,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "DLD",
+      "id": 8201,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Faroe Islands | Føroyar",
+      "country_alpha2": "FO",
+      "country_alpha3": "FRO",
+      "document_type": "DLD",
+      "id": 8207,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Faroe Islands | Føroyar",
+      "country_alpha2": "FO",
+      "country_alpha3": "FRO",
+      "document_type": "DLD",
+      "id": 8208,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mexico | México",
+      "country_alpha2": "MX",
+      "country_alpha3": "MEX",
+      "document_type": "DLD",
+      "id": 8570,
+      "region_iso": "CMX",
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 8607,
+      "region_iso": "VI",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2006"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "DLD",
+      "id": 8608,
+      "region_iso": "VI",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2019"
     }
   }
 ]

--- a/src/supported-documents/supported-docs-national_identity_card.json
+++ b/src/supported-documents/supported-docs-national_identity_card.json
@@ -2,17 +2,3058 @@
   {
     "sourceData": {
       "back_required": false,
-      "common_name": "State Identity Card",
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
+      "common_name": null,
+      "country": "Albania | Shqipëria",
+      "country_alpha2": "AL",
+      "country_alpha3": "ALB",
       "document_type": "NIC",
-      "id": 3997,
-      "region_iso": "AZ",
+      "id": 2920,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Algeria | الجزائر",
+      "country_alpha2": "DZ",
+      "country_alpha3": "DZA",
+      "document_type": "NIC",
+      "id": 4981,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Angola | Ngola",
+      "country_alpha2": "AO",
+      "country_alpha3": "AGO",
+      "document_type": "NIC",
+      "id": 4982,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Angola | Ngola",
+      "country_alpha2": "AO",
+      "country_alpha3": "AGO",
+      "document_type": "NIC",
+      "id": 7052,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "NIC",
+      "id": 4554,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "NIC",
+      "id": 4555,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "NIC",
+      "id": 4556,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "NIC",
+      "id": 8125,
+      "region_iso": null,
       "usecases": [
         "verify"
       ],
       "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Austria | Österreich",
+      "country_alpha2": "AT",
+      "country_alpha3": "AUT",
+      "document_type": "NIC",
+      "id": 6004,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Austria | Österreich",
+      "country_alpha2": "AT",
+      "country_alpha3": "AUT",
+      "document_type": "NIC",
+      "id": 2977,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2005"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Austria | Österreich",
+      "country_alpha2": "AT",
+      "country_alpha3": "AUT",
+      "document_type": "NIC",
+      "id": 4819,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Austria | Österreich",
+      "country_alpha2": "AT",
+      "country_alpha3": "AUT",
+      "document_type": "NIC",
+      "id": 4820,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2002"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Austria | Österreich",
+      "country_alpha2": "AT",
+      "country_alpha3": "AUT",
+      "document_type": "NIC",
+      "id": 6003,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Azerbaijan | Azərbaycan",
+      "country_alpha2": "AZ",
+      "country_alpha3": "AZE",
+      "document_type": "NIC",
+      "id": 2991,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Azerbaijan | Azərbaycan",
+      "country_alpha2": "AZ",
+      "country_alpha3": "AZE",
+      "document_type": "NIC",
+      "id": 5871,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Bahrain | البحرين",
+      "country_alpha2": "BH",
+      "country_alpha3": "BHR",
+      "document_type": "NIC",
+      "id": 5140,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Bangladesh | বাংলাদেশ",
+      "country_alpha2": "BD",
+      "country_alpha3": "BGD",
+      "document_type": "NIC",
+      "id": 5877,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Bangladesh | বাংলাদেশ",
+      "country_alpha2": "BD",
+      "country_alpha3": "BGD",
+      "document_type": "NIC",
+      "id": 5141,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016 2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "NIC",
+      "id": 3037,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2000"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "NIC",
+      "id": 4088,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "NIC",
+      "id": 4089,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "NIC",
+      "id": 4249,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "NIC",
+      "id": 6007,
+      "region_iso": "VLG",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "NIC",
+      "id": 6008,
+      "region_iso": "WAL",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "NIC",
+      "id": 6013,
+      "region_iso": "WAL",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "NIC",
+      "id": 3023,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "NIC",
+      "id": 3025,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "NIC",
+      "id": 3026,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "NIC",
+      "id": 4639,
+      "region_iso": "VLG",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "NIC",
+      "id": 6010,
+      "region_iso": "BRU",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "NIC",
+      "id": 6014,
+      "region_iso": "VLG",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "NIC",
+      "id": 6015,
+      "region_iso": "VLG",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Bolivia (Plurinational State of) | Bolivia",
+      "country_alpha2": "BO",
+      "country_alpha3": "BOL",
+      "document_type": "NIC",
+      "id": 5045,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Bolivia (Plurinational State of) | Bolivia",
+      "country_alpha2": "BO",
+      "country_alpha3": "BOL",
+      "document_type": "NIC",
+      "id": 5799,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Bosnia and Herzegovina | Bosna i Hercegovina",
+      "country_alpha2": "BA",
+      "country_alpha3": "BIH",
+      "document_type": "NIC",
+      "id": 5122,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Bosnia and Herzegovina | Bosna i Hercegovina",
+      "country_alpha2": "BA",
+      "country_alpha3": "BIH",
+      "document_type": "NIC",
+      "id": 6023,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Botswana",
+      "country_alpha2": "BW",
+      "country_alpha3": "BWA",
+      "document_type": "NIC",
+      "id": 4984,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "",
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8178,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8198,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8199,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "RG Card",
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 4090,
+      "region_iso": "SP",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2019"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8504,
+      "region_iso": "AC",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8505,
+      "region_iso": "AL",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8506,
+      "region_iso": "AM",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8507,
+      "region_iso": "AP",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8508,
+      "region_iso": "BA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8509,
+      "region_iso": "CE",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8510,
+      "region_iso": "DF",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8511,
+      "region_iso": "GO",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8512,
+      "region_iso": "MA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8513,
+      "region_iso": "MG",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8514,
+      "region_iso": "MS",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8515,
+      "region_iso": "MT",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8516,
+      "region_iso": "PA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8517,
+      "region_iso": "PB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8518,
+      "region_iso": "PE",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8519,
+      "region_iso": "PI",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8520,
+      "region_iso": "PR",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8521,
+      "region_iso": "RJ",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8522,
+      "region_iso": "RN",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8523,
+      "region_iso": "RO",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8524,
+      "region_iso": "RR",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8525,
+      "region_iso": "RS",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8526,
+      "region_iso": "SC",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8527,
+      "region_iso": "SE",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8529,
+      "region_iso": "TO",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8195,
+      "region_iso": "SP",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8196,
+      "region_iso": "SP",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8197,
+      "region_iso": "ES",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8194,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Brunei Darussalam | بروني",
+      "country_alpha2": "BN",
+      "country_alpha3": "BRN",
+      "document_type": "NIC",
+      "id": 5145,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Brunei Darussalam | بروني",
+      "country_alpha2": "BN",
+      "country_alpha3": "BRN",
+      "document_type": "NIC",
+      "id": 7118,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Bulgaria | България",
+      "country_alpha2": "BG",
+      "country_alpha3": "BGR",
+      "document_type": "NIC",
+      "id": 4092,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Bulgaria | България",
+      "country_alpha2": "BG",
+      "country_alpha3": "BGR",
+      "document_type": "NIC",
+      "id": 4093,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2006"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Cameroon",
+      "country_alpha2": "CM",
+      "country_alpha3": "CMR",
+      "document_type": "NIC",
+      "id": 4985,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Cameroon",
+      "country_alpha2": "CM",
+      "country_alpha3": "CMR",
+      "document_type": "NIC",
+      "id": 7812,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5547,
+      "region_iso": "NL",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 8114,
+      "region_iso": "PE",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 3123,
+      "region_iso": "NL",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5059,
+      "region_iso": "AB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5060,
+      "region_iso": "BC",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5061,
+      "region_iso": "MB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5062,
+      "region_iso": "NB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5065,
+      "region_iso": "NU",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5066,
+      "region_iso": "ON",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5067,
+      "region_iso": "PE",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5068,
+      "region_iso": "SK",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5195,
+      "region_iso": "YT",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5532,
+      "region_iso": "AB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5533,
+      "region_iso": "NL",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5534,
+      "region_iso": "NT",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5544,
+      "region_iso": "NB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5548,
+      "region_iso": "PE",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5549,
+      "region_iso": "NS",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5550,
+      "region_iso": "NS",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Chile",
+      "country_alpha2": "CL",
+      "country_alpha3": "CHL",
+      "document_type": "NIC",
+      "id": 3141,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Chile",
+      "country_alpha2": "CL",
+      "country_alpha3": "CHL",
+      "document_type": "NIC",
+      "id": 3140,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Chile",
+      "country_alpha2": "CL",
+      "country_alpha3": "CHL",
+      "document_type": "NIC",
+      "id": 3142,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2002"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "China | 中国",
+      "country_alpha2": "CN",
+      "country_alpha3": "CHN",
+      "document_type": "NIC",
+      "id": 5147,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "China | 中国",
+      "country_alpha2": "CN",
+      "country_alpha3": "CHN",
+      "document_type": "NIC",
+      "id": 5879,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Colombia",
+      "country_alpha2": "CO",
+      "country_alpha3": "COL",
+      "document_type": "NIC",
+      "id": 4547,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1993"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Colombia",
+      "country_alpha2": "CO",
+      "country_alpha3": "COL",
+      "document_type": "NIC",
+      "id": 4548,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2000"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Colombia",
+      "country_alpha2": "CO",
+      "country_alpha3": "COL",
+      "document_type": "NIC",
+      "id": 4549,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Costa Rica",
+      "country_alpha2": "CR",
+      "country_alpha3": "CRI",
+      "document_type": "NIC",
+      "id": 5071,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1999"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Costa Rica",
+      "country_alpha2": "CR",
+      "country_alpha3": "CRI",
+      "document_type": "NIC",
+      "id": 5538,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1998"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Côte d'Ivoire | Côte d'Ivoire",
+      "country_alpha2": "CI",
+      "country_alpha3": "CIV",
+      "document_type": "NIC",
+      "id": 4989,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Côte d'Ivoire | Côte d'Ivoire",
+      "country_alpha2": "CI",
+      "country_alpha3": "CIV",
+      "document_type": "NIC",
+      "id": 6557,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1991"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Croatia | Hrvatska",
+      "country_alpha2": "HR",
+      "country_alpha3": "HRV",
+      "document_type": "NIC",
+      "id": 4097,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Croatia | Hrvatska",
+      "country_alpha2": "HR",
+      "country_alpha3": "HRV",
+      "document_type": "NIC",
+      "id": 4099,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Croatia | Hrvatska",
+      "country_alpha2": "HR",
+      "country_alpha3": "HRV",
+      "document_type": "NIC",
+      "id": 6025,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Croatia | Hrvatska",
+      "country_alpha2": "HR",
+      "country_alpha3": "HRV",
+      "document_type": "NIC",
+      "id": 6026,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013-2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Cyprus | Κύπρος",
+      "country_alpha2": "CY",
+      "country_alpha3": "CYP",
+      "document_type": "NIC",
+      "id": 4261,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Cyprus | Κύπρος",
+      "country_alpha2": "CY",
+      "country_alpha3": "CYP",
+      "document_type": "NIC",
+      "id": 4262,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2000"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Cyprus | Κύπρος",
+      "country_alpha2": "CY",
+      "country_alpha3": "CYP",
+      "document_type": "NIC",
+      "id": 4263,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Czech Republic | Česko",
+      "country_alpha2": "CZ",
+      "country_alpha3": "CZE",
+      "document_type": "NIC",
+      "id": 4102,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2005"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Czech Republic | Česko",
+      "country_alpha2": "CZ",
+      "country_alpha3": "CZE",
+      "document_type": "NIC",
+      "id": 4266,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2000"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Czech Republic | Česko",
+      "country_alpha2": "CZ",
+      "country_alpha3": "CZE",
+      "document_type": "NIC",
+      "id": 4267,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Czech Republic | Česko",
+      "country_alpha2": "CZ",
+      "country_alpha3": "CZE",
+      "document_type": "NIC",
+      "id": 4264,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Czech Republic | Česko",
+      "country_alpha2": "CZ",
+      "country_alpha3": "CZE",
+      "document_type": "NIC",
+      "id": 4265,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Dominican Republic | República Dominicana",
+      "country_alpha2": "DO",
+      "country_alpha3": "DOM",
+      "document_type": "NIC",
+      "id": 5198,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Dominican Republic | República Dominicana",
+      "country_alpha2": "DO",
+      "country_alpha3": "DOM",
+      "document_type": "NIC",
+      "id": 8438,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Ecuador",
+      "country_alpha2": "EC",
+      "country_alpha3": "ECU",
+      "document_type": "NIC",
+      "id": 4894,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Ecuador",
+      "country_alpha2": "EC",
+      "country_alpha3": "ECU",
+      "document_type": "NIC",
+      "id": 4895,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "El Salvador",
+      "country_alpha2": "SV",
+      "country_alpha3": "SLV",
+      "document_type": "NIC",
+      "id": 5199,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "El Salvador",
+      "country_alpha2": "SV",
+      "country_alpha3": "SLV",
+      "document_type": "NIC",
+      "id": 7285,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Estonia | Eesti",
+      "country_alpha2": "EE",
+      "country_alpha3": "EST",
+      "document_type": "NIC",
+      "id": 4599,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Estonia | Eesti",
+      "country_alpha2": "EE",
+      "country_alpha3": "EST",
+      "document_type": "NIC",
+      "id": 4600,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Estonia | Eesti",
+      "country_alpha2": "EE",
+      "country_alpha3": "EST",
+      "document_type": "NIC",
+      "id": 4601,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Ethiopia | ኢትዮጵያ",
+      "country_alpha2": "ET",
+      "country_alpha3": "ETH",
+      "document_type": "NIC",
+      "id": 4993,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Finland | Suomi",
+      "country_alpha2": "FI",
+      "country_alpha3": "FIN",
+      "document_type": "NIC",
+      "id": 3288,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Finland | Suomi",
+      "country_alpha2": "FI",
+      "country_alpha3": "FIN",
+      "document_type": "NIC",
+      "id": 3289,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Finland | Suomi",
+      "country_alpha2": "FI",
+      "country_alpha3": "FIN",
+      "document_type": "NIC",
+      "id": 3290,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Finland | Suomi",
+      "country_alpha2": "FI",
+      "country_alpha3": "FIN",
+      "document_type": "NIC",
+      "id": 6041,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "France",
+      "country_alpha2": "FR",
+      "country_alpha3": "FRA",
+      "document_type": "NIC",
+      "id": 4106,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1994"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Georgia | საქართველო",
+      "country_alpha2": "GE",
+      "country_alpha3": "GEO",
+      "document_type": "NIC",
+      "id": 5127,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Germany | Deutschland",
+      "country_alpha2": "DE",
+      "country_alpha3": "DEU",
+      "document_type": "NIC",
+      "id": 4112,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Germany | Deutschland",
+      "country_alpha2": "DE",
+      "country_alpha3": "DEU",
+      "document_type": "NIC",
+      "id": 4113,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": "2010 label variation",
+      "country": "Germany | Deutschland",
+      "country_alpha2": "DE",
+      "country_alpha3": "DEU",
+      "document_type": "NIC",
+      "id": 8405,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2020"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Ghana",
+      "country_alpha2": "GH",
+      "country_alpha3": "GHA",
+      "document_type": "NIC",
+      "id": 8011,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2019"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Ghana",
+      "country_alpha2": "GH",
+      "country_alpha3": "GHA",
+      "document_type": "NIC",
+      "id": 8012,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Ghana",
+      "country_alpha2": "GH",
+      "country_alpha3": "GHA",
+      "document_type": "NIC",
+      "id": 8013,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Ghana",
+      "country_alpha2": "GH",
+      "country_alpha3": "GHA",
+      "document_type": "NIC",
+      "id": 4996,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Gibraltar",
+      "country_alpha2": "GI",
+      "country_alpha3": "GIB",
+      "document_type": "NIC",
+      "id": 5129,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Gibraltar",
+      "country_alpha2": "GI",
+      "country_alpha3": "GIB",
+      "document_type": "NIC",
+      "id": 6079,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2000"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Greece | Ελλάδα",
+      "country_alpha2": "GR",
+      "country_alpha3": "GRC",
+      "document_type": "NIC",
+      "id": 4115,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2000"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Greece | Ελλάδα",
+      "country_alpha2": "GR",
+      "country_alpha3": "GRC",
+      "document_type": "NIC",
+      "id": 6080,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2000-2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Greece | Ελλάδα",
+      "country_alpha2": "GR",
+      "country_alpha3": "GRC",
+      "document_type": "NIC",
+      "id": 4317,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Guam | Guåhån",
+      "country_alpha2": "GU",
+      "country_alpha3": "GUM",
+      "document_type": "NIC",
+      "id": 5105,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Guam | Guåhån",
+      "country_alpha2": "GU",
+      "country_alpha3": "GUM",
+      "document_type": "NIC",
+      "id": 6168,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Guam | Guåhån",
+      "country_alpha2": "GU",
+      "country_alpha3": "GUM",
+      "document_type": "NIC",
+      "id": 6169,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Guatemala",
+      "country_alpha2": "GT",
+      "country_alpha3": "GTM",
+      "document_type": "NIC",
+      "id": 5201,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Guatemala",
+      "country_alpha2": "GT",
+      "country_alpha3": "GTM",
+      "document_type": "NIC",
+      "id": 5557,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Hong Kong | 香港",
+      "country_alpha2": "HK",
+      "country_alpha3": "HKG",
+      "document_type": "NIC",
+      "id": 7977,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003 3"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "HKID",
+      "country": "Hong Kong | 香港",
+      "country_alpha2": "HK",
+      "country_alpha3": "HKG",
+      "document_type": "NIC",
+      "id": 3380,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "HKID",
+      "country": "Hong Kong | 香港",
+      "country_alpha2": "HK",
+      "country_alpha3": "HKG",
+      "document_type": "NIC",
+      "id": 5882,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "HKID",
+      "country": "Hong Kong | 香港",
+      "country_alpha2": "HK",
+      "country_alpha3": "HKG",
+      "document_type": "NIC",
+      "id": 5884,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003 2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "HKID",
+      "country": "Hong Kong | 香港",
+      "country_alpha2": "HK",
+      "country_alpha3": "HKG",
+      "document_type": "NIC",
+      "id": 5885,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018-2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
+      "document_type": "NIC",
+      "id": 6085,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016 "
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
+      "document_type": "NIC",
+      "id": 7978,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016 2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
+      "document_type": "NIC",
+      "id": 7979,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016 3"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
+      "document_type": "NIC",
+      "id": 7980,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012 1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
+      "document_type": "NIC",
+      "id": 4122,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012 2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
+      "document_type": "NIC",
+      "id": 6082,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016 1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
+      "document_type": "NIC",
+      "id": 6086,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016 4"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "Aadhaar Card",
+      "country": "India | भारत",
+      "country_alpha2": "IN",
+      "country_alpha3": "IND",
+      "document_type": "NIC",
+      "id": 5274,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "5"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "Aadhaar Card",
+      "country": "India | भारत",
+      "country_alpha2": "IN",
+      "country_alpha3": "IND",
+      "document_type": "NIC",
+      "id": 5886,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "6"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "Aadhaar Card",
+      "country": "India | भारत",
+      "country_alpha2": "IN",
+      "country_alpha3": "IND",
+      "document_type": "NIC",
+      "id": 5887,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "Aadhaar Card",
+      "country": "India | भारत",
+      "country_alpha2": "IN",
+      "country_alpha3": "IND",
+      "document_type": "NIC",
+      "id": 5888,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "3"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "Aadhaar Card",
+      "country": "India | भारत",
+      "country_alpha2": "IN",
+      "country_alpha3": "IND",
+      "document_type": "NIC",
+      "id": 5889,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "4"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Indonesia",
+      "country_alpha2": "ID",
+      "country_alpha3": "IDN",
+      "document_type": "NIC",
+      "id": 4126,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Indonesia",
+      "country_alpha2": "ID",
+      "country_alpha3": "IDN",
+      "document_type": "NIC",
+      "id": 5896,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1977"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Italy | Italia",
+      "country_alpha2": "IT",
+      "country_alpha3": "ITA",
+      "document_type": "NIC",
+      "id": 4343,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016 v1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Italy | Italia",
+      "country_alpha2": "IT",
+      "country_alpha3": "ITA",
+      "document_type": "NIC",
+      "id": 3446,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Italy | Italia",
+      "country_alpha2": "IT",
+      "country_alpha3": "ITA",
+      "document_type": "NIC",
+      "id": 4342,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Italy | Italia",
+      "country_alpha2": "IT",
+      "country_alpha3": "ITA",
+      "document_type": "NIC",
+      "id": 4341,
+      "region_iso": null,
+      "usecases": [
+        "verify",
+        "right_to_work"
+      ],
+      "version": "1994"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": "Individual Number Card",
+      "country": "Japan | 日本",
+      "country_alpha2": "JP",
+      "country_alpha3": "JPN",
+      "document_type": "NIC",
+      "id": 5151,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Jordan | الأردن",
+      "country_alpha2": "JO",
+      "country_alpha3": "JOR",
+      "document_type": "NIC",
+      "id": 5156,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Jordan | الأردن",
+      "country_alpha2": "JO",
+      "country_alpha3": "JOR",
+      "document_type": "NIC",
+      "id": 5903,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Kenya",
+      "country_alpha2": "KE",
+      "country_alpha3": "KEN",
+      "document_type": "NIC",
+      "id": 4570,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1996"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Kenya",
+      "country_alpha2": "KE",
+      "country_alpha3": "KEN",
+      "document_type": "NIC",
+      "id": 4571,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Korea (Republic of) | 한국",
+      "country_alpha2": "KR",
+      "country_alpha3": "KOR",
+      "document_type": "NIC",
+      "id": 6491,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2001"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Korea (Republic of) | 한국",
+      "country_alpha2": "KR",
+      "country_alpha3": "KOR",
+      "document_type": "NIC",
+      "id": 8142,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Kosovo, Republic of",
+      "country_alpha2": "XK",
+      "country_alpha3": "RKS",
+      "document_type": "NIC",
+      "id": 6098,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Kuwait | دولة الكويت",
+      "country_alpha2": "KW",
+      "country_alpha3": "KWT",
+      "document_type": "NIC",
+      "id": 5158,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Kuwait | دولة الكويت",
+      "country_alpha2": "KW",
+      "country_alpha3": "KWT",
+      "document_type": "NIC",
+      "id": 5907,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Latvia | Latvija",
+      "country_alpha2": "LV",
+      "country_alpha3": "LVA",
+      "document_type": "NIC",
+      "id": 4142,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2019"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Latvia | Latvija",
+      "country_alpha2": "LV",
+      "country_alpha3": "LVA",
+      "document_type": "NIC",
+      "id": 4143,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Lesotho",
+      "country_alpha2": "LS",
+      "country_alpha3": "LSO",
+      "document_type": "NIC",
+      "id": 3536,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Lesotho",
+      "country_alpha2": "LS",
+      "country_alpha3": "LSO",
+      "document_type": "NIC",
+      "id": 5489,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Liechtenstein",
+      "country_alpha2": "LI",
+      "country_alpha3": "LIE",
+      "document_type": "NIC",
+      "id": 5130,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Liechtenstein",
+      "country_alpha2": "LI",
+      "country_alpha3": "LIE",
+      "document_type": "NIC",
+      "id": 6103,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1995"
     }
   },
   {
@@ -25,6 +3066,1799 @@
       "document_type": "NIC",
       "id": 4144,
       "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "NIC",
+      "id": 4356,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "NIC",
+      "id": 4355,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2002"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "NIC",
+      "id": 4145,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "NIC",
+      "id": 4147,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Luxembourg | Luxemburg",
+      "country_alpha2": "LU",
+      "country_alpha3": "LUX",
+      "document_type": "NIC",
+      "id": 6107,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014 1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Luxembourg | Luxemburg",
+      "country_alpha2": "LU",
+      "country_alpha3": "LUX",
+      "document_type": "NIC",
+      "id": 3566,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Luxembourg | Luxemburg",
+      "country_alpha2": "LU",
+      "country_alpha3": "LUX",
+      "document_type": "NIC",
+      "id": 3567,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Luxembourg | Luxemburg",
+      "country_alpha2": "LU",
+      "country_alpha3": "LUX",
+      "document_type": "NIC",
+      "id": 3568,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Macedonia (the former Yugoslav Republic of) | Македонија",
+      "country_alpha2": "MK",
+      "country_alpha3": "MKD",
+      "document_type": "NIC",
+      "id": 3584,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Macedonia (the former Yugoslav Republic of) | Македонија",
+      "country_alpha2": "MK",
+      "country_alpha3": "MKD",
+      "document_type": "NIC",
+      "id": 7911,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Malawi | Malaŵi",
+      "country_alpha2": "MW",
+      "country_alpha3": "MWI",
+      "document_type": "NIC",
+      "id": 5000,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": "MyKAD",
+      "country": "Malaysia",
+      "country_alpha2": "MY",
+      "country_alpha3": "MYS",
+      "document_type": "NIC",
+      "id": 3594,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "MyKAD",
+      "country": "Malaysia",
+      "country_alpha2": "MY",
+      "country_alpha3": "MYS",
+      "document_type": "NIC",
+      "id": 4156,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "MyKAD",
+      "country": "Malaysia",
+      "country_alpha2": "MY",
+      "country_alpha3": "MYS",
+      "document_type": "NIC",
+      "id": 4157,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "MyTentera",
+      "country": "Malaysia",
+      "country_alpha2": "MY",
+      "country_alpha3": "MYS",
+      "document_type": "NIC",
+      "id": 5910,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Malta",
+      "country_alpha2": "MT",
+      "country_alpha3": "MLT",
+      "document_type": "NIC",
+      "id": 4160,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Malta",
+      "country_alpha2": "MT",
+      "country_alpha3": "MLT",
+      "document_type": "NIC",
+      "id": 4391,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Malta",
+      "country_alpha2": "MT",
+      "country_alpha3": "MLT",
+      "document_type": "NIC",
+      "id": 3610,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Mauritius | Maurice",
+      "country_alpha2": "MU",
+      "country_alpha3": "MUS",
+      "document_type": "NIC",
+      "id": 5001,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Moldova (Republic of)",
+      "country_alpha2": "MD",
+      "country_alpha3": "MDA",
+      "document_type": "NIC",
+      "id": 3629,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Moldova (Republic of)",
+      "country_alpha2": "MD",
+      "country_alpha3": "MDA",
+      "document_type": "NIC",
+      "id": 3630,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Moldova (Republic of)",
+      "country_alpha2": "MD",
+      "country_alpha3": "MDA",
+      "document_type": "NIC",
+      "id": 3631,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Moldova (Republic of)",
+      "country_alpha2": "MD",
+      "country_alpha3": "MDA",
+      "document_type": "NIC",
+      "id": 3632,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1997"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Moldova (Republic of)",
+      "country_alpha2": "MD",
+      "country_alpha3": "MDA",
+      "document_type": "NIC",
+      "id": 6114,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1996"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Moldova (Republic of)",
+      "country_alpha2": "MD",
+      "country_alpha3": "MDA",
+      "document_type": "NIC",
+      "id": 6115,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2005"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Monaco",
+      "country_alpha2": "MC",
+      "country_alpha3": "MCO",
+      "document_type": "NIC",
+      "id": 5133,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Montenegro | Crna Gora",
+      "country_alpha2": "ME",
+      "country_alpha3": "MNE",
+      "document_type": "NIC",
+      "id": 5136,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Morocco | المغرب",
+      "country_alpha2": "MA",
+      "country_alpha3": "MAR",
+      "document_type": "NIC",
+      "id": 4881,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Morocco | المغرب",
+      "country_alpha2": "MA",
+      "country_alpha3": "MAR",
+      "document_type": "NIC",
+      "id": 8273,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2020"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Mozambique | Moçambique",
+      "country_alpha2": "MZ",
+      "country_alpha3": "MOZ",
+      "document_type": "NIC",
+      "id": 3664,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Mozambique | Moçambique",
+      "country_alpha2": "MZ",
+      "country_alpha3": "MOZ",
+      "document_type": "NIC",
+      "id": 5495,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2019"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Mozambique | Moçambique",
+      "country_alpha2": "MZ",
+      "country_alpha3": "MOZ",
+      "document_type": "NIC",
+      "id": 6887,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Namibia",
+      "country_alpha2": "NA",
+      "country_alpha3": "NAM",
+      "document_type": "NIC",
+      "id": 5002,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1994"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Netherlands | Nederland",
+      "country_alpha2": "NL",
+      "country_alpha3": "NLD",
+      "document_type": "NIC",
+      "id": 3681,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Netherlands | Nederland",
+      "country_alpha2": "NL",
+      "country_alpha3": "NLD",
+      "document_type": "NIC",
+      "id": 4165,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2006"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Netherlands | Nederland",
+      "country_alpha2": "NL",
+      "country_alpha3": "NLD",
+      "document_type": "NIC",
+      "id": 3679,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Netherlands | Nederland",
+      "country_alpha2": "NL",
+      "country_alpha3": "NLD",
+      "document_type": "NIC",
+      "id": 3680,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Nigeria | Nijeriya",
+      "country_alpha2": "NG",
+      "country_alpha3": "NGA",
+      "document_type": "NIC",
+      "id": 3717,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2000"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Nigeria | Nijeriya",
+      "country_alpha2": "NG",
+      "country_alpha3": "NGA",
+      "document_type": "NIC",
+      "id": 5497,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Nigeria | Nijeriya",
+      "country_alpha2": "NG",
+      "country_alpha3": "NGA",
+      "document_type": "NIC",
+      "id": 5500,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Oman | عمان",
+      "country_alpha2": "OM",
+      "country_alpha3": "OMN",
+      "document_type": "NIC",
+      "id": 3743,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Oman | عمان",
+      "country_alpha2": "OM",
+      "country_alpha3": "OMN",
+      "document_type": "NIC",
+      "id": 5918,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Oman | عمان",
+      "country_alpha2": "OM",
+      "country_alpha3": "OMN",
+      "document_type": "NIC",
+      "id": 5919,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2019"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Pakistan | پاکستان",
+      "country_alpha2": "PK",
+      "country_alpha3": "PAK",
+      "document_type": "NIC",
+      "id": 4649,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "Origin Card",
+      "country": "Pakistan | پاکستان",
+      "country_alpha2": "PK",
+      "country_alpha3": "PAK",
+      "document_type": "NIC",
+      "id": 5921,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": ""
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "Overseas ",
+      "country": "Pakistan | پاکستان",
+      "country_alpha2": "PK",
+      "country_alpha3": "PAK",
+      "document_type": "NIC",
+      "id": 5922,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Paraguay | Paraguái",
+      "country_alpha2": "PY",
+      "country_alpha3": "PRY",
+      "document_type": "NIC",
+      "id": 5051,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Paraguay | Paraguái",
+      "country_alpha2": "PY",
+      "country_alpha3": "PRY",
+      "document_type": "NIC",
+      "id": 5809,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Peru | Perú",
+      "country_alpha2": "PE",
+      "country_alpha3": "PER",
+      "document_type": "NIC",
+      "id": 4584,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2005"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Peru | Perú",
+      "country_alpha2": "PE",
+      "country_alpha3": "PER",
+      "document_type": "NIC",
+      "id": 4585,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Peru | Perú",
+      "country_alpha2": "PE",
+      "country_alpha3": "PER",
+      "document_type": "NIC",
+      "id": 8307,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2020"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Philippines | Pilipinas",
+      "country_alpha2": "PH",
+      "country_alpha3": "PHL",
+      "document_type": "NIC",
+      "id": 5163,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2000"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Philippines | Pilipinas",
+      "country_alpha2": "PH",
+      "country_alpha3": "PHL",
+      "document_type": "NIC",
+      "id": 5925,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "NIC",
+      "id": 6689,
+      "region_iso": null,
+      "usecases": [
+        "verify",
+        "right_to_work"
+      ],
+      "version": "2019"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "NIC",
+      "id": 3777,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "NIC",
+      "id": 4398,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "NIC",
+      "id": 4170,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "NIC",
+      "id": 4171,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Portugal",
+      "country_alpha2": "PT",
+      "country_alpha3": "PRT",
+      "document_type": "NIC",
+      "id": 4177,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Portugal",
+      "country_alpha2": "PT",
+      "country_alpha3": "PRT",
+      "document_type": "NIC",
+      "id": 3794,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Portugal",
+      "country_alpha2": "PT",
+      "country_alpha3": "PRT",
+      "document_type": "NIC",
+      "id": 3795,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Portugal",
+      "country_alpha2": "PT",
+      "country_alpha3": "PRT",
+      "document_type": "NIC",
+      "id": 4416,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Puerto Rico",
+      "country_alpha2": "PR",
+      "country_alpha3": "PRI",
+      "document_type": "NIC",
+      "id": 5571,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Puerto Rico",
+      "country_alpha2": "PR",
+      "country_alpha3": "PRI",
+      "document_type": "NIC",
+      "id": 5572,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Qatar | قطر",
+      "country_alpha2": "QA",
+      "country_alpha3": "QAT",
+      "document_type": "NIC",
+      "id": 5170,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Qatar | قطر",
+      "country_alpha2": "QA",
+      "country_alpha3": "QAT",
+      "document_type": "NIC",
+      "id": 5932,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Romania | România",
+      "country_alpha2": "RO",
+      "country_alpha3": "ROU",
+      "document_type": "NIC",
+      "id": 3802,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2001"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Romania | România",
+      "country_alpha2": "RO",
+      "country_alpha3": "ROU",
+      "document_type": "NIC",
+      "id": 3803,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Romania | România",
+      "country_alpha2": "RO",
+      "country_alpha3": "ROU",
+      "document_type": "NIC",
+      "id": 4425,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2006"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Romania | România",
+      "country_alpha2": "RO",
+      "country_alpha3": "ROU",
+      "document_type": "NIC",
+      "id": 6124,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Romania | România",
+      "country_alpha2": "RO",
+      "country_alpha3": "ROU",
+      "document_type": "NIC",
+      "id": 6125,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Romania | România",
+      "country_alpha2": "RO",
+      "country_alpha3": "ROU",
+      "document_type": "NIC",
+      "id": 6127,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": "Internal Passport",
+      "country": "Russian Federation | Россия",
+      "country_alpha2": "RU",
+      "country_alpha3": "RUS",
+      "document_type": "NIC",
+      "id": 6128,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": "Internal Passport",
+      "country": "Russian Federation | Россия",
+      "country_alpha2": "RU",
+      "country_alpha3": "RUS",
+      "document_type": "NIC",
+      "id": 6129,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Rwanda",
+      "country_alpha2": "RW",
+      "country_alpha3": "RWA",
+      "document_type": "NIC",
+      "id": 3817,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2005"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Senegal | Sénégal",
+      "country_alpha2": "SN",
+      "country_alpha3": "SEN",
+      "document_type": "NIC",
+      "id": 3833,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2006"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Senegal | Sénégal",
+      "country_alpha2": "SN",
+      "country_alpha3": "SEN",
+      "document_type": "NIC",
+      "id": 5505,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2019"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Serbia | Србија",
+      "country_alpha2": "RS",
+      "country_alpha3": "SRB",
+      "document_type": "NIC",
+      "id": 5138,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": "NRIC",
+      "country": "Singapore",
+      "country_alpha2": "SG",
+      "country_alpha3": "SGP",
+      "document_type": "NIC",
+      "id": 3845,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2000"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Singapore",
+      "country_alpha2": "SG",
+      "country_alpha3": "SGP",
+      "document_type": "NIC",
+      "id": 5940,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Singapore",
+      "country_alpha2": "SG",
+      "country_alpha3": "SGP",
+      "document_type": "NIC",
+      "id": 5941,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "3"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Singapore",
+      "country_alpha2": "SG",
+      "country_alpha3": "SGP",
+      "document_type": "NIC",
+      "id": 5942,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "4"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Singapore",
+      "country_alpha2": "SG",
+      "country_alpha3": "SGP",
+      "document_type": "NIC",
+      "id": 5943,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "5"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Slovakia | Slovensko",
+      "country_alpha2": "SK",
+      "country_alpha3": "SVK",
+      "document_type": "NIC",
+      "id": 3856,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Slovakia | Slovensko",
+      "country_alpha2": "SK",
+      "country_alpha3": "SVK",
+      "document_type": "NIC",
+      "id": 3857,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1993"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Slovakia | Slovensko",
+      "country_alpha2": "SK",
+      "country_alpha3": "SVK",
+      "document_type": "NIC",
+      "id": 3858,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Slovakia | Slovensko",
+      "country_alpha2": "SK",
+      "country_alpha3": "SVK",
+      "document_type": "NIC",
+      "id": 4187,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Slovenia | Slovenija",
+      "country_alpha2": "SI",
+      "country_alpha3": "SVN",
+      "document_type": "NIC",
+      "id": 4592,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1998"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "South Africa | Suid-Afrika",
+      "country_alpha2": "ZA",
+      "country_alpha3": "ZAF",
+      "document_type": "NIC",
+      "id": 4189,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "South Africa | Suid-Afrika",
+      "country_alpha2": "ZA",
+      "country_alpha3": "ZAF",
+      "document_type": "NIC",
+      "id": 4188,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Spain | España",
+      "country_alpha2": "ES",
+      "country_alpha3": "ESP",
+      "document_type": "NIC",
+      "id": 3896,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2006"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Spain | España",
+      "country_alpha2": "ES",
+      "country_alpha3": "ESP",
+      "document_type": "NIC",
+      "id": 4442,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Swaziland | eSwatini",
+      "country_alpha2": "SZ",
+      "country_alpha3": "SWZ",
+      "document_type": "NIC",
+      "id": 5008,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2000"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Sweden | Sverige",
+      "country_alpha2": "SE",
+      "country_alpha3": "SWE",
+      "document_type": "NIC",
+      "id": 3909,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Sweden | Sverige",
+      "country_alpha2": "SE",
+      "country_alpha3": "SWE",
+      "document_type": "NIC",
+      "id": 3912,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Sweden | Sverige",
+      "country_alpha2": "SE",
+      "country_alpha3": "SWE",
+      "document_type": "NIC",
+      "id": 4597,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Switzerland | Schweiz",
+      "country_alpha2": "CH",
+      "country_alpha3": "CHE",
+      "document_type": "NIC",
+      "id": 3918,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Switzerland | Schweiz",
+      "country_alpha2": "CH",
+      "country_alpha3": "CHE",
+      "document_type": "NIC",
+      "id": 4456,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2005"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Taiwan, Province of China | 中華民國",
+      "country_alpha2": "TW",
+      "country_alpha3": "TWN",
+      "document_type": "NIC",
+      "id": 5269,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Tanzania, United Republic of",
+      "country_alpha2": "TZ",
+      "country_alpha3": "TZA",
+      "document_type": "NIC",
+      "id": 5435,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Tanzania, United Republic of",
+      "country_alpha2": "TZ",
+      "country_alpha3": "TZA",
+      "document_type": "NIC",
+      "id": 8118,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "3"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Tanzania, United Republic of",
+      "country_alpha2": "TZ",
+      "country_alpha3": "TZA",
+      "document_type": "NIC",
+      "id": 8117,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Thailand | ประเทศไทย",
+      "country_alpha2": "TH",
+      "country_alpha3": "THA",
+      "document_type": "NIC",
+      "id": 5179,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Trinidad and Tobago",
+      "country_alpha2": "TT",
+      "country_alpha3": "TTO",
+      "document_type": "NIC",
+      "id": 5303,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Turkey | Türkiye",
+      "country_alpha2": "TR",
+      "country_alpha3": "TUR",
+      "document_type": "NIC",
+      "id": 6835,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Turkey | Türkiye",
+      "country_alpha2": "TR",
+      "country_alpha3": "TUR",
+      "document_type": "NIC",
+      "id": 8042,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Turkey | Türkiye",
+      "country_alpha2": "TR",
+      "country_alpha3": "TUR",
+      "document_type": "NIC",
+      "id": 4202,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2002"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Uganda",
+      "country_alpha2": "UG",
+      "country_alpha3": "UGA",
+      "document_type": "NIC",
+      "id": 5014,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Ukraine | Ukraїna",
+      "country_alpha2": "UA",
+      "country_alpha3": "UKR",
+      "document_type": "NIC",
+      "id": 4826,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "United Arab Emirates | الإمارات العربية المتحدة",
+      "country_alpha2": "AE",
+      "country_alpha3": "ARE",
+      "document_type": "NIC",
+      "id": 3968,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United Arab Emirates | الإمارات العربية المتحدة",
+      "country_alpha2": "AE",
+      "country_alpha3": "ARE",
+      "document_type": "NIC",
+      "id": 5956,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "State Identity Card",
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "NIC",
+      "id": 3997,
+      "region_iso": "AZ",
       "usecases": [
         "verify"
       ],
@@ -66,22 +4900,6 @@
   {
     "sourceData": {
       "back_required": false,
-      "common_name": null,
-      "country": "Austria | Österreich",
-      "country_alpha2": "AT",
-      "country_alpha3": "AUT",
-      "document_type": "NIC",
-      "id": 6004,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
       "common_name": "State Identity Card",
       "country": "United States of America",
       "country_alpha2": "US",
@@ -109,86 +4927,6 @@
         "verify"
       ],
       "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Côte d'Ivoire | Côte d'Ivoire",
-      "country_alpha2": "CI",
-      "country_alpha3": "CIV",
-      "document_type": "NIC",
-      "id": 4989,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Viet Nam | Việt Nam",
-      "country_alpha2": "VN",
-      "country_alpha3": "VNM",
-      "document_type": "NIC",
-      "id": 5182,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Côte d'Ivoire | Côte d'Ivoire",
-      "country_alpha2": "CI",
-      "country_alpha3": "CIV",
-      "document_type": "NIC",
-      "id": 6557,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1991"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "NIC",
-      "id": 4356,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Italy | Italia",
-      "country_alpha2": "IT",
-      "country_alpha3": "ITA",
-      "document_type": "NIC",
-      "id": 4343,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016 v1"
     }
   },
   {
@@ -242,166 +4980,6 @@
   {
     "sourceData": {
       "back_required": false,
-      "common_name": null,
-      "country": "Macedonia (the former Yugoslav Republic of) | Македонија",
-      "country_alpha2": "MK",
-      "country_alpha3": "MKD",
-      "document_type": "NIC",
-      "id": 3584,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Macedonia (the former Yugoslav Republic of) | Македонија",
-      "country_alpha2": "MK",
-      "country_alpha3": "MKD",
-      "document_type": "NIC",
-      "id": 7911,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "NIC",
-      "id": 6085,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016 "
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Hong Kong | 香港",
-      "country_alpha2": "HK",
-      "country_alpha3": "HKG",
-      "document_type": "NIC",
-      "id": 7977,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003 3"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "NIC",
-      "id": 7978,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016 2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "NIC",
-      "id": 7979,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016 3"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "NIC",
-      "id": 7980,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012 1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Ghana",
-      "country_alpha2": "GH",
-      "country_alpha3": "GHA",
-      "document_type": "NIC",
-      "id": 8011,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2019"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Ghana",
-      "country_alpha2": "GH",
-      "country_alpha3": "GHA",
-      "document_type": "NIC",
-      "id": 8012,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Ghana",
-      "country_alpha2": "GH",
-      "country_alpha3": "GHA",
-      "document_type": "NIC",
-      "id": 8013,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
       "common_name": "State Identity Card",
       "country": "United States of America",
       "country_alpha2": "US",
@@ -435,44 +5013,12 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Turkey | Türkiye",
-      "country_alpha2": "TR",
-      "country_alpha3": "TUR",
-      "document_type": "NIC",
-      "id": 6835,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "United States of America",
       "country_alpha2": "US",
       "country_alpha3": "USA",
       "document_type": "NIC",
       "id": 6881,
       "region_iso": "WA",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Turkey | Türkiye",
-      "country_alpha2": "TR",
-      "country_alpha3": "TUR",
-      "document_type": "NIC",
-      "id": 8042,
-      "region_iso": null,
       "usecases": [
         "verify"
       ],
@@ -595,76 +5141,12 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Bangladesh | বাংলাদেশ",
-      "country_alpha2": "BD",
-      "country_alpha3": "BGD",
-      "document_type": "NIC",
-      "id": 5877,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "",
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8178,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "United States of America",
       "country_alpha2": "US",
       "country_alpha3": "USA",
       "document_type": "NIC",
       "id": 8192,
       "region_iso": "WA",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8198,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8199,
-      "region_iso": null,
       "usecases": [
         "verify"
       ],
@@ -685,1158 +5167,6 @@
         "verify"
       ],
       "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Albania | Shqipëria",
-      "country_alpha2": "AL",
-      "country_alpha3": "ALB",
-      "document_type": "NIC",
-      "id": 2920,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Austria | Österreich",
-      "country_alpha2": "AT",
-      "country_alpha3": "AUT",
-      "document_type": "NIC",
-      "id": 2977,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2005"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Azerbaijan | Azərbaycan",
-      "country_alpha2": "AZ",
-      "country_alpha3": "AZE",
-      "document_type": "NIC",
-      "id": 2991,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "NIC",
-      "id": 3037,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2000"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Finland | Suomi",
-      "country_alpha2": "FI",
-      "country_alpha3": "FIN",
-      "document_type": "NIC",
-      "id": 3288,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Finland | Suomi",
-      "country_alpha2": "FI",
-      "country_alpha3": "FIN",
-      "document_type": "NIC",
-      "id": 3289,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Finland | Suomi",
-      "country_alpha2": "FI",
-      "country_alpha3": "FIN",
-      "document_type": "NIC",
-      "id": 3290,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "HKID",
-      "country": "Hong Kong | 香港",
-      "country_alpha2": "HK",
-      "country_alpha3": "HKG",
-      "document_type": "NIC",
-      "id": 3380,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Lesotho",
-      "country_alpha2": "LS",
-      "country_alpha3": "LSO",
-      "document_type": "NIC",
-      "id": 3536,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": "MyKAD",
-      "country": "Malaysia",
-      "country_alpha2": "MY",
-      "country_alpha3": "MYS",
-      "document_type": "NIC",
-      "id": 3594,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Moldova (Republic of)",
-      "country_alpha2": "MD",
-      "country_alpha3": "MDA",
-      "document_type": "NIC",
-      "id": 3629,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Moldova (Republic of)",
-      "country_alpha2": "MD",
-      "country_alpha3": "MDA",
-      "document_type": "NIC",
-      "id": 3630,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Moldova (Republic of)",
-      "country_alpha2": "MD",
-      "country_alpha3": "MDA",
-      "document_type": "NIC",
-      "id": 3631,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Moldova (Republic of)",
-      "country_alpha2": "MD",
-      "country_alpha3": "MDA",
-      "document_type": "NIC",
-      "id": 3632,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1997"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Mozambique | Moçambique",
-      "country_alpha2": "MZ",
-      "country_alpha3": "MOZ",
-      "document_type": "NIC",
-      "id": 3664,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Netherlands | Nederland",
-      "country_alpha2": "NL",
-      "country_alpha3": "NLD",
-      "document_type": "NIC",
-      "id": 3681,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Nigeria | Nijeriya",
-      "country_alpha2": "NG",
-      "country_alpha3": "NGA",
-      "document_type": "NIC",
-      "id": 3717,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2000"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Oman | عمان",
-      "country_alpha2": "OM",
-      "country_alpha3": "OMN",
-      "document_type": "NIC",
-      "id": 3743,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Romania | România",
-      "country_alpha2": "RO",
-      "country_alpha3": "ROU",
-      "document_type": "NIC",
-      "id": 3802,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2001"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Romania | România",
-      "country_alpha2": "RO",
-      "country_alpha3": "ROU",
-      "document_type": "NIC",
-      "id": 3803,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Rwanda",
-      "country_alpha2": "RW",
-      "country_alpha3": "RWA",
-      "document_type": "NIC",
-      "id": 3817,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2005"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Senegal | Sénégal",
-      "country_alpha2": "SN",
-      "country_alpha3": "SEN",
-      "document_type": "NIC",
-      "id": 3833,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": "NRIC",
-      "country": "Singapore",
-      "country_alpha2": "SG",
-      "country_alpha3": "SGP",
-      "document_type": "NIC",
-      "id": 3845,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2000"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Sweden | Sverige",
-      "country_alpha2": "SE",
-      "country_alpha3": "SWE",
-      "document_type": "NIC",
-      "id": 3909,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Sweden | Sverige",
-      "country_alpha2": "SE",
-      "country_alpha3": "SWE",
-      "document_type": "NIC",
-      "id": 3912,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Switzerland | Schweiz",
-      "country_alpha2": "CH",
-      "country_alpha3": "CHE",
-      "document_type": "NIC",
-      "id": 3918,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "United Arab Emirates | الإمارات العربية المتحدة",
-      "country_alpha2": "AE",
-      "country_alpha3": "ARE",
-      "document_type": "NIC",
-      "id": 3968,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Uruguay",
-      "country_alpha2": "UY",
-      "country_alpha3": "URY",
-      "document_type": "NIC",
-      "id": 4006,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015 "
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "NIC",
-      "id": 4088,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "NIC",
-      "id": 4089,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "RG Card",
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 4090,
-      "region_iso": "SP",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2019"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Bulgaria | България",
-      "country_alpha2": "BG",
-      "country_alpha3": "BGR",
-      "document_type": "NIC",
-      "id": 4092,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Bulgaria | България",
-      "country_alpha2": "BG",
-      "country_alpha3": "BGR",
-      "document_type": "NIC",
-      "id": 4093,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Croatia | Hrvatska",
-      "country_alpha2": "HR",
-      "country_alpha3": "HRV",
-      "document_type": "NIC",
-      "id": 4097,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Croatia | Hrvatska",
-      "country_alpha2": "HR",
-      "country_alpha3": "HRV",
-      "document_type": "NIC",
-      "id": 4099,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Czech Republic | Česko",
-      "country_alpha2": "CZ",
-      "country_alpha3": "CZE",
-      "document_type": "NIC",
-      "id": 4102,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2005"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "France",
-      "country_alpha2": "FR",
-      "country_alpha3": "FRA",
-      "document_type": "NIC",
-      "id": 4106,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1994"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Greece | Ελλάδα",
-      "country_alpha2": "GR",
-      "country_alpha3": "GRC",
-      "document_type": "NIC",
-      "id": 4115,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2000"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "NIC",
-      "id": 4122,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012 2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Indonesia",
-      "country_alpha2": "ID",
-      "country_alpha3": "IDN",
-      "document_type": "NIC",
-      "id": 4126,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Latvia | Latvija",
-      "country_alpha2": "LV",
-      "country_alpha3": "LVA",
-      "document_type": "NIC",
-      "id": 4142,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2019"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "MyKAD",
-      "country": "Malaysia",
-      "country_alpha2": "MY",
-      "country_alpha3": "MYS",
-      "document_type": "NIC",
-      "id": 4156,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "MyKAD",
-      "country": "Malaysia",
-      "country_alpha2": "MY",
-      "country_alpha3": "MYS",
-      "document_type": "NIC",
-      "id": 4157,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Malta",
-      "country_alpha2": "MT",
-      "country_alpha3": "MLT",
-      "document_type": "NIC",
-      "id": 4160,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Netherlands | Nederland",
-      "country_alpha2": "NL",
-      "country_alpha3": "NLD",
-      "document_type": "NIC",
-      "id": 4165,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Turkey | Türkiye",
-      "country_alpha2": "TR",
-      "country_alpha3": "TUR",
-      "document_type": "NIC",
-      "id": 4202,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2002"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "NIC",
-      "id": 4249,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Cyprus | Κύπρος",
-      "country_alpha2": "CY",
-      "country_alpha3": "CYP",
-      "document_type": "NIC",
-      "id": 4261,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Cyprus | Κύπρος",
-      "country_alpha2": "CY",
-      "country_alpha3": "CYP",
-      "document_type": "NIC",
-      "id": 4262,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2000"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Cyprus | Κύπρος",
-      "country_alpha2": "CY",
-      "country_alpha3": "CYP",
-      "document_type": "NIC",
-      "id": 4263,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Czech Republic | Česko",
-      "country_alpha2": "CZ",
-      "country_alpha3": "CZE",
-      "document_type": "NIC",
-      "id": 4266,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2000"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Czech Republic | Česko",
-      "country_alpha2": "CZ",
-      "country_alpha3": "CZE",
-      "document_type": "NIC",
-      "id": 4267,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "NIC",
-      "id": 4355,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2002"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Malta",
-      "country_alpha2": "MT",
-      "country_alpha3": "MLT",
-      "document_type": "NIC",
-      "id": 4391,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Romania | România",
-      "country_alpha2": "RO",
-      "country_alpha3": "ROU",
-      "document_type": "NIC",
-      "id": 4425,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Switzerland | Schweiz",
-      "country_alpha2": "CH",
-      "country_alpha3": "CHE",
-      "document_type": "NIC",
-      "id": 4456,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2005"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Colombia",
-      "country_alpha2": "CO",
-      "country_alpha3": "COL",
-      "document_type": "NIC",
-      "id": 4547,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1993"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Colombia",
-      "country_alpha2": "CO",
-      "country_alpha3": "COL",
-      "document_type": "NIC",
-      "id": 4548,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2000"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Colombia",
-      "country_alpha2": "CO",
-      "country_alpha3": "COL",
-      "document_type": "NIC",
-      "id": 4549,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "NIC",
-      "id": 4554,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "NIC",
-      "id": 4555,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "NIC",
-      "id": 4556,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Kenya",
-      "country_alpha2": "KE",
-      "country_alpha3": "KEN",
-      "document_type": "NIC",
-      "id": 4570,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1996"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Kenya",
-      "country_alpha2": "KE",
-      "country_alpha3": "KEN",
-      "document_type": "NIC",
-      "id": 4571,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Peru | Perú",
-      "country_alpha2": "PE",
-      "country_alpha3": "PER",
-      "document_type": "NIC",
-      "id": 4584,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2005"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Peru | Perú",
-      "country_alpha2": "PE",
-      "country_alpha3": "PER",
-      "document_type": "NIC",
-      "id": 4585,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Slovenia | Slovenija",
-      "country_alpha2": "SI",
-      "country_alpha3": "SVN",
-      "document_type": "NIC",
-      "id": 4592,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1998"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Sweden | Sverige",
-      "country_alpha2": "SE",
-      "country_alpha3": "SWE",
-      "document_type": "NIC",
-      "id": 4597,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Estonia | Eesti",
-      "country_alpha2": "EE",
-      "country_alpha3": "EST",
-      "document_type": "NIC",
-      "id": 4599,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Estonia | Eesti",
-      "country_alpha2": "EE",
-      "country_alpha3": "EST",
-      "document_type": "NIC",
-      "id": 4600,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Estonia | Eesti",
-      "country_alpha2": "EE",
-      "country_alpha3": "EST",
-      "document_type": "NIC",
-      "id": 4601,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Pakistan | پاکستان",
-      "country_alpha2": "PK",
-      "country_alpha3": "PAK",
-      "document_type": "NIC",
-      "id": 4649,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
     }
   },
   {
@@ -2097,342 +5427,6 @@
   },
   {
     "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Austria | Österreich",
-      "country_alpha2": "AT",
-      "country_alpha3": "AUT",
-      "document_type": "NIC",
-      "id": 4819,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Austria | Österreich",
-      "country_alpha2": "AT",
-      "country_alpha3": "AUT",
-      "document_type": "NIC",
-      "id": 4820,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2002"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Ukraine | Ukraїna",
-      "country_alpha2": "UA",
-      "country_alpha3": "UKR",
-      "document_type": "NIC",
-      "id": 4826,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Morocco | المغرب",
-      "country_alpha2": "MA",
-      "country_alpha3": "MAR",
-      "document_type": "NIC",
-      "id": 4881,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Ecuador",
-      "country_alpha2": "EC",
-      "country_alpha3": "ECU",
-      "document_type": "NIC",
-      "id": 4894,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Ecuador",
-      "country_alpha2": "EC",
-      "country_alpha3": "ECU",
-      "document_type": "NIC",
-      "id": 4895,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Algeria | الجزائر",
-      "country_alpha2": "DZ",
-      "country_alpha3": "DZA",
-      "document_type": "NIC",
-      "id": 4981,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Angola | Ngola",
-      "country_alpha2": "AO",
-      "country_alpha3": "AGO",
-      "document_type": "NIC",
-      "id": 4982,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Botswana",
-      "country_alpha2": "BW",
-      "country_alpha3": "BWA",
-      "document_type": "NIC",
-      "id": 4984,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Cameroon",
-      "country_alpha2": "CM",
-      "country_alpha3": "CMR",
-      "document_type": "NIC",
-      "id": 4985,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Ethiopia | ኢትዮጵያ",
-      "country_alpha2": "ET",
-      "country_alpha3": "ETH",
-      "document_type": "NIC",
-      "id": 4993,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Ghana",
-      "country_alpha2": "GH",
-      "country_alpha3": "GHA",
-      "document_type": "NIC",
-      "id": 4996,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Malawi | Malaŵi",
-      "country_alpha2": "MW",
-      "country_alpha3": "MWI",
-      "document_type": "NIC",
-      "id": 5000,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Namibia",
-      "country_alpha2": "NA",
-      "country_alpha3": "NAM",
-      "document_type": "NIC",
-      "id": 5002,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1994"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Swaziland | eSwatini",
-      "country_alpha2": "SZ",
-      "country_alpha3": "SWZ",
-      "document_type": "NIC",
-      "id": 5008,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2000"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Uganda",
-      "country_alpha2": "UG",
-      "country_alpha3": "UGA",
-      "document_type": "NIC",
-      "id": 5014,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Zimbabwe",
-      "country_alpha2": "ZW",
-      "country_alpha3": "ZWE",
-      "document_type": "NIC",
-      "id": 5017,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Bolivia (Plurinational State of) | Bolivia",
-      "country_alpha2": "BO",
-      "country_alpha3": "BOL",
-      "document_type": "NIC",
-      "id": 5045,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Paraguay | Paraguái",
-      "country_alpha2": "PY",
-      "country_alpha3": "PRY",
-      "document_type": "NIC",
-      "id": 5051,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Costa Rica",
-      "country_alpha2": "CR",
-      "country_alpha3": "CRI",
-      "document_type": "NIC",
-      "id": 5071,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1999"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Guam | Guåhån",
-      "country_alpha2": "GU",
-      "country_alpha3": "GUM",
-      "document_type": "NIC",
-      "id": 5105,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
       "back_required": false,
       "common_name": "State Identity Card",
       "country": "United States of America",
@@ -2525,278 +5519,6 @@
         "verify"
       ],
       "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Bosnia and Herzegovina | Bosna i Hercegovina",
-      "country_alpha2": "BA",
-      "country_alpha3": "BIH",
-      "document_type": "NIC",
-      "id": 5122,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Gibraltar",
-      "country_alpha2": "GI",
-      "country_alpha3": "GIB",
-      "document_type": "NIC",
-      "id": 5129,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Liechtenstein",
-      "country_alpha2": "LI",
-      "country_alpha3": "LIE",
-      "document_type": "NIC",
-      "id": 5130,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Serbia | Србија",
-      "country_alpha2": "RS",
-      "country_alpha3": "SRB",
-      "document_type": "NIC",
-      "id": 5138,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Bahrain | البحرين",
-      "country_alpha2": "BH",
-      "country_alpha3": "BHR",
-      "document_type": "NIC",
-      "id": 5140,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Bangladesh | বাংলাদেশ",
-      "country_alpha2": "BD",
-      "country_alpha3": "BGD",
-      "document_type": "NIC",
-      "id": 5141,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016 2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Brunei Darussalam | بروني",
-      "country_alpha2": "BN",
-      "country_alpha3": "BRN",
-      "document_type": "NIC",
-      "id": 5145,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "China | 中国",
-      "country_alpha2": "CN",
-      "country_alpha3": "CHN",
-      "document_type": "NIC",
-      "id": 5147,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": "Individual Number Card",
-      "country": "Japan | 日本",
-      "country_alpha2": "JP",
-      "country_alpha3": "JPN",
-      "document_type": "NIC",
-      "id": 5151,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Jordan | الأردن",
-      "country_alpha2": "JO",
-      "country_alpha3": "JOR",
-      "document_type": "NIC",
-      "id": 5156,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Kuwait | دولة الكويت",
-      "country_alpha2": "KW",
-      "country_alpha3": "KWT",
-      "document_type": "NIC",
-      "id": 5158,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Philippines | Pilipinas",
-      "country_alpha2": "PH",
-      "country_alpha3": "PHL",
-      "document_type": "NIC",
-      "id": 5163,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2000"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Qatar | قطر",
-      "country_alpha2": "QA",
-      "country_alpha3": "QAT",
-      "document_type": "NIC",
-      "id": 5170,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Thailand | ประเทศไทย",
-      "country_alpha2": "TH",
-      "country_alpha3": "THA",
-      "document_type": "NIC",
-      "id": 5179,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Dominican Republic | República Dominicana",
-      "country_alpha2": "DO",
-      "country_alpha3": "DOM",
-      "document_type": "NIC",
-      "id": 5198,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "El Salvador",
-      "country_alpha2": "SV",
-      "country_alpha3": "SLV",
-      "document_type": "NIC",
-      "id": 5199,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Guatemala",
-      "country_alpha2": "GT",
-      "country_alpha3": "GTM",
-      "document_type": "NIC",
-      "id": 5201,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
     }
   },
   {
@@ -3219,998 +5941,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Taiwan, Province of China | 中華民國",
-      "country_alpha2": "TW",
-      "country_alpha3": "TWN",
-      "document_type": "NIC",
-      "id": 5269,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "Aadhaar Card",
-      "country": "India | भारत",
-      "country_alpha2": "IN",
-      "country_alpha3": "IND",
-      "document_type": "NIC",
-      "id": 5274,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "5"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Trinidad and Tobago",
-      "country_alpha2": "TT",
-      "country_alpha3": "TTO",
-      "document_type": "NIC",
-      "id": 5303,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Tanzania, United Republic of",
-      "country_alpha2": "TZ",
-      "country_alpha3": "TZA",
-      "document_type": "NIC",
-      "id": 5435,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Lesotho",
-      "country_alpha2": "LS",
-      "country_alpha3": "LSO",
-      "document_type": "NIC",
-      "id": 5489,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Mozambique | Moçambique",
-      "country_alpha2": "MZ",
-      "country_alpha3": "MOZ",
-      "document_type": "NIC",
-      "id": 5495,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2019"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Nigeria | Nijeriya",
-      "country_alpha2": "NG",
-      "country_alpha3": "NGA",
-      "document_type": "NIC",
-      "id": 5497,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Nigeria | Nijeriya",
-      "country_alpha2": "NG",
-      "country_alpha3": "NGA",
-      "document_type": "NIC",
-      "id": 5500,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Senegal | Sénégal",
-      "country_alpha2": "SN",
-      "country_alpha3": "SEN",
-      "document_type": "NIC",
-      "id": 5505,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2019"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Costa Rica",
-      "country_alpha2": "CR",
-      "country_alpha3": "CRI",
-      "document_type": "NIC",
-      "id": 5538,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1998"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5547,
-      "region_iso": "NL",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Guatemala",
-      "country_alpha2": "GT",
-      "country_alpha3": "GTM",
-      "document_type": "NIC",
-      "id": 5557,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Puerto Rico",
-      "country_alpha2": "PR",
-      "country_alpha3": "PRI",
-      "document_type": "NIC",
-      "id": 5571,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Puerto Rico",
-      "country_alpha2": "PR",
-      "country_alpha3": "PRI",
-      "document_type": "NIC",
-      "id": 5572,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Bolivia (Plurinational State of) | Bolivia",
-      "country_alpha2": "BO",
-      "country_alpha3": "BOL",
-      "document_type": "NIC",
-      "id": 5799,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Paraguay | Paraguái",
-      "country_alpha2": "PY",
-      "country_alpha3": "PRY",
-      "document_type": "NIC",
-      "id": 5809,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Azerbaijan | Azərbaycan",
-      "country_alpha2": "AZ",
-      "country_alpha3": "AZE",
-      "document_type": "NIC",
-      "id": 5871,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "China | 中国",
-      "country_alpha2": "CN",
-      "country_alpha3": "CHN",
-      "document_type": "NIC",
-      "id": 5879,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "HKID",
-      "country": "Hong Kong | 香港",
-      "country_alpha2": "HK",
-      "country_alpha3": "HKG",
-      "document_type": "NIC",
-      "id": 5882,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "HKID",
-      "country": "Hong Kong | 香港",
-      "country_alpha2": "HK",
-      "country_alpha3": "HKG",
-      "document_type": "NIC",
-      "id": 5884,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003 2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "Aadhaar Card",
-      "country": "India | भारत",
-      "country_alpha2": "IN",
-      "country_alpha3": "IND",
-      "document_type": "NIC",
-      "id": 5886,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "6"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "Aadhaar Card",
-      "country": "India | भारत",
-      "country_alpha2": "IN",
-      "country_alpha3": "IND",
-      "document_type": "NIC",
-      "id": 5887,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "Aadhaar Card",
-      "country": "India | भारत",
-      "country_alpha2": "IN",
-      "country_alpha3": "IND",
-      "document_type": "NIC",
-      "id": 5888,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "3"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "Aadhaar Card",
-      "country": "India | भारत",
-      "country_alpha2": "IN",
-      "country_alpha3": "IND",
-      "document_type": "NIC",
-      "id": 5889,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "4"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Indonesia",
-      "country_alpha2": "ID",
-      "country_alpha3": "IDN",
-      "document_type": "NIC",
-      "id": 5896,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1977"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Jordan | الأردن",
-      "country_alpha2": "JO",
-      "country_alpha3": "JOR",
-      "document_type": "NIC",
-      "id": 5903,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Kuwait | دولة الكويت",
-      "country_alpha2": "KW",
-      "country_alpha3": "KWT",
-      "document_type": "NIC",
-      "id": 5907,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "MyTentera",
-      "country": "Malaysia",
-      "country_alpha2": "MY",
-      "country_alpha3": "MYS",
-      "document_type": "NIC",
-      "id": 5910,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Oman | عمان",
-      "country_alpha2": "OM",
-      "country_alpha3": "OMN",
-      "document_type": "NIC",
-      "id": 5918,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Oman | عمان",
-      "country_alpha2": "OM",
-      "country_alpha3": "OMN",
-      "document_type": "NIC",
-      "id": 5919,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2019"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "Origin Card",
-      "country": "Pakistan | پاکستان",
-      "country_alpha2": "PK",
-      "country_alpha3": "PAK",
-      "document_type": "NIC",
-      "id": 5921,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": ""
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "Overseas ",
-      "country": "Pakistan | پاکستان",
-      "country_alpha2": "PK",
-      "country_alpha3": "PAK",
-      "document_type": "NIC",
-      "id": 5922,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Philippines | Pilipinas",
-      "country_alpha2": "PH",
-      "country_alpha3": "PHL",
-      "document_type": "NIC",
-      "id": 5925,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Qatar | قطر",
-      "country_alpha2": "QA",
-      "country_alpha3": "QAT",
-      "document_type": "NIC",
-      "id": 5932,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Singapore",
-      "country_alpha2": "SG",
-      "country_alpha3": "SGP",
-      "document_type": "NIC",
-      "id": 5940,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Singapore",
-      "country_alpha2": "SG",
-      "country_alpha3": "SGP",
-      "document_type": "NIC",
-      "id": 5941,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "3"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Singapore",
-      "country_alpha2": "SG",
-      "country_alpha3": "SGP",
-      "document_type": "NIC",
-      "id": 5942,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "4"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Singapore",
-      "country_alpha2": "SG",
-      "country_alpha3": "SGP",
-      "document_type": "NIC",
-      "id": 5943,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "5"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United Arab Emirates | الإمارات العربية المتحدة",
-      "country_alpha2": "AE",
-      "country_alpha3": "ARE",
-      "document_type": "NIC",
-      "id": 5956,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Viet Nam | Việt Nam",
-      "country_alpha2": "VN",
-      "country_alpha3": "VNM",
-      "document_type": "NIC",
-      "id": 5962,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Viet Nam | Việt Nam",
-      "country_alpha2": "VN",
-      "country_alpha3": "VNM",
-      "document_type": "NIC",
-      "id": 5963,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Austria | Österreich",
-      "country_alpha2": "AT",
-      "country_alpha3": "AUT",
-      "document_type": "NIC",
-      "id": 6003,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "NIC",
-      "id": 6007,
-      "region_iso": "VLG",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "NIC",
-      "id": 6008,
-      "region_iso": "WAL",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "NIC",
-      "id": 6013,
-      "region_iso": "WAL",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Croatia | Hrvatska",
-      "country_alpha2": "HR",
-      "country_alpha3": "HRV",
-      "document_type": "NIC",
-      "id": 6025,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Croatia | Hrvatska",
-      "country_alpha2": "HR",
-      "country_alpha3": "HRV",
-      "document_type": "NIC",
-      "id": 6026,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013-2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Finland | Suomi",
-      "country_alpha2": "FI",
-      "country_alpha3": "FIN",
-      "document_type": "NIC",
-      "id": 6041,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Gibraltar",
-      "country_alpha2": "GI",
-      "country_alpha3": "GIB",
-      "document_type": "NIC",
-      "id": 6079,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2000"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Greece | Ελλάδα",
-      "country_alpha2": "GR",
-      "country_alpha3": "GRC",
-      "document_type": "NIC",
-      "id": 6080,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2000-2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "NIC",
-      "id": 6082,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016 1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "NIC",
-      "id": 6086,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016 4"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Kosovo, Republic of",
-      "country_alpha2": "XK",
-      "country_alpha3": "RKS",
-      "document_type": "NIC",
-      "id": 6098,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Liechtenstein",
-      "country_alpha2": "LI",
-      "country_alpha3": "LIE",
-      "document_type": "NIC",
-      "id": 6103,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1995"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Luxembourg | Luxemburg",
-      "country_alpha2": "LU",
-      "country_alpha3": "LUX",
-      "document_type": "NIC",
-      "id": 6107,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014 1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Moldova (Republic of)",
-      "country_alpha2": "MD",
-      "country_alpha3": "MDA",
-      "document_type": "NIC",
-      "id": 6114,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1996"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Moldova (Republic of)",
-      "country_alpha2": "MD",
-      "country_alpha3": "MDA",
-      "document_type": "NIC",
-      "id": 6115,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2005"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Romania | România",
-      "country_alpha2": "RO",
-      "country_alpha3": "ROU",
-      "document_type": "NIC",
-      "id": 6124,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Romania | România",
-      "country_alpha2": "RO",
-      "country_alpha3": "ROU",
-      "document_type": "NIC",
-      "id": 6125,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Romania | România",
-      "country_alpha2": "RO",
-      "country_alpha3": "ROU",
-      "document_type": "NIC",
-      "id": 6127,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": "Internal Passport",
-      "country": "Russian Federation | Россия",
-      "country_alpha2": "RU",
-      "country_alpha3": "RUS",
-      "document_type": "NIC",
-      "id": 6128,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": "Internal Passport",
-      "country": "Russian Federation | Россия",
-      "country_alpha2": "RU",
-      "country_alpha3": "RUS",
-      "document_type": "NIC",
-      "id": 6129,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "United States of America",
       "country_alpha2": "US",
       "country_alpha3": "USA",
@@ -4477,38 +6207,6 @@
         "verify"
       ],
       "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Guam | Guåhån",
-      "country_alpha2": "GU",
-      "country_alpha3": "GUM",
-      "document_type": "NIC",
-      "id": 6168,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Guam | Guåhån",
-      "country_alpha2": "GU",
-      "country_alpha3": "GUM",
-      "document_type": "NIC",
-      "id": 6169,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
     }
   },
   {
@@ -5905,22 +7603,6 @@
   },
   {
     "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Virgin Islands (U.S.)",
-      "country_alpha2": "VI",
-      "country_alpha3": "VIR",
-      "document_type": "NIC",
-      "id": 6265,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2019"
-    }
-  },
-  {
-    "sourceData": {
       "back_required": true,
       "common_name": null,
       "country": "United States of America",
@@ -6173,39 +7855,6 @@
         "verify"
       ],
       "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Korea (Republic of) | 한국",
-      "country_alpha2": "KR",
-      "country_alpha3": "KOR",
-      "document_type": "NIC",
-      "id": 6491,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2001"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "NIC",
-      "id": 6689,
-      "region_iso": null,
-      "usecases": [
-        "verify",
-        "right_to_work"
-      ],
-      "version": "2019"
     }
   },
   {
@@ -6595,486 +8244,6 @@
   {
     "sourceData": {
       "back_required": false,
-      "common_name": null,
-      "country": "Mozambique | Moçambique",
-      "country_alpha2": "MZ",
-      "country_alpha3": "MOZ",
-      "document_type": "NIC",
-      "id": 6887,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Angola | Ngola",
-      "country_alpha2": "AO",
-      "country_alpha3": "AGO",
-      "document_type": "NIC",
-      "id": 7052,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Brunei Darussalam | بروني",
-      "country_alpha2": "BN",
-      "country_alpha3": "BRN",
-      "document_type": "NIC",
-      "id": 7118,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Uruguay",
-      "country_alpha2": "UY",
-      "country_alpha3": "URY",
-      "document_type": "NIC",
-      "id": 7251,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": ""
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "El Salvador",
-      "country_alpha2": "SV",
-      "country_alpha3": "SLV",
-      "document_type": "NIC",
-      "id": 7285,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Korea (Republic of) | 한국",
-      "country_alpha2": "KR",
-      "country_alpha3": "KOR",
-      "document_type": "NIC",
-      "id": 8142,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Morocco | المغرب",
-      "country_alpha2": "MA",
-      "country_alpha3": "MAR",
-      "document_type": "NIC",
-      "id": 8273,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2020"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Peru | Perú",
-      "country_alpha2": "PE",
-      "country_alpha3": "PER",
-      "document_type": "NIC",
-      "id": 8307,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2020"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Chile",
-      "country_alpha2": "CL",
-      "country_alpha3": "CHL",
-      "document_type": "NIC",
-      "id": 3141,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "NIC",
-      "id": 3777,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Germany | Deutschland",
-      "country_alpha2": "DE",
-      "country_alpha3": "DEU",
-      "document_type": "NIC",
-      "id": 4112,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Germany | Deutschland",
-      "country_alpha2": "DE",
-      "country_alpha3": "DEU",
-      "document_type": "NIC",
-      "id": 4113,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Portugal",
-      "country_alpha2": "PT",
-      "country_alpha3": "PRT",
-      "document_type": "NIC",
-      "id": 4177,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "South Africa | Suid-Afrika",
-      "country_alpha2": "ZA",
-      "country_alpha3": "ZAF",
-      "document_type": "NIC",
-      "id": 4189,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Greece | Ελλάδα",
-      "country_alpha2": "GR",
-      "country_alpha3": "GRC",
-      "document_type": "NIC",
-      "id": 4317,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "NIC",
-      "id": 4398,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Venezuela (Bolivarian Republic of)",
-      "country_alpha2": "VE",
-      "country_alpha3": "VEN",
-      "document_type": "NIC",
-      "id": 5189,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": "2010 label variation",
-      "country": "Germany | Deutschland",
-      "country_alpha2": "DE",
-      "country_alpha3": "DEU",
-      "document_type": "NIC",
-      "id": 8405,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2020"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "NIC",
-      "id": 3023,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "NIC",
-      "id": 3025,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "NIC",
-      "id": 3026,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Chile",
-      "country_alpha2": "CL",
-      "country_alpha3": "CHL",
-      "document_type": "NIC",
-      "id": 3140,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Chile",
-      "country_alpha2": "CL",
-      "country_alpha3": "CHL",
-      "document_type": "NIC",
-      "id": 3142,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2002"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Malta",
-      "country_alpha2": "MT",
-      "country_alpha3": "MLT",
-      "document_type": "NIC",
-      "id": 3610,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Netherlands | Nederland",
-      "country_alpha2": "NL",
-      "country_alpha3": "NLD",
-      "document_type": "NIC",
-      "id": 3679,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Netherlands | Nederland",
-      "country_alpha2": "NL",
-      "country_alpha3": "NLD",
-      "document_type": "NIC",
-      "id": 3680,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Slovakia | Slovensko",
-      "country_alpha2": "SK",
-      "country_alpha3": "SVK",
-      "document_type": "NIC",
-      "id": 3856,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Slovakia | Slovensko",
-      "country_alpha2": "SK",
-      "country_alpha3": "SVK",
-      "document_type": "NIC",
-      "id": 3857,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1993"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Slovakia | Slovensko",
-      "country_alpha2": "SK",
-      "country_alpha3": "SVK",
-      "document_type": "NIC",
-      "id": 3858,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Spain | España",
-      "country_alpha2": "ES",
-      "country_alpha3": "ESP",
-      "document_type": "NIC",
-      "id": 3896,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
       "common_name": "State Identity Card",
       "country": "United States of America",
       "country_alpha2": "US",
@@ -7086,950 +8255,6 @@
         "verify"
       ],
       "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Czech Republic | Česko",
-      "country_alpha2": "CZ",
-      "country_alpha3": "CZE",
-      "document_type": "NIC",
-      "id": 4264,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Czech Republic | Česko",
-      "country_alpha2": "CZ",
-      "country_alpha3": "CZE",
-      "document_type": "NIC",
-      "id": 4265,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Spain | España",
-      "country_alpha2": "ES",
-      "country_alpha3": "ESP",
-      "document_type": "NIC",
-      "id": 4442,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "HKID",
-      "country": "Hong Kong | 香港",
-      "country_alpha2": "HK",
-      "country_alpha3": "HKG",
-      "document_type": "NIC",
-      "id": 5885,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018-2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 8114,
-      "region_iso": "PE",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Mauritius | Maurice",
-      "country_alpha2": "MU",
-      "country_alpha3": "MUS",
-      "document_type": "NIC",
-      "id": 5001,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Georgia | საქართველო",
-      "country_alpha2": "GE",
-      "country_alpha3": "GEO",
-      "document_type": "NIC",
-      "id": 5127,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Tanzania, United Republic of",
-      "country_alpha2": "TZ",
-      "country_alpha3": "TZA",
-      "document_type": "NIC",
-      "id": 8118,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "3"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 3123,
-      "region_iso": "NL",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Italy | Italia",
-      "country_alpha2": "IT",
-      "country_alpha3": "ITA",
-      "document_type": "NIC",
-      "id": 3446,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Italy | Italia",
-      "country_alpha2": "IT",
-      "country_alpha3": "ITA",
-      "document_type": "NIC",
-      "id": 4342,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5059,
-      "region_iso": "AB",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5060,
-      "region_iso": "BC",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5061,
-      "region_iso": "MB",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5062,
-      "region_iso": "NB",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5065,
-      "region_iso": "NU",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5066,
-      "region_iso": "ON",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5067,
-      "region_iso": "PE",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5068,
-      "region_iso": "SK",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5195,
-      "region_iso": "YT",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5532,
-      "region_iso": "AB",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5533,
-      "region_iso": "NL",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5534,
-      "region_iso": "NT",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5544,
-      "region_iso": "NB",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5548,
-      "region_iso": "PE",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5549,
-      "region_iso": "NS",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5550,
-      "region_iso": "NS",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8504,
-      "region_iso": "AC",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8505,
-      "region_iso": "AL",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8506,
-      "region_iso": "AM",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8507,
-      "region_iso": "AP",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8508,
-      "region_iso": "BA",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8509,
-      "region_iso": "CE",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8510,
-      "region_iso": "DF",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8511,
-      "region_iso": "GO",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8512,
-      "region_iso": "MA",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8513,
-      "region_iso": "MG",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8514,
-      "region_iso": "MS",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8515,
-      "region_iso": "MT",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8516,
-      "region_iso": "PA",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8517,
-      "region_iso": "PB",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8518,
-      "region_iso": "PE",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8519,
-      "region_iso": "PI",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8520,
-      "region_iso": "PR",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8521,
-      "region_iso": "RJ",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8522,
-      "region_iso": "RN",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8523,
-      "region_iso": "RO",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8524,
-      "region_iso": "RR",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8525,
-      "region_iso": "RS",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8526,
-      "region_iso": "SC",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8527,
-      "region_iso": "SE",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8529,
-      "region_iso": "TO",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8195,
-      "region_iso": "SP",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8196,
-      "region_iso": "SP",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8197,
-      "region_iso": "ES",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Cameroon",
-      "country_alpha2": "CM",
-      "country_alpha3": "CMR",
-      "document_type": "NIC",
-      "id": 7812,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Tanzania, United Republic of",
-      "country_alpha2": "TZ",
-      "country_alpha3": "TZA",
-      "document_type": "NIC",
-      "id": 8117,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "NIC",
-      "id": 8125,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8194,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
     }
   },
   {
@@ -8050,71 +8275,6 @@
   },
   {
     "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Italy | Italia",
-      "country_alpha2": "IT",
-      "country_alpha3": "ITA",
-      "document_type": "NIC",
-      "id": 4341,
-      "region_iso": null,
-      "usecases": [
-        "verify",
-        "right_to_work"
-      ],
-      "version": "1994"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Luxembourg | Luxemburg",
-      "country_alpha2": "LU",
-      "country_alpha3": "LUX",
-      "document_type": "NIC",
-      "id": 3566,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Luxembourg | Luxemburg",
-      "country_alpha2": "LU",
-      "country_alpha3": "LUX",
-      "document_type": "NIC",
-      "id": 3567,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Luxembourg | Luxemburg",
-      "country_alpha2": "LU",
-      "country_alpha3": "LUX",
-      "document_type": "NIC",
-      "id": 3568,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
       "back_required": false,
       "common_name": null,
       "country": "United States of America",
@@ -8127,182 +8287,6 @@
         "verify"
       ],
       "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Portugal",
-      "country_alpha2": "PT",
-      "country_alpha3": "PRT",
-      "document_type": "NIC",
-      "id": 3794,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Portugal",
-      "country_alpha2": "PT",
-      "country_alpha3": "PRT",
-      "document_type": "NIC",
-      "id": 3795,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Latvia | Latvija",
-      "country_alpha2": "LV",
-      "country_alpha3": "LVA",
-      "document_type": "NIC",
-      "id": 4143,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "NIC",
-      "id": 4145,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "NIC",
-      "id": 4147,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "NIC",
-      "id": 4170,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "NIC",
-      "id": 4171,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Slovakia | Slovensko",
-      "country_alpha2": "SK",
-      "country_alpha3": "SVK",
-      "document_type": "NIC",
-      "id": 4187,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Portugal",
-      "country_alpha2": "PT",
-      "country_alpha3": "PRT",
-      "document_type": "NIC",
-      "id": 4416,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Monaco",
-      "country_alpha2": "MC",
-      "country_alpha3": "MCO",
-      "document_type": "NIC",
-      "id": 5133,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Montenegro | Crna Gora",
-      "country_alpha2": "ME",
-      "country_alpha3": "MNE",
-      "document_type": "NIC",
-      "id": 5136,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
     }
   },
   {
@@ -8379,22 +8363,6 @@
       "document_type": "NIC",
       "id": 5248,
       "region_iso": "PA",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Bosnia and Herzegovina | Bosna i Hercegovina",
-      "country_alpha2": "BA",
-      "country_alpha3": "BIH",
-      "document_type": "NIC",
-      "id": 6023,
-      "region_iso": null,
       "usecases": [
         "verify"
       ],
@@ -8501,11 +8469,59 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Dominican Republic | República Dominicana",
-      "country_alpha2": "DO",
-      "country_alpha3": "DOM",
+      "country": "Uruguay",
+      "country_alpha2": "UY",
+      "country_alpha3": "URY",
       "document_type": "NIC",
-      "id": 8438,
+      "id": 4006,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015 "
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Uruguay",
+      "country_alpha2": "UY",
+      "country_alpha3": "URY",
+      "document_type": "NIC",
+      "id": 7251,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": ""
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Venezuela (Bolivarian Republic of)",
+      "country_alpha2": "VE",
+      "country_alpha3": "VEN",
+      "document_type": "NIC",
+      "id": 5189,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Viet Nam | Việt Nam",
+      "country_alpha2": "VN",
+      "country_alpha3": "VNM",
+      "document_type": "NIC",
+      "id": 5182,
       "region_iso": null,
       "usecases": [
         "verify"
@@ -8517,80 +8533,64 @@
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "South Africa | Suid-Afrika",
-      "country_alpha2": "ZA",
-      "country_alpha3": "ZAF",
+      "country": "Viet Nam | Việt Nam",
+      "country_alpha2": "VN",
+      "country_alpha3": "VNM",
       "document_type": "NIC",
-      "id": 4188,
+      "id": 5962,
       "region_iso": null,
       "usecases": [
         "verify"
       ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "NIC",
-      "id": 4639,
-      "region_iso": "VLG",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
+      "version": "2012"
     }
   },
   {
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
+      "country": "Viet Nam | Việt Nam",
+      "country_alpha2": "VN",
+      "country_alpha3": "VNM",
       "document_type": "NIC",
-      "id": 6010,
-      "region_iso": "BRU",
+      "id": 5963,
+      "region_iso": null,
       "usecases": [
         "verify"
       ],
-      "version": "2015"
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Virgin Islands (U.S.)",
+      "country_alpha2": "VI",
+      "country_alpha3": "VIR",
+      "document_type": "NIC",
+      "id": 6265,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2019"
     }
   },
   {
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
+      "country": "Zimbabwe",
+      "country_alpha2": "ZW",
+      "country_alpha3": "ZWE",
       "document_type": "NIC",
-      "id": 6014,
-      "region_iso": "VLG",
+      "id": 5017,
+      "region_iso": null,
       "usecases": [
         "verify"
       ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "NIC",
-      "id": 6015,
-      "region_iso": "VLG",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
+      "version": "2012"
     }
   }
 ]

--- a/src/supported-documents/supported-docs-national_identity_card.json
+++ b/src/supported-documents/supported-docs-national_identity_card.json
@@ -227,38 +227,6 @@
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "Saudi Arabia | السعودية",
-      "country_alpha2": "SA",
-      "country_alpha3": "SAU",
-      "document_type": "NIC",
-      "id": 7811,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Cameroon",
-      "country_alpha2": "CM",
-      "country_alpha3": "CMR",
-      "document_type": "NIC",
-      "id": 7812,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
       "country": "United States of America",
       "country_alpha2": "US",
       "country_alpha3": "USA",
@@ -535,22 +503,6 @@
       "country_alpha2": "US",
       "country_alpha3": "USA",
       "document_type": "NIC",
-      "id": 8057,
-      "region_iso": "CA",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "NIC",
       "id": 8058,
       "region_iso": "CT",
       "usecases": [
@@ -658,38 +610,6 @@
   {
     "sourceData": {
       "back_required": false,
-      "common_name": null,
-      "country": "Tanzania, United Republic of",
-      "country_alpha2": "TZ",
-      "country_alpha3": "TZA",
-      "document_type": "NIC",
-      "id": 8118,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Argentina",
-      "country_alpha2": "AR",
-      "country_alpha3": "ARG",
-      "document_type": "NIC",
-      "id": 8125,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
       "common_name": "",
       "country": "Brazil | Brasil",
       "country_alpha2": "BR",
@@ -711,104 +631,8 @@
       "country_alpha2": "US",
       "country_alpha3": "USA",
       "document_type": "NIC",
-      "id": 8191,
-      "region_iso": "WA",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "NIC",
       "id": 8192,
       "region_iso": "WA",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "NIC",
-      "id": 8193,
-      "region_iso": "WV",
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8194,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8195,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8196,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Brazil | Brasil",
-      "country_alpha2": "BR",
-      "country_alpha3": "BRA",
-      "document_type": "NIC",
-      "id": 8197,
-      "region_iso": null,
       "usecases": [
         "verify"
       ],
@@ -931,22 +755,6 @@
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 3123,
-      "region_iso": "NL",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
       "country": "Finland | Suomi",
       "country_alpha2": "FI",
       "country_alpha3": "FIN",
@@ -1021,54 +829,6 @@
         "verify"
       ],
       "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Luxembourg | Luxemburg",
-      "country_alpha2": "LU",
-      "country_alpha3": "LUX",
-      "document_type": "NIC",
-      "id": 3566,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Luxembourg | Luxemburg",
-      "country_alpha2": "LU",
-      "country_alpha3": "LUX",
-      "document_type": "NIC",
-      "id": 3567,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Luxembourg | Luxemburg",
-      "country_alpha2": "LU",
-      "country_alpha3": "LUX",
-      "document_type": "NIC",
-      "id": 3568,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
     }
   },
   {
@@ -1585,54 +1345,6 @@
   },
   {
     "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Latvia | Latvija",
-      "country_alpha2": "LV",
-      "country_alpha3": "LVA",
-      "document_type": "NIC",
-      "id": 4143,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "NIC",
-      "id": 4145,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "NIC",
-      "id": 4147,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
       "back_required": false,
       "common_name": "MyKAD",
       "country": "Malaysia",
@@ -1693,22 +1405,6 @@
         "verify"
       ],
       "version": "2006"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Slovakia | Slovensko",
-      "country_alpha2": "SK",
-      "country_alpha3": "SVK",
-      "document_type": "NIC",
-      "id": 4187,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
     }
   },
   {
@@ -2129,22 +1825,6 @@
   },
   {
     "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "NIC",
-      "id": 4639,
-      "region_iso": "VLG",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
       "back_required": false,
       "common_name": null,
       "country": "Pakistan | پاکستان",
@@ -2205,22 +1885,6 @@
         "verify"
       ],
       "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "State Identity Card",
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "NIC",
-      "id": 4660,
-      "region_iso": "AK",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
     }
   },
   {
@@ -2643,22 +2307,6 @@
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "Mauritius | Maurice",
-      "country_alpha2": "MU",
-      "country_alpha3": "MUS",
-      "document_type": "NIC",
-      "id": 5001,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
       "country": "Namibia",
       "country_alpha2": "NA",
       "country_alpha3": "NAM",
@@ -2749,134 +2397,6 @@
         "verify"
       ],
       "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5059,
-      "region_iso": "AB",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5060,
-      "region_iso": "BC",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5061,
-      "region_iso": "MB",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5062,
-      "region_iso": "NB",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5065,
-      "region_iso": "NU",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5066,
-      "region_iso": "ON",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5067,
-      "region_iso": "PE",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5068,
-      "region_iso": "SK",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
     }
   },
   {
@@ -3027,22 +2547,6 @@
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "Georgia | საქართველო",
-      "country_alpha2": "GE",
-      "country_alpha3": "GEO",
-      "document_type": "NIC",
-      "id": 5127,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
       "country": "Gibraltar",
       "country_alpha2": "GI",
       "country_alpha3": "GIB",
@@ -3069,38 +2573,6 @@
         "verify"
       ],
       "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Monaco",
-      "country_alpha2": "MC",
-      "country_alpha3": "MCO",
-      "document_type": "NIC",
-      "id": 5133,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Montenegro | Crna Gora",
-      "country_alpha2": "ME",
-      "country_alpha3": "MNE",
-      "document_type": "NIC",
-      "id": 5136,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
     }
   },
   {
@@ -3277,22 +2749,6 @@
         "verify"
       ],
       "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5195,
-      "region_iso": "YT",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
     }
   },
   {
@@ -3511,38 +2967,6 @@
       "country_alpha2": "US",
       "country_alpha3": "USA",
       "document_type": "NIC",
-      "id": 5234,
-      "region_iso": "ND",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "State Identity Card",
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "NIC",
-      "id": 5235,
-      "region_iso": "NE",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "State Identity Card",
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "NIC",
       "id": 5237,
       "region_iso": "NH",
       "usecases": [
@@ -3607,60 +3031,12 @@
       "country_alpha2": "US",
       "country_alpha3": "USA",
       "document_type": "NIC",
-      "id": 5243,
-      "region_iso": "OH",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "State Identity Card",
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "NIC",
       "id": 5245,
       "region_iso": "OK",
       "usecases": [
         "verify"
       ],
       "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": "State Identity Card",
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "NIC",
-      "id": 5247,
-      "region_iso": "OR",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "State Identity Card",
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "NIC",
-      "id": 5248,
-      "region_iso": "PA",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
     }
   },
   {
@@ -3987,54 +3363,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5532,
-      "region_iso": "AB",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5533,
-      "region_iso": "NL",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5534,
-      "region_iso": "NT",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "Costa Rica",
       "country_alpha2": "CR",
       "country_alpha3": "CRI",
@@ -4055,76 +3383,12 @@
       "country_alpha2": "CA",
       "country_alpha3": "CAN",
       "document_type": "NIC",
-      "id": 5544,
-      "region_iso": "NB",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
       "id": 5547,
       "region_iso": "NL",
       "usecases": [
         "verify"
       ],
       "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5548,
-      "region_iso": "PE",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007-2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5549,
-      "region_iso": "NS",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "NIC",
-      "id": 5550,
-      "region_iso": "NS",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
     }
   },
   {
@@ -4657,22 +3921,6 @@
   },
   {
     "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "NIC",
-      "id": 6010,
-      "region_iso": "BRU",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
       "back_required": true,
       "common_name": null,
       "country": "Belgium | België",
@@ -4685,54 +3933,6 @@
         "verify"
       ],
       "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "NIC",
-      "id": 6014,
-      "region_iso": "VLG",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Belgium | België",
-      "country_alpha2": "BE",
-      "country_alpha3": "BEL",
-      "document_type": "NIC",
-      "id": 6015,
-      "region_iso": "VLG",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Bosnia and Herzegovina | Bosna i Hercegovina",
-      "country_alpha2": "BA",
-      "country_alpha3": "BIH",
-      "document_type": "NIC",
-      "id": 6023,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
     }
   },
   {
@@ -5569,38 +4769,6 @@
   },
   {
     "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "NIC",
-      "id": 6186,
-      "region_iso": "IA",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "NIC",
-      "id": 6187,
-      "region_iso": "KS",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
       "back_required": false,
       "common_name": null,
       "country": "United States of America",
@@ -5960,22 +5128,6 @@
       "country_alpha3": "USA",
       "document_type": "NIC",
       "id": 6210,
-      "region_iso": "MO",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "NIC",
-      "id": 6211,
       "region_iso": "MO",
       "usecases": [
         "verify"
@@ -6733,22 +5885,6 @@
         "verify"
       ],
       "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "NIC",
-      "id": 6263,
-      "region_iso": "VT",
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
     }
   },
   {
@@ -7604,59 +6740,11 @@
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "Italy | Italia",
-      "country_alpha2": "IT",
-      "country_alpha3": "ITA",
-      "document_type": "NIC",
-      "id": 3446,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
       "country": "Poland | Polska",
       "country_alpha2": "PL",
       "country_alpha3": "POL",
       "document_type": "NIC",
       "id": 3777,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Portugal",
-      "country_alpha2": "PT",
-      "country_alpha3": "PRT",
-      "document_type": "NIC",
-      "id": 3794,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Portugal",
-      "country_alpha2": "PT",
-      "country_alpha3": "PRT",
-      "document_type": "NIC",
-      "id": 3795,
       "region_iso": null,
       "usecases": [
         "verify"
@@ -7700,59 +6788,11 @@
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "NIC",
-      "id": 4170,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "NIC",
-      "id": 4171,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
       "country": "Portugal",
       "country_alpha2": "PT",
       "country_alpha3": "PRT",
       "document_type": "NIC",
       "id": 4177,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "South Africa | Suid-Afrika",
-      "country_alpha2": "ZA",
-      "country_alpha3": "ZAF",
-      "document_type": "NIC",
-      "id": 4188,
       "region_iso": null,
       "usecases": [
         "verify"
@@ -7796,60 +6836,11 @@
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "Italy | Italia",
-      "country_alpha2": "IT",
-      "country_alpha3": "ITA",
-      "document_type": "NIC",
-      "id": 4341,
-      "region_iso": null,
-      "usecases": [
-        "verify",
-        "right_to_work"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Italy | Italia",
-      "country_alpha2": "IT",
-      "country_alpha3": "ITA",
-      "document_type": "NIC",
-      "id": 4342,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
       "country": "Poland | Polska",
       "country_alpha2": "PL",
       "country_alpha3": "POL",
       "document_type": "NIC",
       "id": 4398,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Portugal",
-      "country_alpha2": "PT",
-      "country_alpha3": "PRT",
-      "document_type": "NIC",
-      "id": 4416,
       "region_iso": null,
       "usecases": [
         "verify"
@@ -7871,22 +6862,6 @@
         "verify"
       ],
       "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Tanzania, United Republic of",
-      "country_alpha2": "TZ",
-      "country_alpha3": "TZA",
-      "document_type": "NIC",
-      "id": 8117,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
     }
   },
   {
@@ -8164,22 +7139,6 @@
   {
     "sourceData": {
       "back_required": false,
-      "common_name": null,
-      "country": "Dominican Republic | República Dominicana",
-      "country_alpha2": "DO",
-      "country_alpha3": "DOM",
-      "document_type": "NIC",
-      "id": 8438,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
       "common_name": "HKID",
       "country": "Hong Kong | 香港",
       "country_alpha2": "HK",
@@ -8207,6 +7166,1431 @@
         "verify"
       ],
       "version": "2017"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Mauritius | Maurice",
+      "country_alpha2": "MU",
+      "country_alpha3": "MUS",
+      "document_type": "NIC",
+      "id": 5001,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Georgia | საქართველო",
+      "country_alpha2": "GE",
+      "country_alpha3": "GEO",
+      "document_type": "NIC",
+      "id": 5127,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Tanzania, United Republic of",
+      "country_alpha2": "TZ",
+      "country_alpha3": "TZA",
+      "document_type": "NIC",
+      "id": 8118,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "3"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 3123,
+      "region_iso": "NL",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Italy | Italia",
+      "country_alpha2": "IT",
+      "country_alpha3": "ITA",
+      "document_type": "NIC",
+      "id": 3446,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Italy | Italia",
+      "country_alpha2": "IT",
+      "country_alpha3": "ITA",
+      "document_type": "NIC",
+      "id": 4342,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5059,
+      "region_iso": "AB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5060,
+      "region_iso": "BC",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5061,
+      "region_iso": "MB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5062,
+      "region_iso": "NB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5065,
+      "region_iso": "NU",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5066,
+      "region_iso": "ON",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5067,
+      "region_iso": "PE",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5068,
+      "region_iso": "SK",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5195,
+      "region_iso": "YT",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5532,
+      "region_iso": "AB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5533,
+      "region_iso": "NL",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5534,
+      "region_iso": "NT",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5544,
+      "region_iso": "NB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5548,
+      "region_iso": "PE",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5549,
+      "region_iso": "NS",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "NIC",
+      "id": 5550,
+      "region_iso": "NS",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8504,
+      "region_iso": "AC",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8505,
+      "region_iso": "AL",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8506,
+      "region_iso": "AM",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8507,
+      "region_iso": "AP",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8508,
+      "region_iso": "BA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8509,
+      "region_iso": "CE",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8510,
+      "region_iso": "DF",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8511,
+      "region_iso": "GO",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8512,
+      "region_iso": "MA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8513,
+      "region_iso": "MG",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8514,
+      "region_iso": "MS",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8515,
+      "region_iso": "MT",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8516,
+      "region_iso": "PA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8517,
+      "region_iso": "PB",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8518,
+      "region_iso": "PE",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8519,
+      "region_iso": "PI",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8520,
+      "region_iso": "PR",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8521,
+      "region_iso": "RJ",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8522,
+      "region_iso": "RN",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8523,
+      "region_iso": "RO",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8524,
+      "region_iso": "RR",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8525,
+      "region_iso": "RS",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8526,
+      "region_iso": "SC",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8527,
+      "region_iso": "SE",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8529,
+      "region_iso": "TO",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8195,
+      "region_iso": "SP",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8196,
+      "region_iso": "SP",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8197,
+      "region_iso": "ES",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Cameroon",
+      "country_alpha2": "CM",
+      "country_alpha3": "CMR",
+      "document_type": "NIC",
+      "id": 7812,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Tanzania, United Republic of",
+      "country_alpha2": "TZ",
+      "country_alpha3": "TZA",
+      "document_type": "NIC",
+      "id": 8117,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Argentina",
+      "country_alpha2": "AR",
+      "country_alpha3": "ARG",
+      "document_type": "NIC",
+      "id": 8125,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Brazil | Brasil",
+      "country_alpha2": "BR",
+      "country_alpha3": "BRA",
+      "document_type": "NIC",
+      "id": 8194,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "State Identity Card",
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "NIC",
+      "id": 4660,
+      "region_iso": "AK",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Italy | Italia",
+      "country_alpha2": "IT",
+      "country_alpha3": "ITA",
+      "document_type": "NIC",
+      "id": 4341,
+      "region_iso": null,
+      "usecases": [
+        "verify",
+        "right_to_work"
+      ],
+      "version": "1994"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Luxembourg | Luxemburg",
+      "country_alpha2": "LU",
+      "country_alpha3": "LUX",
+      "document_type": "NIC",
+      "id": 3566,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Luxembourg | Luxemburg",
+      "country_alpha2": "LU",
+      "country_alpha3": "LUX",
+      "document_type": "NIC",
+      "id": 3567,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Luxembourg | Luxemburg",
+      "country_alpha2": "LU",
+      "country_alpha3": "LUX",
+      "document_type": "NIC",
+      "id": 3568,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "NIC",
+      "id": 6263,
+      "region_iso": "VT",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Portugal",
+      "country_alpha2": "PT",
+      "country_alpha3": "PRT",
+      "document_type": "NIC",
+      "id": 3794,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Portugal",
+      "country_alpha2": "PT",
+      "country_alpha3": "PRT",
+      "document_type": "NIC",
+      "id": 3795,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Latvia | Latvija",
+      "country_alpha2": "LV",
+      "country_alpha3": "LVA",
+      "document_type": "NIC",
+      "id": 4143,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "NIC",
+      "id": 4145,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "NIC",
+      "id": 4147,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "NIC",
+      "id": 4170,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "NIC",
+      "id": 4171,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Slovakia | Slovensko",
+      "country_alpha2": "SK",
+      "country_alpha3": "SVK",
+      "document_type": "NIC",
+      "id": 4187,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Portugal",
+      "country_alpha2": "PT",
+      "country_alpha3": "PRT",
+      "document_type": "NIC",
+      "id": 4416,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Monaco",
+      "country_alpha2": "MC",
+      "country_alpha3": "MCO",
+      "document_type": "NIC",
+      "id": 5133,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Montenegro | Crna Gora",
+      "country_alpha2": "ME",
+      "country_alpha3": "MNE",
+      "document_type": "NIC",
+      "id": 5136,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "State Identity Card",
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "NIC",
+      "id": 5234,
+      "region_iso": "ND",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "State Identity Card",
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "NIC",
+      "id": 5235,
+      "region_iso": "NE",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "State Identity Card",
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "NIC",
+      "id": 5243,
+      "region_iso": "OH",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": "State Identity Card",
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "NIC",
+      "id": 5247,
+      "region_iso": "OR",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "State Identity Card",
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "NIC",
+      "id": 5248,
+      "region_iso": "PA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Bosnia and Herzegovina | Bosna i Hercegovina",
+      "country_alpha2": "BA",
+      "country_alpha3": "BIH",
+      "document_type": "NIC",
+      "id": 6023,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "NIC",
+      "id": 6186,
+      "region_iso": "IA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "NIC",
+      "id": 6187,
+      "region_iso": "KS",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "NIC",
+      "id": 6211,
+      "region_iso": "MO",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "NIC",
+      "id": 8057,
+      "region_iso": "CA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "NIC",
+      "id": 8191,
+      "region_iso": "WA",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "NIC",
+      "id": 8193,
+      "region_iso": "WV",
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Dominican Republic | República Dominicana",
+      "country_alpha2": "DO",
+      "country_alpha3": "DOM",
+      "document_type": "NIC",
+      "id": 8438,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "South Africa | Suid-Afrika",
+      "country_alpha2": "ZA",
+      "country_alpha3": "ZAF",
+      "document_type": "NIC",
+      "id": 4188,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "NIC",
+      "id": 4639,
+      "region_iso": "VLG",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "NIC",
+      "id": 6010,
+      "region_iso": "BRU",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "NIC",
+      "id": 6014,
+      "region_iso": "VLG",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Belgium | België",
+      "country_alpha2": "BE",
+      "country_alpha3": "BEL",
+      "document_type": "NIC",
+      "id": 6015,
+      "region_iso": "VLG",
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
     }
   }
 ]

--- a/src/supported-documents/supported-docs-residence_permit.json
+++ b/src/supported-documents/supported-docs-residence_permit.json
@@ -209,54 +209,6 @@
   },
   {
     "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Romania | România",
-      "country_alpha2": "RO",
-      "country_alpha3": "ROU",
-      "document_type": "REP",
-      "id": 8119,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Romania | România",
-      "country_alpha2": "RO",
-      "country_alpha3": "ROU",
-      "document_type": "REP",
-      "id": 8120,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Slovakia | Slovensko",
-      "country_alpha2": "SK",
-      "country_alpha3": "SVK",
-      "document_type": "REP",
-      "id": 8140,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
       "back_required": true,
       "common_name": null,
       "country": "Portugal",
@@ -413,22 +365,6 @@
         "verify"
       ],
       "version": "2009 1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Italy | Italia",
-      "country_alpha2": "IT",
-      "country_alpha3": "ITA",
-      "document_type": "REP",
-      "id": 3451,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
     }
   },
   {
@@ -755,22 +691,6 @@
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "Italy | Italia",
-      "country_alpha2": "IT",
-      "country_alpha3": "ITA",
-      "document_type": "REP",
-      "id": 4551,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
       "country": "Poland | Polska",
       "country_alpha2": "PL",
       "country_alpha3": "POL",
@@ -968,38 +888,6 @@
       "country_alpha3": "BEL",
       "document_type": "REP",
       "id": 4587,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Italy | Italia",
-      "country_alpha2": "IT",
-      "country_alpha3": "ITA",
-      "document_type": "REP",
-      "id": 4595,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Italy | Italia",
-      "country_alpha2": "IT",
-      "country_alpha3": "ITA",
-      "document_type": "REP",
-      "id": 4596,
       "region_iso": null,
       "usecases": [
         "verify"
@@ -2307,11 +2195,27 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Italy | Italia",
-      "country_alpha2": "IT",
-      "country_alpha3": "ITA",
+      "country": "Latvia | Latvija",
+      "country_alpha2": "LV",
+      "country_alpha3": "LVA",
       "document_type": "REP",
-      "id": 8112,
+      "id": 8373,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Romania | România",
+      "country_alpha2": "RO",
+      "country_alpha3": "ROU",
+      "document_type": "REP",
+      "id": 8119,
       "region_iso": null,
       "usecases": [
         "verify"
@@ -2323,11 +2227,91 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Latvia | Latvija",
-      "country_alpha2": "LV",
-      "country_alpha3": "LVA",
+      "country": "Romania | România",
+      "country_alpha2": "RO",
+      "country_alpha3": "ROU",
       "document_type": "REP",
-      "id": 8373,
+      "id": 8120,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007-3"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Italy | Italia",
+      "country_alpha2": "IT",
+      "country_alpha3": "ITA",
+      "document_type": "REP",
+      "id": 3451,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Italy | Italia",
+      "country_alpha2": "IT",
+      "country_alpha3": "ITA",
+      "document_type": "REP",
+      "id": 4551,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Italy | Italia",
+      "country_alpha2": "IT",
+      "country_alpha3": "ITA",
+      "document_type": "REP",
+      "id": 4595,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Italy | Italia",
+      "country_alpha2": "IT",
+      "country_alpha3": "ITA",
+      "document_type": "REP",
+      "id": 4596,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Italy | Italia",
+      "country_alpha2": "IT",
+      "country_alpha3": "ITA",
+      "document_type": "REP",
+      "id": 8112,
       "region_iso": null,
       "usecases": [
         "verify"
@@ -2349,6 +2333,70 @@
         "verify"
       ],
       "version": "2007-3"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Slovakia | Slovensko",
+      "country_alpha2": "SK",
+      "country_alpha3": "SVK",
+      "document_type": "REP",
+      "id": 8140,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Peru | Perú",
+      "country_alpha2": "PE",
+      "country_alpha3": "PER",
+      "document_type": "REP",
+      "id": 8537,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Peru | Perú",
+      "country_alpha2": "PE",
+      "country_alpha3": "PER",
+      "document_type": "REP",
+      "id": 8538,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Colombia",
+      "country_alpha2": "CO",
+      "country_alpha3": "COL",
+      "document_type": "REP",
+      "id": 5437,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
     }
   }
 ]

--- a/src/supported-documents/supported-docs-residence_permit.json
+++ b/src/supported-documents/supported-docs-residence_permit.json
@@ -3,150 +3,6 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Denmark | Danmark",
-      "country_alpha2": "DK",
-      "country_alpha3": "DNK",
-      "document_type": "REP",
-      "id": 3239,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Denmark | Danmark",
-      "country_alpha2": "DK",
-      "country_alpha3": "DNK",
-      "document_type": "REP",
-      "id": 7283,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017 1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Saudi Arabia | السعودية",
-      "country_alpha2": "SA",
-      "country_alpha3": "SAU",
-      "document_type": "REP",
-      "id": 5938,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Czech Republic | Česko",
-      "country_alpha2": "CZ",
-      "country_alpha3": "CZE",
-      "document_type": "REP",
-      "id": 4844,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Malta",
-      "country_alpha2": "MT",
-      "country_alpha3": "MLT",
-      "document_type": "REP",
-      "id": 7547,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2020"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Ireland | Éire",
-      "country_alpha2": "IE",
-      "country_alpha3": "IRL",
-      "document_type": "REP",
-      "id": 4133,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Spain | España",
-      "country_alpha2": "ES",
-      "country_alpha3": "ESP",
-      "document_type": "REP",
-      "id": 7679,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2020"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "REP",
-      "id": 6083,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "REP",
-      "id": 6084,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
       "country": "Austria | Österreich",
       "country_alpha2": "AT",
       "country_alpha3": "AUT",
@@ -157,70 +13,6 @@
         "verify"
       ],
       "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Malta",
-      "country_alpha2": "MT",
-      "country_alpha3": "MLT",
-      "document_type": "REP",
-      "id": 6112,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "REP",
-      "id": 8010,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016 2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Germany | Deutschland",
-      "country_alpha2": "DE",
-      "country_alpha3": "DEU",
-      "document_type": "REP",
-      "id": 6075,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Portugal",
-      "country_alpha2": "PT",
-      "country_alpha3": "PRT",
-      "document_type": "REP",
-      "id": 8174,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
     }
   },
   {
@@ -259,139 +51,11 @@
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "Bulgaria | България",
-      "country_alpha2": "BG",
-      "country_alpha3": "BGR",
+      "country": "Austria | Österreich",
+      "country_alpha2": "AT",
+      "country_alpha3": "AUT",
       "document_type": "REP",
-      "id": 3098,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Bulgaria | България",
-      "country_alpha2": "BG",
-      "country_alpha3": "BGR",
-      "document_type": "REP",
-      "id": 3099,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Croatia | Hrvatska",
-      "country_alpha2": "HR",
-      "country_alpha3": "HRV",
-      "document_type": "REP",
-      "id": 3189,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Czech Republic | Česko",
-      "country_alpha2": "CZ",
-      "country_alpha3": "CZE",
-      "document_type": "REP",
-      "id": 3224,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Denmark | Danmark",
-      "country_alpha2": "DK",
-      "country_alpha3": "DNK",
-      "document_type": "REP",
-      "id": 3238,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017 2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Estonia | Eesti",
-      "country_alpha2": "EE",
-      "country_alpha3": "EST",
-      "document_type": "REP",
-      "id": 3276,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": "",
-      "country": "Ireland | Éire",
-      "country_alpha2": "IE",
-      "country_alpha3": "IRL",
-      "document_type": "REP",
-      "id": 3431,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009 1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "REP",
-      "id": 3563,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "REP",
-      "id": 3564,
+      "id": 6005,
       "region_iso": null,
       "usecases": [
         "verify"
@@ -403,480 +67,16 @@
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "Macao | 澳門",
-      "country_alpha2": "MO",
-      "country_alpha3": "MAC",
+      "country": "Austria | Österreich",
+      "country_alpha2": "AT",
+      "country_alpha3": "AUT",
       "document_type": "REP",
-      "id": 3581,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2002"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Macao | 澳門",
-      "country_alpha2": "MO",
-      "country_alpha3": "MAC",
-      "document_type": "REP",
-      "id": 3582,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Macedonia (the former Yugoslav Republic of) | Македонија",
-      "country_alpha2": "MK",
-      "country_alpha3": "MKD",
-      "document_type": "REP",
-      "id": 3589,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Moldova (Republic of)",
-      "country_alpha2": "MD",
-      "country_alpha3": "MDA",
-      "document_type": "REP",
-      "id": 3646,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Moldova (Republic of)",
-      "country_alpha2": "MD",
-      "country_alpha3": "MDA",
-      "document_type": "REP",
-      "id": 3647,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Mozambique | Moçambique",
-      "country_alpha2": "MZ",
-      "country_alpha3": "MOZ",
-      "document_type": "REP",
-      "id": 3666,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Netherlands | Nederland",
-      "country_alpha2": "NL",
-      "country_alpha3": "NLD",
-      "document_type": "REP",
-      "id": 3700,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Oman | عمان",
-      "country_alpha2": "OM",
-      "country_alpha3": "OMN",
-      "document_type": "REP",
-      "id": 3755,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "REP",
-      "id": 3791,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Slovakia | Slovensko",
-      "country_alpha2": "SK",
-      "country_alpha3": "SVK",
-      "document_type": "REP",
-      "id": 3868,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Slovenia | Slovenija",
-      "country_alpha2": "SI",
-      "country_alpha3": "SVN",
-      "document_type": "REP",
-      "id": 3878,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Spain | España",
-      "country_alpha2": "ES",
-      "country_alpha3": "ESP",
-      "document_type": "REP",
-      "id": 3905,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Switzerland | Schweiz",
-      "country_alpha2": "CH",
-      "country_alpha3": "CHE",
-      "document_type": "REP",
-      "id": 3931,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Germany | Deutschland",
-      "country_alpha2": "DE",
-      "country_alpha3": "DEU",
-      "document_type": "REP",
-      "id": 4111,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Ireland | Éire",
-      "country_alpha2": "IE",
-      "country_alpha3": "IRL",
-      "document_type": "REP",
-      "id": 4134,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Spain | España",
-      "country_alpha2": "ES",
-      "country_alpha3": "ESP",
-      "document_type": "REP",
-      "id": 4451,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United Kingdom of Great Britain and Northern Ireland",
-      "country_alpha2": "GB",
-      "country_alpha3": "GBR",
-      "document_type": "REP",
-      "id": 4474,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United Kingdom of Great Britain and Northern Ireland",
-      "country_alpha2": "GB",
-      "country_alpha3": "GBR",
-      "document_type": "REP",
-      "id": 4475,
+      "id": 6006,
       "region_iso": null,
       "usecases": [
         "verify"
       ],
       "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "REP",
-      "id": 4560,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "REP",
-      "id": 4561,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Portugal",
-      "country_alpha2": "PT",
-      "country_alpha3": "PRT",
-      "document_type": "REP",
-      "id": 4562,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Portugal",
-      "country_alpha2": "PT",
-      "country_alpha3": "PRT",
-      "document_type": "REP",
-      "id": 4563,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "REP",
-      "id": 4572,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2003"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "REP",
-      "id": 4573,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "REP",
-      "id": 4574,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "REP",
-      "id": 4575,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "REP",
-      "id": 4576,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "REP",
-      "id": 4577,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Hungary | Magyarország",
-      "country_alpha2": "HU",
-      "country_alpha3": "HUN",
-      "document_type": "REP",
-      "id": 4578,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Switzerland | Schweiz",
-      "country_alpha2": "CH",
-      "country_alpha3": "CHE",
-      "document_type": "REP",
-      "id": 4586,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
     }
   },
   {
@@ -893,70 +93,6 @@
         "verify"
       ],
       "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "REP",
-      "id": 4612,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "REP",
-      "id": 4614,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2001"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "REP",
-      "id": 4615,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "REP",
-      "id": 4616,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
     }
   },
   {
@@ -1005,742 +141,6 @@
         "verify"
       ],
       "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Portugal",
-      "country_alpha2": "PT",
-      "country_alpha3": "PRT",
-      "document_type": "REP",
-      "id": 4709,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2019"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "REP",
-      "id": 4710,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2001"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "REP",
-      "id": 4711,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "REP",
-      "id": 4712,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "REP",
-      "id": 4713,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Poland | Polska",
-      "country_alpha2": "PL",
-      "country_alpha3": "POL",
-      "document_type": "REP",
-      "id": 4714,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Malta",
-      "country_alpha2": "MT",
-      "country_alpha3": "MLT",
-      "document_type": "REP",
-      "id": 4775,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Latvia | Latvija",
-      "country_alpha2": "LV",
-      "country_alpha3": "LVA",
-      "document_type": "REP",
-      "id": 4792,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Czech Republic | Česko",
-      "country_alpha2": "CZ",
-      "country_alpha3": "CZE",
-      "document_type": "REP",
-      "id": 4843,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Czech Republic | Česko",
-      "country_alpha2": "CZ",
-      "country_alpha3": "CZE",
-      "document_type": "REP",
-      "id": 4847,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Estonia | Eesti",
-      "country_alpha2": "EE",
-      "country_alpha3": "EST",
-      "document_type": "REP",
-      "id": 4853,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2018"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Estonia | Eesti",
-      "country_alpha2": "EE",
-      "country_alpha3": "EST",
-      "document_type": "REP",
-      "id": 4854,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Estonia | Eesti",
-      "country_alpha2": "EE",
-      "country_alpha3": "EST",
-      "document_type": "REP",
-      "id": 4855,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Estonia | Eesti",
-      "country_alpha2": "EE",
-      "country_alpha3": "EST",
-      "document_type": "REP",
-      "id": 4858,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2016"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Sweden | Sverige",
-      "country_alpha2": "SE",
-      "country_alpha3": "SWE",
-      "document_type": "REP",
-      "id": 4878,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Sweden | Sverige",
-      "country_alpha2": "SE",
-      "country_alpha3": "SWE",
-      "document_type": "REP",
-      "id": 4879,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "REP",
-      "id": 4891,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Lithuania | Lietuva",
-      "country_alpha2": "LT",
-      "country_alpha3": "LTU",
-      "document_type": "REP",
-      "id": 4892,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Ethiopia | ኢትዮጵያ",
-      "country_alpha2": "ET",
-      "country_alpha3": "ETH",
-      "document_type": "REP",
-      "id": 4994,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Chile",
-      "country_alpha2": "CL",
-      "country_alpha3": "CHL",
-      "document_type": "REP",
-      "id": 5048,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Costa Rica",
-      "country_alpha2": "CR",
-      "country_alpha3": "CRI",
-      "document_type": "REP",
-      "id": 5072,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": "Green Card",
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "REP",
-      "id": 5108,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Cyprus | Κύπρος",
-      "country_alpha2": "CY",
-      "country_alpha3": "CYP",
-      "document_type": "REP",
-      "id": 5123,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Finland | Suomi",
-      "country_alpha2": "FI",
-      "country_alpha3": "FIN",
-      "document_type": "REP",
-      "id": 5125,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Liechtenstein",
-      "country_alpha2": "LI",
-      "country_alpha3": "LIE",
-      "document_type": "REP",
-      "id": 5131,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Luxembourg | Luxemburg",
-      "country_alpha2": "LU",
-      "country_alpha3": "LUX",
-      "document_type": "REP",
-      "id": 5132,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Norway | Norge",
-      "country_alpha2": "NO",
-      "country_alpha3": "NOR",
-      "document_type": "REP",
-      "id": 5137,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Turkey | Türkiye",
-      "country_alpha2": "TR",
-      "country_alpha3": "TUR",
-      "document_type": "REP",
-      "id": 5139,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Japan | 日本",
-      "country_alpha2": "JP",
-      "country_alpha3": "JPN",
-      "document_type": "REP",
-      "id": 5154,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Malaysia",
-      "country_alpha2": "MY",
-      "country_alpha3": "MYS",
-      "document_type": "REP",
-      "id": 5159,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "1"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Qatar | قطر",
-      "country_alpha2": "QA",
-      "country_alpha3": "QAT",
-      "document_type": "REP",
-      "id": 5168,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Saudi Arabia | السعودية",
-      "country_alpha2": "SA",
-      "country_alpha3": "SAU",
-      "document_type": "REP",
-      "id": 5172,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Taiwan, Province of China | 中華民國",
-      "country_alpha2": "TW",
-      "country_alpha3": "TWN",
-      "document_type": "REP",
-      "id": 5178,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "United Arab Emirates | الإمارات العربية المتحدة",
-      "country_alpha2": "AE",
-      "country_alpha3": "ARE",
-      "document_type": "REP",
-      "id": 5181,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "REP",
-      "id": 5193,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
-      "document_type": "REP",
-      "id": 5406,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Tanzania, United Republic of",
-      "country_alpha2": "TZ",
-      "country_alpha3": "TZA",
-      "document_type": "REP",
-      "id": 5436,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Ethiopia | ኢትዮጵያ",
-      "country_alpha2": "ET",
-      "country_alpha3": "ETH",
-      "document_type": "REP",
-      "id": 5478,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Ethiopia | ኢትዮጵያ",
-      "country_alpha2": "ET",
-      "country_alpha3": "ETH",
-      "document_type": "REP",
-      "id": 5479,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2004"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Canada",
-      "country_alpha2": "CA",
-      "country_alpha3": "CAN",
-      "document_type": "REP",
-      "id": 5535,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2009"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Chile",
-      "country_alpha2": "CL",
-      "country_alpha3": "CHL",
-      "document_type": "REP",
-      "id": 5802,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Oman | عمان",
-      "country_alpha2": "OM",
-      "country_alpha3": "OMN",
-      "document_type": "REP",
-      "id": 5920,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2019"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Qatar | قطر",
-      "country_alpha2": "QA",
-      "country_alpha3": "QAT",
-      "document_type": "REP",
-      "id": 5931,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Taiwan, Province of China | 中華民國",
-      "country_alpha2": "TW",
-      "country_alpha3": "TWN",
-      "document_type": "REP",
-      "id": 5951,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Austria | Österreich",
-      "country_alpha2": "AT",
-      "country_alpha3": "AUT",
-      "document_type": "REP",
-      "id": 6005,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2011"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Austria | Österreich",
-      "country_alpha2": "AT",
-      "country_alpha3": "AUT",
-      "document_type": "REP",
-      "id": 6006,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2012"
     }
   },
   {
@@ -1859,6 +259,278 @@
     "sourceData": {
       "back_required": true,
       "common_name": null,
+      "country": "Bulgaria | България",
+      "country_alpha2": "BG",
+      "country_alpha3": "BGR",
+      "document_type": "REP",
+      "id": 3098,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Bulgaria | България",
+      "country_alpha2": "BG",
+      "country_alpha3": "BGR",
+      "document_type": "REP",
+      "id": 3099,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "REP",
+      "id": 5193,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Canada",
+      "country_alpha2": "CA",
+      "country_alpha3": "CAN",
+      "document_type": "REP",
+      "id": 5535,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Chile",
+      "country_alpha2": "CL",
+      "country_alpha3": "CHL",
+      "document_type": "REP",
+      "id": 5048,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Chile",
+      "country_alpha2": "CL",
+      "country_alpha3": "CHL",
+      "document_type": "REP",
+      "id": 5802,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Colombia",
+      "country_alpha2": "CO",
+      "country_alpha3": "COL",
+      "document_type": "REP",
+      "id": 5437,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Costa Rica",
+      "country_alpha2": "CR",
+      "country_alpha3": "CRI",
+      "document_type": "REP",
+      "id": 5072,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Croatia | Hrvatska",
+      "country_alpha2": "HR",
+      "country_alpha3": "HRV",
+      "document_type": "REP",
+      "id": 3189,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Cyprus | Κύπρος",
+      "country_alpha2": "CY",
+      "country_alpha3": "CYP",
+      "document_type": "REP",
+      "id": 5123,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Czech Republic | Česko",
+      "country_alpha2": "CZ",
+      "country_alpha3": "CZE",
+      "document_type": "REP",
+      "id": 4844,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Czech Republic | Česko",
+      "country_alpha2": "CZ",
+      "country_alpha3": "CZE",
+      "document_type": "REP",
+      "id": 3224,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Czech Republic | Česko",
+      "country_alpha2": "CZ",
+      "country_alpha3": "CZE",
+      "document_type": "REP",
+      "id": 4843,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Czech Republic | Česko",
+      "country_alpha2": "CZ",
+      "country_alpha3": "CZE",
+      "document_type": "REP",
+      "id": 4847,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Denmark | Danmark",
+      "country_alpha2": "DK",
+      "country_alpha3": "DNK",
+      "document_type": "REP",
+      "id": 3239,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Denmark | Danmark",
+      "country_alpha2": "DK",
+      "country_alpha3": "DNK",
+      "document_type": "REP",
+      "id": 7283,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017 1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Denmark | Danmark",
+      "country_alpha2": "DK",
+      "country_alpha3": "DNK",
+      "document_type": "REP",
+      "id": 3238,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017 2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
       "country": "Denmark | Danmark",
       "country_alpha2": "DK",
       "country_alpha3": "DNK",
@@ -1869,6 +541,214 @@
         "verify"
       ],
       "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Estonia | Eesti",
+      "country_alpha2": "EE",
+      "country_alpha3": "EST",
+      "document_type": "REP",
+      "id": 3276,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Estonia | Eesti",
+      "country_alpha2": "EE",
+      "country_alpha3": "EST",
+      "document_type": "REP",
+      "id": 4853,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2018"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Estonia | Eesti",
+      "country_alpha2": "EE",
+      "country_alpha3": "EST",
+      "document_type": "REP",
+      "id": 4854,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Estonia | Eesti",
+      "country_alpha2": "EE",
+      "country_alpha3": "EST",
+      "document_type": "REP",
+      "id": 4855,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Estonia | Eesti",
+      "country_alpha2": "EE",
+      "country_alpha3": "EST",
+      "document_type": "REP",
+      "id": 4858,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Ethiopia | ኢትዮጵያ",
+      "country_alpha2": "ET",
+      "country_alpha3": "ETH",
+      "document_type": "REP",
+      "id": 4994,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Ethiopia | ኢትዮጵያ",
+      "country_alpha2": "ET",
+      "country_alpha3": "ETH",
+      "document_type": "REP",
+      "id": 5478,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Ethiopia | ኢትዮጵያ",
+      "country_alpha2": "ET",
+      "country_alpha3": "ETH",
+      "document_type": "REP",
+      "id": 5479,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Finland | Suomi",
+      "country_alpha2": "FI",
+      "country_alpha3": "FIN",
+      "document_type": "REP",
+      "id": 5125,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "France",
+      "country_alpha2": "FR",
+      "country_alpha3": "FRA",
+      "document_type": "REP",
+      "id": 6623,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "France",
+      "country_alpha2": "FR",
+      "country_alpha3": "FRA",
+      "document_type": "REP",
+      "id": 5126,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Germany | Deutschland",
+      "country_alpha2": "DE",
+      "country_alpha3": "DEU",
+      "document_type": "REP",
+      "id": 6075,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Germany | Deutschland",
+      "country_alpha2": "DE",
+      "country_alpha3": "DEU",
+      "document_type": "REP",
+      "id": 4111,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
     }
   },
   {
@@ -1907,59 +787,11 @@
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "Macedonia (the former Yugoslav Republic of) | Македонија",
-      "country_alpha2": "MK",
-      "country_alpha3": "MKD",
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
       "document_type": "REP",
-      "id": 6111,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2008-2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Moldova (Republic of)",
-      "country_alpha2": "MD",
-      "country_alpha3": "MDA",
-      "document_type": "REP",
-      "id": 6116,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2013"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Moldova (Republic of)",
-      "country_alpha2": "MD",
-      "country_alpha3": "MDA",
-      "document_type": "REP",
-      "id": 6117,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2015"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Monaco",
-      "country_alpha2": "MC",
-      "country_alpha3": "MCO",
-      "document_type": "REP",
-      "id": 6118,
+      "id": 6083,
       "region_iso": null,
       "usecases": [
         "verify"
@@ -1971,43 +803,59 @@
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "Norway | Norge",
-      "country_alpha2": "NO",
-      "country_alpha3": "NOR",
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
       "document_type": "REP",
-      "id": 6121,
+      "id": 6084,
       "region_iso": null,
       "usecases": [
         "verify"
       ],
-      "version": "2012"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Norway | Norge",
-      "country_alpha2": "NO",
-      "country_alpha3": "NOR",
-      "document_type": "REP",
-      "id": 6122,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2017-2"
+      "version": null
     }
   },
   {
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Romania | România",
-      "country_alpha2": "RO",
-      "country_alpha3": "ROU",
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
       "document_type": "REP",
-      "id": 6126,
+      "id": 8010,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016 2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
+      "document_type": "REP",
+      "id": 4572,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2003"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
+      "document_type": "REP",
+      "id": 4573,
       "region_iso": null,
       "usecases": [
         "verify"
@@ -2019,11 +867,27 @@
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "Slovakia | Slovensko",
-      "country_alpha2": "SK",
-      "country_alpha3": "SVK",
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
       "document_type": "REP",
-      "id": 6131,
+      "id": 4574,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
+      "document_type": "REP",
+      "id": 4575,
       "region_iso": null,
       "usecases": [
         "verify"
@@ -2035,91 +899,91 @@
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "Turkey | Türkiye",
-      "country_alpha2": "TR",
-      "country_alpha3": "TUR",
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
       "document_type": "REP",
-      "id": 6136,
+      "id": 4576,
       "region_iso": null,
       "usecases": [
         "verify"
       ],
-      "version": "2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": "student",
-      "country": "Spain | España",
-      "country_alpha2": "ES",
-      "country_alpha3": "ESP",
-      "document_type": "REP",
-      "id": 6137,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2010"
+      "version": "2012"
     }
   },
   {
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "United Kingdom of Great Britain and Northern Ireland",
-      "country_alpha2": "GB",
-      "country_alpha3": "GBR",
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
       "document_type": "REP",
-      "id": 6293,
+      "id": 4577,
       "region_iso": null,
       "usecases": [
         "verify"
       ],
-      "version": "2015"
+      "version": "2013"
     }
   },
   {
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "United Kingdom of Great Britain and Northern Ireland",
-      "country_alpha2": "GB",
-      "country_alpha3": "GBR",
+      "country": "Hungary | Magyarország",
+      "country_alpha2": "HU",
+      "country_alpha3": "HUN",
       "document_type": "REP",
-      "id": 6296,
+      "id": 4578,
       "region_iso": null,
       "usecases": [
         "verify"
       ],
-      "version": "2010-2"
+      "version": "2016"
     }
   },
   {
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "France",
-      "country_alpha2": "FR",
-      "country_alpha3": "FRA",
+      "country": "Ireland | Éire",
+      "country_alpha2": "IE",
+      "country_alpha3": "IRL",
       "document_type": "REP",
-      "id": 6623,
+      "id": 4133,
       "region_iso": null,
       "usecases": [
         "verify"
       ],
-      "version": "2011"
+      "version": null
     }
   },
   {
     "sourceData": {
       "back_required": true,
-      "common_name": "Green Card",
-      "country": "United States of America",
-      "country_alpha2": "US",
-      "country_alpha3": "USA",
+      "common_name": "",
+      "country": "Ireland | Éire",
+      "country_alpha2": "IE",
+      "country_alpha3": "IRL",
       "document_type": "REP",
-      "id": 6826,
+      "id": 3431,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009 1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Ireland | Éire",
+      "country_alpha2": "IE",
+      "country_alpha3": "IRL",
+      "document_type": "REP",
+      "id": 4134,
       "region_iso": null,
       "usecases": [
         "verify"
@@ -2157,86 +1021,6 @@
         "verify"
       ],
       "version": "2014"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "Switzerland | Schweiz",
-      "country_alpha2": "CH",
-      "country_alpha3": "CHE",
-      "document_type": "REP",
-      "id": 8240,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": true,
-      "common_name": null,
-      "country": "France",
-      "country_alpha2": "FR",
-      "country_alpha3": "FRA",
-      "document_type": "REP",
-      "id": 5126,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Latvia | Latvija",
-      "country_alpha2": "LV",
-      "country_alpha3": "LVA",
-      "document_type": "REP",
-      "id": 8373,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": null
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Romania | România",
-      "country_alpha2": "RO",
-      "country_alpha3": "ROU",
-      "document_type": "REP",
-      "id": 8119,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007-2"
-    }
-  },
-  {
-    "sourceData": {
-      "back_required": false,
-      "common_name": null,
-      "country": "Romania | România",
-      "country_alpha2": "RO",
-      "country_alpha3": "ROU",
-      "document_type": "REP",
-      "id": 8120,
-      "region_iso": null,
-      "usecases": [
-        "verify"
-      ],
-      "version": "2007-3"
     }
   },
   {
@@ -2339,16 +1123,464 @@
     "sourceData": {
       "back_required": false,
       "common_name": null,
-      "country": "Slovakia | Slovensko",
-      "country_alpha2": "SK",
-      "country_alpha3": "SVK",
+      "country": "Japan | 日本",
+      "country_alpha2": "JP",
+      "country_alpha3": "JPN",
       "document_type": "REP",
-      "id": 8140,
+      "id": 5154,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Latvia | Latvija",
+      "country_alpha2": "LV",
+      "country_alpha3": "LVA",
+      "document_type": "REP",
+      "id": 4792,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Latvia | Latvija",
+      "country_alpha2": "LV",
+      "country_alpha3": "LVA",
+      "document_type": "REP",
+      "id": 8373,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Liechtenstein",
+      "country_alpha2": "LI",
+      "country_alpha3": "LIE",
+      "document_type": "REP",
+      "id": 5131,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "REP",
+      "id": 3563,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "REP",
+      "id": 3564,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "REP",
+      "id": 4891,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Lithuania | Lietuva",
+      "country_alpha2": "LT",
+      "country_alpha3": "LTU",
+      "document_type": "REP",
+      "id": 4892,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2009"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Luxembourg | Luxemburg",
+      "country_alpha2": "LU",
+      "country_alpha3": "LUX",
+      "document_type": "REP",
+      "id": 5132,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Macao | 澳門",
+      "country_alpha2": "MO",
+      "country_alpha3": "MAC",
+      "document_type": "REP",
+      "id": 3581,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2002"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Macao | 澳門",
+      "country_alpha2": "MO",
+      "country_alpha3": "MAC",
+      "document_type": "REP",
+      "id": 3582,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Macedonia (the former Yugoslav Republic of) | Македонија",
+      "country_alpha2": "MK",
+      "country_alpha3": "MKD",
+      "document_type": "REP",
+      "id": 3589,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Macedonia (the former Yugoslav Republic of) | Македонија",
+      "country_alpha2": "MK",
+      "country_alpha3": "MKD",
+      "document_type": "REP",
+      "id": 6111,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008-2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Malaysia",
+      "country_alpha2": "MY",
+      "country_alpha3": "MYS",
+      "document_type": "REP",
+      "id": 5159,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "1"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Malta",
+      "country_alpha2": "MT",
+      "country_alpha3": "MLT",
+      "document_type": "REP",
+      "id": 7547,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2020"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Malta",
+      "country_alpha2": "MT",
+      "country_alpha3": "MLT",
+      "document_type": "REP",
+      "id": 6112,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Malta",
+      "country_alpha2": "MT",
+      "country_alpha3": "MLT",
+      "document_type": "REP",
+      "id": 4775,
       "region_iso": null,
       "usecases": [
         "verify"
       ],
       "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Moldova (Republic of)",
+      "country_alpha2": "MD",
+      "country_alpha3": "MDA",
+      "document_type": "REP",
+      "id": 3646,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Moldova (Republic of)",
+      "country_alpha2": "MD",
+      "country_alpha3": "MDA",
+      "document_type": "REP",
+      "id": 3647,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2016"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Moldova (Republic of)",
+      "country_alpha2": "MD",
+      "country_alpha3": "MDA",
+      "document_type": "REP",
+      "id": 6116,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Moldova (Republic of)",
+      "country_alpha2": "MD",
+      "country_alpha3": "MDA",
+      "document_type": "REP",
+      "id": 6117,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Monaco",
+      "country_alpha2": "MC",
+      "country_alpha3": "MCO",
+      "document_type": "REP",
+      "id": 6118,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Mozambique | Moçambique",
+      "country_alpha2": "MZ",
+      "country_alpha3": "MOZ",
+      "document_type": "REP",
+      "id": 3666,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Netherlands | Nederland",
+      "country_alpha2": "NL",
+      "country_alpha3": "NLD",
+      "document_type": "REP",
+      "id": 3700,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Norway | Norge",
+      "country_alpha2": "NO",
+      "country_alpha3": "NOR",
+      "document_type": "REP",
+      "id": 5137,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Norway | Norge",
+      "country_alpha2": "NO",
+      "country_alpha3": "NOR",
+      "document_type": "REP",
+      "id": 6121,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Norway | Norge",
+      "country_alpha2": "NO",
+      "country_alpha3": "NOR",
+      "document_type": "REP",
+      "id": 6122,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017-2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Oman | عمان",
+      "country_alpha2": "OM",
+      "country_alpha3": "OMN",
+      "document_type": "REP",
+      "id": 3755,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2013"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Oman | عمان",
+      "country_alpha2": "OM",
+      "country_alpha3": "OMN",
+      "document_type": "REP",
+      "id": 5920,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2019"
     }
   },
   {
@@ -2387,16 +1619,784 @@
     "sourceData": {
       "back_required": true,
       "common_name": null,
-      "country": "Colombia",
-      "country_alpha2": "CO",
-      "country_alpha3": "COL",
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
       "document_type": "REP",
-      "id": 5437,
+      "id": 3791,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "REP",
+      "id": 4560,
       "region_iso": null,
       "usecases": [
         "verify"
       ],
       "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "REP",
+      "id": 4561,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "REP",
+      "id": 4612,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "REP",
+      "id": 4614,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2001"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "REP",
+      "id": 4615,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "REP",
+      "id": 4616,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "REP",
+      "id": 4710,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2001"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "REP",
+      "id": 4711,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "REP",
+      "id": 4712,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "REP",
+      "id": 4713,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Poland | Polska",
+      "country_alpha2": "PL",
+      "country_alpha3": "POL",
+      "document_type": "REP",
+      "id": 4714,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Portugal",
+      "country_alpha2": "PT",
+      "country_alpha3": "PRT",
+      "document_type": "REP",
+      "id": 8174,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Portugal",
+      "country_alpha2": "PT",
+      "country_alpha3": "PRT",
+      "document_type": "REP",
+      "id": 4562,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Portugal",
+      "country_alpha2": "PT",
+      "country_alpha3": "PRT",
+      "document_type": "REP",
+      "id": 4563,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Portugal",
+      "country_alpha2": "PT",
+      "country_alpha3": "PRT",
+      "document_type": "REP",
+      "id": 4709,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2019"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Qatar | قطر",
+      "country_alpha2": "QA",
+      "country_alpha3": "QAT",
+      "document_type": "REP",
+      "id": 5168,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Qatar | قطر",
+      "country_alpha2": "QA",
+      "country_alpha3": "QAT",
+      "document_type": "REP",
+      "id": 5931,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Romania | România",
+      "country_alpha2": "RO",
+      "country_alpha3": "ROU",
+      "document_type": "REP",
+      "id": 6126,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Romania | România",
+      "country_alpha2": "RO",
+      "country_alpha3": "ROU",
+      "document_type": "REP",
+      "id": 8119,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007-2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Romania | România",
+      "country_alpha2": "RO",
+      "country_alpha3": "ROU",
+      "document_type": "REP",
+      "id": 8120,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2007-3"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Saudi Arabia | السعودية",
+      "country_alpha2": "SA",
+      "country_alpha3": "SAU",
+      "document_type": "REP",
+      "id": 5938,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Saudi Arabia | السعودية",
+      "country_alpha2": "SA",
+      "country_alpha3": "SAU",
+      "document_type": "REP",
+      "id": 5172,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Slovakia | Slovensko",
+      "country_alpha2": "SK",
+      "country_alpha3": "SVK",
+      "document_type": "REP",
+      "id": 3868,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2004"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Slovakia | Slovensko",
+      "country_alpha2": "SK",
+      "country_alpha3": "SVK",
+      "document_type": "REP",
+      "id": 6131,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Slovakia | Slovensko",
+      "country_alpha2": "SK",
+      "country_alpha3": "SVK",
+      "document_type": "REP",
+      "id": 8140,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2014"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Slovenia | Slovenija",
+      "country_alpha2": "SI",
+      "country_alpha3": "SVN",
+      "document_type": "REP",
+      "id": 3878,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Spain | España",
+      "country_alpha2": "ES",
+      "country_alpha3": "ESP",
+      "document_type": "REP",
+      "id": 7679,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2020"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Spain | España",
+      "country_alpha2": "ES",
+      "country_alpha3": "ESP",
+      "document_type": "REP",
+      "id": 3905,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Spain | España",
+      "country_alpha2": "ES",
+      "country_alpha3": "ESP",
+      "document_type": "REP",
+      "id": 4451,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": "student",
+      "country": "Spain | España",
+      "country_alpha2": "ES",
+      "country_alpha3": "ESP",
+      "document_type": "REP",
+      "id": 6137,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Sweden | Sverige",
+      "country_alpha2": "SE",
+      "country_alpha3": "SWE",
+      "document_type": "REP",
+      "id": 4878,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Sweden | Sverige",
+      "country_alpha2": "SE",
+      "country_alpha3": "SWE",
+      "document_type": "REP",
+      "id": 4879,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Switzerland | Schweiz",
+      "country_alpha2": "CH",
+      "country_alpha3": "CHE",
+      "document_type": "REP",
+      "id": 3931,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2011"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Switzerland | Schweiz",
+      "country_alpha2": "CH",
+      "country_alpha3": "CHE",
+      "document_type": "REP",
+      "id": 4586,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Switzerland | Schweiz",
+      "country_alpha2": "CH",
+      "country_alpha3": "CHE",
+      "document_type": "REP",
+      "id": 8240,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Taiwan, Province of China | 中華民國",
+      "country_alpha2": "TW",
+      "country_alpha3": "TWN",
+      "document_type": "REP",
+      "id": 5178,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Taiwan, Province of China | 中華民國",
+      "country_alpha2": "TW",
+      "country_alpha3": "TWN",
+      "document_type": "REP",
+      "id": 5951,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "Tanzania, United Republic of",
+      "country_alpha2": "TZ",
+      "country_alpha3": "TZA",
+      "document_type": "REP",
+      "id": 5436,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Turkey | Türkiye",
+      "country_alpha2": "TR",
+      "country_alpha3": "TUR",
+      "document_type": "REP",
+      "id": 5139,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "Turkey | Türkiye",
+      "country_alpha2": "TR",
+      "country_alpha3": "TUR",
+      "document_type": "REP",
+      "id": 6136,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "United Arab Emirates | الإمارات العربية المتحدة",
+      "country_alpha2": "AE",
+      "country_alpha3": "ARE",
+      "document_type": "REP",
+      "id": 5181,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": null
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United Kingdom of Great Britain and Northern Ireland",
+      "country_alpha2": "GB",
+      "country_alpha3": "GBR",
+      "document_type": "REP",
+      "id": 4474,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United Kingdom of Great Britain and Northern Ireland",
+      "country_alpha2": "GB",
+      "country_alpha3": "GBR",
+      "document_type": "REP",
+      "id": 4475,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2012"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "United Kingdom of Great Britain and Northern Ireland",
+      "country_alpha2": "GB",
+      "country_alpha3": "GBR",
+      "document_type": "REP",
+      "id": 6293,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2015"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": null,
+      "country": "United Kingdom of Great Britain and Northern Ireland",
+      "country_alpha2": "GB",
+      "country_alpha3": "GBR",
+      "document_type": "REP",
+      "id": 6296,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010-2"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": "Green Card",
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "REP",
+      "id": 5108,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2010"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": false,
+      "common_name": null,
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "REP",
+      "id": 5406,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2008"
+    }
+  },
+  {
+    "sourceData": {
+      "back_required": true,
+      "common_name": "Green Card",
+      "country": "United States of America",
+      "country_alpha2": "US",
+      "country_alpha3": "USA",
+      "document_type": "REP",
+      "id": 6826,
+      "region_iso": null,
+      "usecases": [
+        "verify"
+      ],
+      "version": "2017"
     }
   }
 ]


### PR DESCRIPTION
# PoC
Use `ffmpeg` to convert snapshots to webm video. Added link to download video on Safari.
Tests are going to fail because I've temporarily reused the selfie interface.

Note: This is WIP. This changes might break current features. Do not merge.

TODO: 
* Record audio and add it to ffmpeg conversion
* Improve framerate
* Use video UI instead of selfie UI
* Refactor
