### PR TITLE
Fix typo in en_US translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Fixed
 
 - Public: Fix "File type not supported" error on snapshot upload in selfie step.
+- Public: Fix typo in `en_US.json` file
 
 ## [6.4.0] - 2020-12-21
 

--- a/src/locales/en_US/en_US.json
+++ b/src/locales/en_US/en_US.json
@@ -198,7 +198,7 @@
     },
     "linked_computer": {
         "button_primary": "Continue",
-        "info": "Make sure§",
+        "info": "Make sure",
         "list_item_desktop_open": "2. Your desktop window stays open",
         "list_item_sent_by_you": "1. This link was sent by you",
         "subtitle": "Continue with the verification",


### PR DESCRIPTION
# Problem
Typo in `en_US.json` file. Fixes #1309 

# Solution
Fix typo on translation service. 
Update `en_US.json` file

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
