### PR TITLE
Task/clean up changelog release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Internal: Introduce Hooks on non-critical components.
 - Public: Added `CROSS_DEVICE_INTRO`, `CROSS_DEVICE_GET_LINK` user analytic events for integrators to listen for when tracking user journey when initiating Cross Device flow from desktop browser
 - Public: Added `licenses.json` file containing the list of dependencies licenses.
-- Internal: Introduce Hooks on non-critical components.
 - Internal: Introduce TypeScript on non-critical components & deprecate FlowType.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Added
 
 - Public: Added npm latest version badge
+- Internal: Now the UI tests will hit API endpoints from a dockerised mock server.
+- Internal: Introduce TypeScript on non-critical components & deprecate FlowType.
 
 ### Changed
 
@@ -26,11 +28,9 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Added
 
-- Internal: Now the UI tests will hit API endpoints from a dockerised mock server.
 - Internal: Introduce Hooks on non-critical components.
 - Public: Added `CROSS_DEVICE_INTRO`, `CROSS_DEVICE_GET_LINK` user analytic events for integrators to listen for when tracking user journey when initiating Cross Device flow from desktop browser
 - Public: Added `licenses.json` file containing the list of dependencies licenses.
-- Internal: Introduce TypeScript on non-critical components & deprecate FlowType.
 
 ### Changed
 


### PR DESCRIPTION
# Problem
`CHANGELOG` notes for unreleased features in a couple of recently merged PRs seem to have appeared under `6.4.0` and there is a duplicated feature note also in `6.4.0` after merging with `development`

# Solution
- Remove duplicated feature note in release `6.4.0`
- Move unreleased features out from `6.4.0` to `next-version`

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
