### PR TITLE
Feature/cx 5308 customisation fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,10 @@ A number of options are available to allow you to customize the SDK:
 
   If you would like to customize the SDK, this can be done by providing the `customUI` option with an object with the corresponding CSS values (e.g. RGBA colour values, border radius values) for the following options:
 
+  | Font options | Description                                                    |
+  | ------------ | -------------------------------------------------------------- |
+  | `fontFamily` | Change font family of SDK (only works for basic font families) |
+
   | Primary Button options               | Description                                            |
   | ------------------------------------ | ------------------------------------------------------ |
   | `colorContentButtonPrimaryText`      | Change color of Primary Button text                    |

--- a/README.md
+++ b/README.md
@@ -421,6 +421,8 @@ A number of options are available to allow you to customize the SDK:
   }
   ```
 
+  **Note:** If using a scalable font size unit like em/rem, the SDK's base font size is 16px. This is currently not customisable.
+
   | Primary Button options               | Description                                            |
   | ------------------------------------ | ------------------------------------------------------ |
   | `colorContentButtonPrimaryText`      | Change color of Primary Button text                    |

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ A number of options are available to allow you to customize the SDK:
   }
   ```
 
-  **Note:** If using a scalable font size unit like em/rem, the SDK's base font size is 16px. This is currently not customisable.
+  **Note:** If using a scalable font size unit like em/rem, the SDK's base font size is 16px. This is currently not customizable.
 
   | Primary Button options               | Description                                            |
   | ------------------------------------ | ------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You will receive a response containing the applicant id which will be used to cr
 
 ### 3. Generating an SDK token
 
