### PR TITLE
Fix/cx 5798 non latin characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This change log file is based on best practices from [Keep a Changelog](http://k
 This project adheres to [Semantic Versioning](http://semver.org/). Breaking changes result in a different MAJOR version. UI changes that might break customizations on top of the SDK will be treated as breaking changes too.
 This project adheres to the Node [default version scheme](https://docs.npmjs.com/misc/semver).
 
+## [6.2.1] - 2020-11-04
+
+### Fixed
+
+- Public: Non-Latin localised strings throw exception in Welcome screen.
+
 ## [6.2.0] - 2020-10-19
 
 ### Changed

--- a/src/components/Welcome/index.js
+++ b/src/components/Welcome/index.js
@@ -3,6 +3,7 @@ import PageTitle from '../PageTitle'
 import Button from '../Button'
 import { trackComponent } from '../../Tracker'
 import { localised } from '../../locales'
+import { buildIteratorKey } from '~utils'
 import theme from '../Theme/style.scss'
 import style from './style.scss'
 
@@ -10,10 +11,6 @@ const localisedDescriptions = (translate) => [
   translate('welcome.description_p_1'),
   translate('welcome.description_p_2'),
 ]
-
-// Generate Base64 string from description to use as key in iterator
-const buildDescriptionKey = (description) =>
-  btoa(unescape(encodeURIComponent(description)))
 
 const Welcome = ({ title, descriptions, nextButton, nextStep, translate }) => {
   const welcomeTitle = title ? title : translate('welcome.title')
@@ -29,7 +26,7 @@ const Welcome = ({ title, descriptions, nextButton, nextStep, translate }) => {
       <div className={theme.thickWrapper}>
         <div className={style.text}>
           {welcomeDescriptions.map((description) => (
-            <p key={`description_${buildDescriptionKey(description)}`}>
+            <p key={`description_${buildIteratorKey(description)}`}>
               {description}
             </p>
           ))}

--- a/src/components/Welcome/index.js
+++ b/src/components/Welcome/index.js
@@ -12,7 +12,8 @@ const localisedDescriptions = (translate) => [
 ]
 
 // Generate Base64 string from description to use as key in iterator
-const buildDescriptionKey = (description) => btoa(description)
+const buildDescriptionKey = (description) =>
+  btoa(unescape(encodeURIComponent(description)))
 
 const Welcome = ({ title, descriptions, nextButton, nextStep, translate }) => {
   const welcomeTitle = title ? title : translate('welcome.title')

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -164,3 +164,11 @@ export const capitalise = (string) => {
 
   return string
 }
+
+/**
+ * Generate Base64 string from raw string to use as key in iterator
+ * It's necessary to encode and unescape here is to work with non-Latin characters
+ * See more: https://stackoverflow.com/a/26603875
+ */
+export const buildIteratorKey = (value) =>
+  btoa(unescape(encodeURIComponent(value)))

--- a/src/components/utils/unit_tests/main.test.js
+++ b/src/components/utils/unit_tests/main.test.js
@@ -1,0 +1,10 @@
+import { buildIteratorKey } from '../index.js'
+
+test('buildIteratorKey', () => {
+  expect(buildIteratorKey('Some normal Latin characters')).toBe(
+    'U29tZSBub3JtYWwgTGF0aW4gY2hhcmFjdGVycw=='
+  )
+
+  // Non-Latin characters
+  expect(() => buildIteratorKey('ąęśćłź')).not.toThrow()
+})


### PR DESCRIPTION
# Problem

Some clients face crashes on upgrading from `v5.x.x` to `v6.x.x` with customised non-Latin localised copies. This is because out-of-Latin1-range characters were fed to `btoa()` method in `Welcome` screen:

```
Uncaught (in promise) DOMException: Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.
```

Related issue: #1238 

# Solution

Escape non-Latin characters before feeding to `btoa()` method.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [n/a] Has the README been updated?
- [n/a] Has the CONTRIBUTING doc been updated?
- [n/a] Has the RELEASE_GUIDELINES been updated?
- [n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [n/a] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a] Have any new automated tests been implemented or the existing ones changed?
- [n/a] Have any new manual tests been written down or the existing ones changed?
- [n/a] Have any new strings been translated or the existing ones changed?