### PR TITLE
Add event listener for userAnalyticsEvent in Demo App

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ This change log file is based on best practices from [Keep a Changelog](http://k
 This project adheres to [Semantic Versioning](http://semver.org/). Breaking changes result in a different MAJOR version. UI changes that might break customizations on top of the SDK will be treated as breaking changes too.
 This project adheres to the Node [default version scheme](https://docs.npmjs.com/misc/semver).
 
+## [next-version]
+
+### Added
+
+- Internal: Added event listener for `userAnalyticsEvent` in Demo App. This can be enabled by using a query string.
+
+### Changed
+
+### Fixed
+
 ## [6.3.0] - 2020-11-09
 
 ### Added

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -82,6 +82,20 @@ class Demo extends Component {
     this.callTokenFactory()
   }
 
+  componentDidMount() {
+    if (queryParamToValueString.integratorTrackedUserEvents) {
+      window.addEventListener('userAnalyticsEvent', (event) =>
+        console.log('DEMO APP user analytics event details:', event.detail)
+      )
+    }
+  }
+
+  componentWillUnmount() {
+    if (queryParamToValueString.integratorTrackedUserEvents) {
+      window.removeEventListener('userAnalyticsEvent')
+    }
+  }
+
   componentDidUpdate(prevProps) {
     const { region } = this.props.sdkOptions || {}
     const prevPreviewerOptions = prevProps.sdkOptions || {}


### PR DESCRIPTION
# Problem
Demo App lacks an easy way to see the tracked user analytics events that SDK makes available to integrators.

# Solution
Add event listener to Demo App for `userAnalyticsEvent` that is enabled with URL query parameter `integratorTrackedUserEvents=true`

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