-For security reasons, instead of using the API token directly in you client-side code, you will need to generate and include a short-lived JSON Web Token ([JWT](https://jwt.io/)) every time you initialise the SDK. To generate an SDK Token you should perform a request to the [SDK Token endpoint](https://documentation.onfido.com/#generate-web-sdk-token) in the Onfido API:
+For security reasons, instead of using the API token directly in you client-side code, you will need to generate and include a short-lived JSON Web Token ([JWT](https://jwt.io/)) every time you initialize the SDK. To generate an SDK Token you should perform a request to the [SDK Token endpoint](https://documentation.onfido.com/#generate-web-sdk-token) in the Onfido API:
 
 ```shell
 $ curl https://api.onfido.com/v3/sdk_token \
@@ -148,7 +148,7 @@ verification component will be mounted. -->
 
 ### 6. Initialising the SDK
 
-You are now ready to initialise the SDK:
+You are now ready to initialize the SDK:
 
 ```js
 Onfido.init({
@@ -266,7 +266,7 @@ Congratulations! You have successfully started the flow. Carry on reading the ne
 
 ## Removing the SDK
 
-If you are embedding the SDK inside a single page app, you can call the `tearDown` function to remove the SDK completely from the current webpage. It will reset state and you can safely re-initialise the SDK inside the same webpage later on.
+If you are embedding the SDK inside a single page app, you can call the `tearDown` function to remove the SDK completely from the current webpage. It will reset state and you can safely re-initialize the SDK inside the same webpage later on.
 
 ```javascript
 onfidoOut = Onfido.init({...})
@@ -369,7 +369,7 @@ A number of options are available to allow you to customize the SDK:
 
 - **`smsNumberCountryCode {String} optional`**
 
-  The default country for the SMS number input can be customized by passing the `smsNumberCountryCode` option when the SDK is initialised. The value should be a 2-characters long ISO Country code string. If empty, the SMS number country code will default to `GB`.
+  The default country for the SMS number input can be customized by passing the `smsNumberCountryCode` option when the SDK is initialized. The value should be a 2-characters long ISO Country code string. If empty, the SMS number country code will default to `GB`.
 
   Example:
 
@@ -760,7 +760,7 @@ A number of options are available to allow you to customize the SDK:
 
 ### Changing options in runtime
 
-It's possible to change the options initialised at runtime:
+It's possible to change the options initialized at runtime:
 
 ```javascript
 onfidoOut = Onfido.init({...})
@@ -796,7 +796,7 @@ In order to perform a full document/face check, you need to call our [API](https
 ### 1. Creating a check
 
 With your API token and applicant id (see [Getting started](#getting-started)), you will need to create a check by making a request to the [create check endpoint](https://documentation.onfido.com/#create-check). If you are just verifying a document, you only have to include a [document report](https://documentation.onfido.com/#document-report) as part of the check. On the other hand, if you are verifying a document and a face photo/video, you will also have to include a [facial similarity report](https://documentation.onfido.com/#facial-similarity-reports).
-The facial similarity check can be performed in two different variants: `facial_similarity_photo` and `facial_similarity_video`. If the SDK is initialised with the `requestedVariant` option for the face step, make sure you use the data returned in the `onComplete` callback to request the right report.
+The facial similarity check can be performed in two different variants: `facial_similarity_photo` and `facial_similarity_video`. If the SDK is initialized with the `requestedVariant` option for the face step, make sure you use the data returned in the `onComplete` callback to request the right report.
 The value of `variant` indicates whether a photo or video was captured and it needs to be used to determine the report name you should include in your request.
 Example of data returned by the `onComplete` callback:
 `{face: {variant: 'standard' | 'video'}}`

--- a/README.md
+++ b/README.md
@@ -410,6 +410,17 @@ A number of options are available to allow you to customize the SDK:
   | `colorContentSubtitle` | Change text colour of the SDK screen subtitles |
   | `colorContentBody`     | Change text colour of the SDK screen content   |
 
+  Example configuration with the different CSS font related values that can be used:
+
+  ```javascript
+  customUI: {
+    "fontFamilyTitle": "Impact, fantasy",
+    "fontSizeTitle": "26px",
+    "fontWeightSubtitle": 600,
+    "fontSizeSubtitle": "1.25rem",
+  }
+  ```
+
   | Primary Button options               | Description                                            |
   | ------------------------------------ | ------------------------------------------------------ |
   | `colorContentButtonPrimaryText`      | Change color of Primary Button text                    |

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ A number of options are available to allow you to customize the SDK:
 
 - **`customUI {Object} optional`**
 
-  If you would like to customize the SDK, this can be done by providing the `customUI` option with an object with the corresponding CSS values (e.g. RGBA colour values, border radius values) for the following options:
+  If you would like to customize the SDK, this can be done by providing the `customUI` option with an object with the corresponding CSS values (e.g. RGBA color values, border radius values) for the following options:
 
   | Typography options     | Description                                    |
   | ---------------------- | ---------------------------------------------- |
@@ -406,9 +406,9 @@ A number of options are available to allow you to customize the SDK:
   | `fontWeightTitle`      | Change font weight of the SDK screen titles    |
   | `fontWeightSubtitle`   | Change font weight of the SDK screen subtitles |
   | `fontWeightBody`       | Change font weight of the SDK screen content   |
-  | `colorContentTitle`    | Change text colour of the SDK screen titles    |
-  | `colorContentSubtitle` | Change text colour of the SDK screen subtitles |
-  | `colorContentBody`     | Change text colour of the SDK screen content   |
+  | `colorContentTitle`    | Change text color of the SDK screen titles     |
+  | `colorContentSubtitle` | Change text color of the SDK screen subtitles  |
+  | `colorContentBody`     | Change text color of the SDK screen content    |
 
   Example configuration with the different CSS font related values that can be used:
 
@@ -443,7 +443,7 @@ A number of options are available to allow you to customize the SDK:
   | `colorBorderDocTypeButtonHover`  | Change color of Document Type Button border on hover     |
   | `colorBorderDocTypeButtonActive` | Change color of Document Type Button border on click/tap |
 
-  Example configuration with the different CSS colour value variations that can be used:
+  Example configuration with the different CSS color value variations that can be used:
 
   ```javascript
   customUI: {
@@ -890,7 +890,7 @@ Refer to our [accessibility statement](https://developers.onfido.com/guide/sdk-a
 
 ### Note
 
-If you are making your own UI customizations, you are responsible for ensuring that the UI changes will still adhere to accessibility standards for such things like accessible colour contrast ratios and dyslexic friendly fonts.
+If you are making your own UI customizations, you are responsible for ensuring that the UI changes will still adhere to accessibility standards for such things like accessible color contrast ratios and dyslexic friendly fonts.
 
 ## TypeScript
 

--- a/README.md
+++ b/README.md
@@ -395,9 +395,20 @@ A number of options are available to allow you to customize the SDK:
 
   If you would like to customize the SDK, this can be done by providing the `customUI` option with an object with the corresponding CSS values (e.g. RGBA colour values, border radius values) for the following options:
 
-  | Font options | Description                                                    |
-  | ------------ | -------------------------------------------------------------- |
-  | `fontFamily` | Change font family of SDK (only works for basic font families) |
+  | Typography options     | Description                                  |
+  | ---------------------- | -------------------------------------------- |
+  | `fontFamilyTitle`      | Change font family of the SDK's titles       |
+  | `fontSizeTitle`        | Change font size of the SDK's titles         |
+  | `fontWeightTitle`      | Change font weight of the SDK's titles       |
+  | `colorContentTitle`    | Change text colour of the SDK's titles       |
+  | `fontFamilySubtitle`   | Change font family of the SDK's subtitles    |
+  | `fontSizeSubtitle`     | Change font size of the SDK's subtitles      |
+  | `fontWeightSubtitle`   | Change font weight of the SDK's subtitles    |
+  | `colorContentSubtitle` | Change text colour of the SDK's subtitles    |
+  | `fontFamilyBody`       | Change font family of the SDK's content body |
+  | `fontSizeBody`         | Change font size of the SDK's content body   |
+  | `fontWeightBody`       | Change font weight of the SDK's content body |
+  | `colorContentBody`     | Change text colour of the SDK's content body |
 
   | Primary Button options               | Description                                            |
   | ------------------------------------ | ------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -395,20 +395,20 @@ A number of options are available to allow you to customize the SDK:
 
   If you would like to customize the SDK, this can be done by providing the `customUI` option with an object with the corresponding CSS values (e.g. RGBA colour values, border radius values) for the following options:
 
-  | Typography options     | Description                                  |
-  | ---------------------- | -------------------------------------------- |
-  | `fontFamilyTitle`      | Change font family of the SDK's titles       |
-  | `fontSizeTitle`        | Change font size of the SDK's titles         |
-  | `fontWeightTitle`      | Change font weight of the SDK's titles       |
-  | `colorContentTitle`    | Change text colour of the SDK's titles       |
-  | `fontFamilySubtitle`   | Change font family of the SDK's subtitles    |
-  | `fontSizeSubtitle`     | Change font size of the SDK's subtitles      |
-  | `fontWeightSubtitle`   | Change font weight of the SDK's subtitles    |
-  | `colorContentSubtitle` | Change text colour of the SDK's subtitles    |
-  | `fontFamilyBody`       | Change font family of the SDK's content body |
-  | `fontSizeBody`         | Change font size of the SDK's content body   |
-  | `fontWeightBody`       | Change font weight of the SDK's content body |
-  | `colorContentBody`     | Change text colour of the SDK's content body |
+  | Typography options     | Description                                    |
+  | ---------------------- | ---------------------------------------------- |
+  | `fontFamilyTitle`      | Change font family of the SDK screen titles    |
+  | `fontFamilySubtitle`   | Change font family of the SDK screen subtitles |
+  | `fontFamilyBody`       | Change font family of the SDK screen content   |
+  | `fontSizeTitle`        | Change font size of the SDK screen titles      |
+  | `fontSizeSubtitle`     | Change font size of the SDK screen subtitles   |
+  | `fontSizeBody`         | Change font size of the SDK screen content     |
+  | `fontWeightTitle`      | Change font weight of the SDK screen titles    |
+  | `fontWeightSubtitle`   | Change font weight of the SDK screen subtitles |
+  | `fontWeightBody`       | Change font weight of the SDK screen content   |
+  | `colorContentTitle`    | Change text colour of the SDK screen titles    |
+  | `colorContentSubtitle` | Change text colour of the SDK screen subtitles |
+  | `colorContentBody`     | Change text colour of the SDK screen content   |
 
   | Primary Button options               | Description                                            |
   | ------------------------------------ | ------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Congratulations! You have successfully started the flow. Carry on reading the ne
 
 - Handle callbacks
 - Remove the SDK from the page
-- Customise the SDK
+- Customize the SDK
 - Create checks
 
 ## Handling callbacks

--- a/README.md
+++ b/README.md
@@ -395,20 +395,20 @@ A number of options are available to allow you to customize the SDK:
 
   If you would like to customize the SDK, this can be done by providing the `customUI` option with an object with the corresponding CSS values (e.g. RGBA color values, border radius values) for the following options:
 
-  | Typography options     | Description                                    |
-  | ---------------------- | ---------------------------------------------- |
-  | `fontFamilyTitle`      | Change font family of the SDK screen titles    |
-  | `fontFamilySubtitle`   | Change font family of the SDK screen subtitles |
-  | `fontFamilyBody`       | Change font family of the SDK screen content   |
-  | `fontSizeTitle`        | Change font size of the SDK screen titles      |
-  | `fontSizeSubtitle`     | Change font size of the SDK screen subtitles   |
-  | `fontSizeBody`         | Change font size of the SDK screen content     |
-  | `fontWeightTitle`      | Change font weight of the SDK screen titles    |
-  | `fontWeightSubtitle`   | Change font weight of the SDK screen subtitles |
-  | `fontWeightBody`       | Change font weight of the SDK screen content   |
-  | `colorContentTitle`    | Change text color of the SDK screen titles     |
-  | `colorContentSubtitle` | Change text color of the SDK screen subtitles  |
-  | `colorContentBody`     | Change text color of the SDK screen content    |
+  | Typography options     | Description                                                                        |
+  | ---------------------- | ---------------------------------------------------------------------------------- |
+  | `fontFamilyTitle`      | Change font family of the SDK screen titles                                        |
+  | `fontFamilySubtitle`   | Change font family of the SDK screen subtitles                                     |
+  | `fontFamilyBody`       | Change font family of the SDK screen content                                       |
+  | `fontSizeTitle`        | Change font size of the SDK screen titles                                          |
+  | `fontSizeSubtitle`     | Change font size of the SDK screen subtitles                                       |
+  | `fontSizeBody`         | Change font size of the SDK screen content                                         |
+  | `fontWeightTitle`      | Change font weight of the SDK screen titles (number format only, e.g. 400, 600)    |
+  | `fontWeightSubtitle`   | Change font weight of the SDK screen subtitles (number format only, e.g. 400, 600) |
+  | `fontWeightBody`       | Change font weight of the SDK screen content (number format only, e.g. 400, 600)   |
+  | `colorContentTitle`    | Change text color of the SDK screen titles                                         |
+  | `colorContentSubtitle` | Change text color of the SDK screen subtitles                                      |
+  | `colorContentBody`     | Change text color of the SDK screen content                                        |
 
   Example configuration with the different CSS font related values that can be used:
 

--- a/src/components/CountrySelector/style.scss
+++ b/src/components/CountrySelector/style.scss
@@ -85,7 +85,7 @@
 
 $_sdk-font-size: var(--font-size-small);
 $_sdk-line-height: 18 * $unit-small;
-$_sdk-text-color: $color-body-text;
+$_sdk-text-color: var(--osdk-color-content-body);
 
 $_sdk-border-style: 1px solid $color-input-border;
 $_sdk-input-horizontal-padding: 8 * $unit-small;

--- a/src/components/DocumentSelector/style.scss
+++ b/src/components/DocumentSelector/style.scss
@@ -20,7 +20,7 @@ $selector-button-box-shadow: 0 0 0 2px;
   border-color: var(--osdk-color-border-doc-type-button);
   border-style: solid;
   border-width: 1px;
-  color: $color-body-text;
+  color: var(--osdk-color-content-body);
   cursor: pointer;
   display: flex;
   font: inherit;
@@ -74,7 +74,7 @@ $selector-button-box-shadow: 0 0 0 2px;
 }
 
 .hint {
-  color: $color-body-text;
+  color: var(--osdk-color-content-body);
   font-weight: 500;
   font-size: var(--font-size-small);
   margin-bottom: 4 * $unit-small;

--- a/src/components/Modal/style.scss
+++ b/src/components/Modal/style.scss
@@ -61,7 +61,7 @@ $modal-animation-duration: 200ms;
   border-radius: 8 * $unit;
   border: 1px solid $color-border;
 
-  font-family: var(--font-family-body) !important;
+  font-family: var(--osdk-font-family-body) !important;
   background-color: var(--color-background);
 
   color: $color-body-text;
@@ -108,7 +108,7 @@ $modal-animation-duration: 200ms;
   border-radius: 16 * $unit;
   border: 0;
   cursor: pointer;
-  font-family: var(--osdk-font-family);
+  font-family: var(--osdk-font-family-body);
   height: 32 * $unit;
   position: absolute;
   right: 15 * $unit;

--- a/src/components/Modal/style.scss
+++ b/src/components/Modal/style.scss
@@ -108,7 +108,7 @@ $modal-animation-duration: 200ms;
   border-radius: 16 * $unit;
   border: 0;
   cursor: pointer;
-  font-family: var(--font-family);
+  font-family: var(--osdk-font-family);
   height: 32 * $unit;
   position: absolute;
   right: 15 * $unit;

--- a/src/components/Modal/style.scss
+++ b/src/components/Modal/style.scss
@@ -64,7 +64,7 @@ $modal-animation-duration: 200ms;
   font-family: var(--osdk-font-family-body) !important;
   background-color: var(--color-background);
 
-  color: $color-body-text;
+  color: var(--osdk-color-content-body);
   font-weight: var(--font-weight-body);
   line-height: 1.5;
 

--- a/src/components/NavigationBar/style.scss
+++ b/src/components/NavigationBar/style.scss
@@ -19,7 +19,7 @@
   color: $color-body-text;
   padding: 0;
   font-size: inherit;
-  font-family: var(--osdk-font-family);
+  font-family: var(--osdk-font-family-body);
   line-height: 1;
   border: 0;
   background-color: transparent;

--- a/src/components/NavigationBar/style.scss
+++ b/src/components/NavigationBar/style.scss
@@ -19,7 +19,7 @@
   color: $color-body-text;
   padding: 0;
   font-size: inherit;
-  font-family: var(--font-family);
+  font-family: var(--osdk-font-family);
   line-height: 1;
   border: 0;
   background-color: transparent;

--- a/src/components/NavigationBar/style.scss
+++ b/src/components/NavigationBar/style.scss
@@ -16,7 +16,7 @@
 
 .back {
   height: 32 * $unit;
-  color: $color-body-text;
+  color: var(--osdk-color-content-body);
   padding: 0;
   font-size: inherit;
   font-family: var(--osdk-font-family-body);

--- a/src/components/PageTitle/style.scss
+++ b/src/components/PageTitle/style.scss
@@ -1,14 +1,14 @@
 @import '../Theme/constants';
 
 .title {
-  color: $color-title-text;
-  font-family: var(--font-family-title);
-  font-weight: var(--font-weight-title);
+  color: var(--osdk-color-content-title);
+  font-family: var(--osdk-font-family-title);
+  font-weight: var(--osdk-font-weight-title);
   margin-bottom: 16 * $unit;
 }
 
 .titleSpan {
-  font-size: var(--font-size-title);
+  font-size: var(--osdk-font-size-title);
   line-height: 1.34;
   @media (--small-viewport) {
     font-size: 24 * $unit;
@@ -20,10 +20,10 @@
 }
 
 .subTitle {
-  color: $color-subtitle-text;
-  font-size: var(--font-size-subtitle);
-  font-family: var(--font-family-subtitle);
-  font-weight: var(--font-weight-subtitle);
+  color: var(--osdk-color-content-subtitle);
+  font-size: var(--osdk-font-size-subtitle);
+  font-family: var(--osdk-font-family-subtitle);
+  font-weight: var(--osdk-font-weight-subtitle);
 }
 
 .titleWrapper {

--- a/src/components/PhoneNumberInput/style.scss
+++ b/src/components/PhoneNumberInput/style.scss
@@ -27,7 +27,7 @@
   }
 
   .rrui__select__arrow {
-    color: $color-body-text;
+    color: var(--osdk-color-content-body);
   }
 
   .rrui__select__options:not(.rrui__select__options--menu) {

--- a/src/components/PhoneNumberInput/style.scss
+++ b/src/components/PhoneNumberInput/style.scss
@@ -1,7 +1,8 @@
 @import '../Theme/constants';
 
+/* "Loading" phone number input placeholder text */
 .loading {
-  color: $color-tips-pill;
+  color: rgba(var(--ods-color-content-placeholder));
   font-size: var(--font-size-large);
   line-height: 1.6;
   margin: 8 * $unit-large;

--- a/src/components/Photo/style.scss
+++ b/src/components/Photo/style.scss
@@ -29,11 +29,11 @@
     margin-bottom: 0;
   }
 
-  /* line connecting all three icons */
+  /* line connecting icons on Selfie Intro screen */
   &::before {
     content: '';
     display: block;
-    background-color: rgba(var(--ods-color-neutral-800));
+    background-color: $color-icons-connector-line;
     width: 2 * $unit;
     height: 150%;
     position: absolute;

--- a/src/components/Photo/style.scss
+++ b/src/components/Photo/style.scss
@@ -33,7 +33,7 @@
   &::before {
     content: '';
     display: block;
-    background-color: $color-body-text;
+    background-color: rgba(var(--ods-color-neutral-800));
     width: 2 * $unit;
     height: 150%;
     position: absolute;

--- a/src/components/ProofOfAddress/Guidance/style.scss
+++ b/src/components/ProofOfAddress/Guidance/style.scss
@@ -30,7 +30,7 @@
 }
 
 .makeSure {
-  color: $color-body-text;
+  color: var(--osdk-color-content-body);
   font-weight: 600;
   margin-bottom: 8 * $unit;
 
@@ -60,6 +60,6 @@
 }
 
 .label {
-  fill: $color-body-text;
+  fill: var(--osdk-color-content-body);
   font-size: var(--font-size-small);
 }

--- a/src/components/ProofOfAddress/PoAIntro/style.scss
+++ b/src/components/ProofOfAddress/PoAIntro/style.scss
@@ -11,7 +11,7 @@
 
 .requirements {
   font-weight: 600;
-  color: $color-body-text;
+  color: var(--osdk-color-content-body);
   margin-bottom: 16 * $unit;
 }
 

--- a/src/components/Theme/constants.scss
+++ b/src/components/Theme/constants.scss
@@ -52,6 +52,7 @@ $color-border: rgba(var(--ods-color-neutral-600));
 $color-divider: rgba(var(--ods-color-neutral-400));
 $color-adjust-huener: rgba(var(--ods-color-neutral-600));
 $color-body-text: var(--osdk-color-content-body);
+$color-icons-connector-line: rgba(var(--ods-color-neutral-800));
 
 /* TODO: CX-5306 - "Tips" and "Recovery" header pills background, text colours should be the same */
 $color-tips-pill: #5d6b78;

--- a/src/components/Theme/constants.scss
+++ b/src/components/Theme/constants.scss
@@ -51,9 +51,7 @@ $color-icon-temporary: rgba(var(--ods-color-neutral-300));
 $color-border: rgba(var(--ods-color-neutral-600));
 $color-divider: rgba(var(--ods-color-neutral-400));
 $color-adjust-huener: rgba(var(--ods-color-neutral-600));
-$color-body-text: rgba(var(--ods-color-neutral-800));
-$color-title-text: rgba(var(--ods-color-neutral-800));
-$color-subtitle-text: $color-body-text;
+$color-body-text: var(--osdk-color-content-body);
 
 /* TODO: CX-5306 - "Tips" and "Recovery" header pills background, text colours should be the same */
 $color-tips-pill: #5d6b78;

--- a/src/components/Theme/constants.scss
+++ b/src/components/Theme/constants.scss
@@ -50,8 +50,6 @@ $color-black: rgba(var(--ods-color-neutral-black));
 $color-icon-temporary: rgba(var(--ods-color-neutral-300));
 $color-border: rgba(var(--ods-color-neutral-600));
 $color-divider: rgba(var(--ods-color-neutral-400));
-$color-adjust-huener: rgba(var(--ods-color-neutral-600));
-$color-body-text: var(--osdk-color-content-body);
 $color-icons-connector-line: rgba(var(--ods-color-neutral-800));
 
 /* TODO: CX-5306 - "Tips" and "Recovery" header pills background, text colours should be the same */

--- a/src/components/Theme/style.scss
+++ b/src/components/Theme/style.scss
@@ -262,7 +262,7 @@ $logo-height: 32 * $unit;
   cursor: pointer;
   line-height: 1.43;
   font-size: var(--font-size-small);
-  font-family: var(--font-family);
+  font-family: var(--osdk-font-family);
   margin: auto;
   padding: 2px;
   text-decoration: none;

--- a/src/components/Theme/style.scss
+++ b/src/components/Theme/style.scss
@@ -269,7 +269,7 @@ $logo-height: 32 * $unit;
   border: 1px solid transparent;
   border-bottom-color: var(--color-primary);
   background-color: transparent;
-  color: $color-body-text;
+  color: var(--osdk-color-content-body);
 
   &:not(:disabled) {
     &:hover {
@@ -285,7 +285,7 @@ $logo-height: 32 * $unit;
 
   &:visited {
     text-decoration: none;
-    color: $color-body-text;
+    color: var(--osdk-color-content-body);
     font-size: var(--font-size-small);
   }
 

--- a/src/components/Theme/style.scss
+++ b/src/components/Theme/style.scss
@@ -262,7 +262,7 @@ $logo-height: 32 * $unit;
   cursor: pointer;
   line-height: 1.43;
   font-size: var(--font-size-small);
-  font-family: var(--osdk-font-family);
+  font-family: var(--osdk-font-family-body);
   margin: auto;
   padding: 2px;
   text-decoration: none;

--- a/src/components/Theme/tokens.scss
+++ b/src/components/Theme/tokens.scss
@@ -21,25 +21,28 @@
   --unit: (1/16) * 1em;
 
   /* Font settings */
-  --osdk-font-family: 'Open Sans', sans-serif;
-
-  --font-family-title: var(--osdk-font-family);
-  --font-family-subtitle: var(--osdk-font-family);
-  --font-family-body: var(--osdk-font-family);
+  --font-family: 'Open Sans', sans-serif;
 
   --font-size-base: calc(16 * var(--unit));
-
-  --font-size-title: calc(30 * var(--unit));
-  --font-size-subtitle: var(--font-size-base);
-  --font-size-body: var(--font-size-base);
 
   --font-size-large: calc(20 * var(--unit));
   --font-size-small: calc(14 * var(--unit));
   --font-size-x-small: calc(11 * var(--unit));
 
-  --font-weight-title: 600;
-  --font-weight-subtitle: 600;
-  --font-weight-body: 500;
+  --osdk-font-family-title: var(--font-family);
+  --osdk-font-size-title: calc(30 * var(--unit));
+  --osdk-font-weight-title: 600;
+  --osdk-color-content-title: rgba(var(--ods-color-content-main));
+
+  --osdk-font-family-subtitle: var(--font-family);
+  --osdk-font-size-subtitle: var(--font-size-base);
+  --osdk-font-weight-subtitle: 600;
+  --osdk-color-content-subtitle: rgba(var(--ods-color-content-main));
+
+  --osdk-font-family-body: var(--font-family);
+  --osdk-font-size-body: var(--font-size-base);
+  --osdk-font-weight-body: 500;
+  --osdk-color-content-body: rgba(var(--ods-color-content-main));
 
   /* General UI element background color settings */
   --osdk-color-border-surface-modal: rgba(var(--ods-color-neutral-600));

--- a/src/components/Theme/tokens.scss
+++ b/src/components/Theme/tokens.scss
@@ -20,11 +20,12 @@
 @mixin tokens() {
   --unit: (1/16) * 1em;
 
-  /* Font Variables */
-  --font-family: 'Open Sans', sans-serif;
-  --font-family-title: var(--font-family);
-  --font-family-subtitle: var(--font-family);
-  --font-family-body: var(--font-family);
+  /* Font settings */
+  --osdk-font-family: 'Open Sans', sans-serif;
+
+  --font-family-title: var(--osdk-font-family);
+  --font-family-subtitle: var(--osdk-font-family);
+  --font-family-body: var(--osdk-font-family);
 
   --font-size-base: calc(16 * var(--unit));
 

--- a/src/components/UserConsent/style.scss
+++ b/src/components/UserConsent/style.scss
@@ -6,7 +6,7 @@
   border-style: none;
 
   h1 {
-    color: $color-title-text;
+    color: var(--osdk-color-content-title);
     font-weight: 600;
     font-size: $font-size-x-large;
     line-height: 1.34;

--- a/src/components/crossDevice/CrossDeviceLink/style.scss
+++ b/src/components/crossDevice/CrossDeviceLink/style.scss
@@ -136,7 +136,7 @@ $parent-width: 432;
   line-height: 1.5;
   color: $color-body-text;
   white-space: nowrap;
-  font-family: var(--font-family);
+  font-family: var(--osdk-font-family);
 }
 
 /* FIXME: CX-5306 - text/link Button for x-device Copy link */
@@ -145,7 +145,7 @@ $parent-width: 432;
   float: right;
   height: 100%;
   font-size: var(--font-size-small);
-  font-family: var(--font-family);
+  font-family: var(--osdk-font-family);
   margin-left: 4 * $unit-small;
   padding: 2px;
   text-decoration: none;

--- a/src/components/crossDevice/CrossDeviceLink/style.scss
+++ b/src/components/crossDevice/CrossDeviceLink/style.scss
@@ -33,7 +33,7 @@ $parent-width: 432;
 .label {
   font-weight: 600;
   text-align: left;
-  color: $color-body-text;
+  color: var(--osdk-color-content-body);
   float: left;
 }
 
@@ -134,7 +134,7 @@ $parent-width: 432;
   text-overflow: ellipsis;
   font-size: inherit;
   line-height: 1.5;
-  color: $color-body-text;
+  color: var(--osdk-color-content-body);
   white-space: nowrap;
   font-family: var(--osdk-font-family-body);
 }
@@ -152,7 +152,7 @@ $parent-width: 432;
   border: 1px solid transparent;
   border-bottom-color: var(--color-primary);
   background-color: $color-transparent;
-  color: $color-body-text;
+  color: var(--osdk-color-content-body);
 
   &:hover {
     background-color: var(--osdk-color-background-button-primary-hover);
@@ -166,7 +166,7 @@ $parent-width: 432;
 
   &:visited {
     text-decoration: none;
-    color: $color-body-text;
+    color: var(--osdk-color-content-body);
     font-size: var(--font-size-small);
   }
 }

--- a/src/components/crossDevice/CrossDeviceLink/style.scss
+++ b/src/components/crossDevice/CrossDeviceLink/style.scss
@@ -136,7 +136,7 @@ $parent-width: 432;
   line-height: 1.5;
   color: $color-body-text;
   white-space: nowrap;
-  font-family: var(--osdk-font-family);
+  font-family: var(--osdk-font-family-body);
 }
 
 /* FIXME: CX-5306 - text/link Button for x-device Copy link */
@@ -145,7 +145,7 @@ $parent-width: 432;
   float: right;
   height: 100%;
   font-size: var(--font-size-small);
-  font-family: var(--osdk-font-family);
+  font-family: var(--osdk-font-family-body);
   margin-left: 4 * $unit-small;
   padding: 2px;
   text-decoration: none;

--- a/src/components/crossDevice/Intro/style.scss
+++ b/src/components/crossDevice/Intro/style.scss
@@ -34,7 +34,7 @@
   &::before {
     content: '';
     display: block;
-    background-color: $color-body-text;
+    background-color: var(--osdk-color-content-body);
     width: 2 * $unit;
     height: 100%;
     position: absolute;
@@ -82,6 +82,6 @@
   &-sms,
   &-take-photos,
   &-return-to-computer {
-    color: $color-body-text;
+    color: var(--osdk-color-content-body);
   }
 }

--- a/src/components/crossDevice/Intro/style.scss
+++ b/src/components/crossDevice/Intro/style.scss
@@ -34,7 +34,7 @@
   &::before {
     content: '';
     display: block;
-    background-color: var(--osdk-color-content-body);
+    background-color: $color-icons-connector-line;
     width: 2 * $unit;
     height: 100%;
     position: absolute;

--- a/src/demo/custom-ui-config.json
+++ b/src/demo/custom-ui-config.json
@@ -1,4 +1,5 @@
 {
+  "fontFamily": "Oldtown, fantasy",
   "colorContentButtonPrimaryText": "#333",
   "colorBackgroundButtonPrimary": "#ffb997",
   "colorBorderButtonPrimary": "#b23a48",

--- a/src/demo/custom-ui-config.json
+++ b/src/demo/custom-ui-config.json
@@ -1,5 +1,6 @@
 {
-  "fontFamily": "Oldtown, fantasy",
+  "fontFamilyTitle": "Impact, fantasy",
+  "fontWeightSubtitle": 500,
   "colorContentButtonPrimaryText": "#333",
   "colorBackgroundButtonPrimary": "#ffb997",
   "colorBorderButtonPrimary": "#b23a48",

--- a/src/demo/custom-ui-config.json
+++ b/src/demo/custom-ui-config.json
@@ -1,6 +1,7 @@
 {
   "fontFamilyTitle": "Impact, fantasy",
-  "fontWeightSubtitle": 500,
+  "fontWeightSubtitle": 600,
+  "fontSizeSubtitle": "1.25rem",
   "colorContentButtonPrimaryText": "#333",
   "colorBackgroundButtonPrimary": "#ffb997",
   "colorBorderButtonPrimary": "#b23a48",

--- a/src/types/ui-customisation-options.ts
+++ b/src/types/ui-customisation-options.ts
@@ -1,5 +1,5 @@
 export type UICustomizationOptions = {
-  // Title Fonts
+  // Title Font
   fontFamilyTitle?: string
   fontSizeTitle?: string
   fontWeightTitle?: string | number

--- a/src/types/ui-customisation-options.ts
+++ b/src/types/ui-customisation-options.ts
@@ -1,4 +1,7 @@
 export type UICustomizationOptions = {
+  // Fonts
+  fontFamily?: string
+
   // Primary Button
   colorContentButtonPrimaryText?: string
   colorBackgroundButtonPrimary?: string

--- a/src/types/ui-customisation-options.ts
+++ b/src/types/ui-customisation-options.ts
@@ -2,19 +2,19 @@ export type UICustomizationOptions = {
   // Title Font
   fontFamilyTitle?: string
   fontSizeTitle?: string
-  fontWeightTitle?: string | number
+  fontWeightTitle?: number
   colorContentTitle?: string
 
   // Subtitle Font
   fontFamilySubtitle?: string
   fontSizeSubtitle?: string
-  fontWeightSubtitle?: string | number
+  fontWeightSubtitle?: number
   colorContentSubtitle?: string
 
   // Body Font
   fontFamilyBody?: string
   fontSizeBody?: string
-  fontWeightBody?: string | number
+  fontWeightBody?: number
   colorContentBody?: string
 
   // Primary Button

--- a/src/types/ui-customisation-options.ts
+++ b/src/types/ui-customisation-options.ts
@@ -1,6 +1,21 @@
 export type UICustomizationOptions = {
-  // Fonts
-  fontFamily?: string
+  // Title Fonts
+  fontFamilyTitle?: string
+  fontSizeTitle?: string
+  fontWeightTitle?: string | number
+  colorContentTitle?: string
+
+  // Subtitle Fonts
+  fontFamilySubtitle?: string
+  fontSizeSubtitle?: string
+  fontWeightSubtitle?: string | number
+  colorContentSubtitle?: string
+
+  // Body Fonts
+  fontFamilyBody?: string
+  fontSizeBody?: string
+  fontWeightBody?: string | number
+  colorContentBody?: string
 
   // Primary Button
   colorContentButtonPrimaryText?: string

--- a/src/types/ui-customisation-options.ts
+++ b/src/types/ui-customisation-options.ts
@@ -5,7 +5,7 @@ export type UICustomizationOptions = {
   fontWeightTitle?: string | number
   colorContentTitle?: string
 
-  // Subtitle Fonts
+  // Subtitle Font
   fontFamilySubtitle?: string
   fontSizeSubtitle?: string
   fontWeightSubtitle?: string | number

--- a/src/types/ui-customisation-options.ts
+++ b/src/types/ui-customisation-options.ts
@@ -11,7 +11,7 @@ export type UICustomizationOptions = {
   fontWeightSubtitle?: string | number
   colorContentSubtitle?: string
 
-  // Body Fonts
+  // Body Font
   fontFamilyBody?: string
   fontSizeBody?: string
   fontWeightBody?: string | number


### PR DESCRIPTION
# Task
We want to offer customers supported customisation options for the JS SDK so that they can use custom fonts. We'd like to allow them to change:

- Page title font family/weight/size & colour
- Subtitle font family/weight/size & colour
- Body content font family/weight/size & colour

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [x] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
