### PR TITLE
Fix GitHub actions failing

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches: [master, development]
   pull_request:
+    branches: [master, development]
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,15 +28,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          # We must fetch at least the immediate parents so that if this is
-          # a pull request then we can checkout the head.
-          fetch-depth: 2
-
-      # If this run was triggered by a pull request event, then checkout
-      # the head of the pull request instead of the merge commit.
-      - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -9,7 +9,6 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: 'eu-west-1'
-  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
   deploy:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -17,7 +17,8 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
+          # Match node version with .nvmrc
+          node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Build dist

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -27,19 +27,19 @@ jobs:
 
       - name: Get version
         id: get_version
-        run: echo ::set-env name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
       - name: Determine release type
         run: |
           GIT_TAG_REGEX="^[0-9]\{1,3\}\.[0-9]\{1,2\}\.[0-9]\{1,2\}$"
           LATEST_TAG=`git tag | grep $GIT_TAG_REGEX | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | sed '1!G;h;$!d' | sed -n 1p`
-          echo ::set-env name=LATEST_TAG::${LATEST_TAG}
+          echo "LATEST_TAG=${LATEST_TAG}" >> $GITHUB_ENV
 
       - name: Get base32 version
         id: get_base32_version
         run: |
           source ./release/githubActions/workflows.config
-          echo ::set-env name=BASE_32_VERSION::${BASE_32_VERSION}
+          echo "BASE_32_VERSION=${BASE_32_VERSION}" >> $GITHUB_ENV
 
       - name: Upload Base32 to S3
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ This change log file is based on best practices from [Keep a Changelog](http://k
 This project adheres to [Semantic Versioning](http://semver.org/). Breaking changes result in a different MAJOR version. UI changes that might break customizations on top of the SDK will be treated as breaking changes too.
 This project adheres to the Node [default version scheme](https://docs.npmjs.com/misc/semver).
 
+## [next-version]
+
+### Added
+
+### Changed
+
+- Internal: Update SDK's Publish Release workflow to not use the now deprecated `set-env` command
+
+### Fixed
+
 ## [6.3.1] - 2020-11-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Changed
 
-- Internal: Update SDK's Publish Release workflow to not use the now deprecated `set-env` command
+- Internal: Update SDK's Publish Release workflow to not use the now deprecated `set-env` command.
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6208,9 +6208,9 @@
       }
     },
     "chromedriver": {
-      "version": "85.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-85.0.1.tgz",
-      "integrity": "sha512-z8je3U4tXFZnx7AloRabM4Ep1lpFJvHxLoGuRvLg33Qy0UKk/z6OXmHUO2z6DKE0Oe6CFpjj/bdhuQ8dfvq9ug==",
+      "version": "87.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-87.0.1.tgz",
+      "integrity": "sha512-tSvCV0pj47Sv2xTudV5IffLE50y7D4T1TWHzAAvN362rcetqJk0GipMO79kwZ5/muvIePRjQ1zXjOwS/8qzfFA==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",
@@ -6229,9 +6229,9 @@
           "dev": true
         },
         "agent-base": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
-          "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
           "dev": true,
           "requires": {
             "debug": "4"
@@ -6253,9 +6253,9 @@
           }
         },
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -8942,9 +8942,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "bundlesize": "^0.18.0",
     "chai": "^4.2.0",
     "chalk": "^2.4.2",
-    "chromedriver": "^85.0.1",
+    "chromedriver": "^87.0.1",
     "css-loader": "^3.4.2",
     "enzyme": "^3.11.0",
     "enzyme-adapter-preact-pure": "^2.2.3",


### PR DESCRIPTION
# Problem
GitHub have deprecated `set-env` and `add-path` commands for Github Actions due to a moderate security vulnerability. We don't use the `add-path` command anywhere, but our Publish Release workflow does use `set-env`.  

# Solution
- Patch release publish workflow to use Github's new environment files as detailed in this [Github blog post](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)
- Remove `ACTIONS_ALLOW_UNSECURE_COMMANDS` flag which was added to unblock a recent patch release but now causes subsequent PR builds' CodeQL Analysis action to fail

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [n/a] Has the README been updated?
- [n/a] Has the CONTRIBUTING doc been updated?
- [n/a] Has the RELEASE_GUIDELINES been updated?
- [n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [n/a] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a] Have any new automated tests been implemented or the existing ones changed?
- [n/a] Have any new manual tests been written down or the existing ones changed?
- [n/a] Have any new strings been translated or the existing ones changed?
