### PR TITLE
Update CHANGELOG note for image resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Changed
 
-- UI: User is no longer blocked from uploading an image file over 10MB in size. Instead image is resized to 720p if file size is over 3MB.
+- UI: User is no longer blocked from uploading an image file over 10MB in size. Instead image is resized to 1440px if file size is over 3MB.
 - Internal: Update SDK's Publish Release workflow to not use the now deprecated `set-env` command.
 
 ### Fixed


### PR DESCRIPTION
# Problem
The image resizing feature released in 6.4.0 is actually resizing to 1440px, not 720p.

# Solution
Update CHANGELOG note for that feature.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
