### PR TITLE
Fix/doc filename issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Fixed
 
 - Public: Fix zoomed document capture view for Document Live Capture on some Huawei devices, e.g. Huawei P40, P30.
+- Public: Fix issue where documents are submitted to Onfido API without filename or file type.
 
 ## [6.5.0] - 2020-02-08
 

--- a/src/components/Camera/index.js
+++ b/src/components/Camera/index.js
@@ -48,6 +48,7 @@ const CameraPure = ({
   translate,
   facing = 'user',
   docLiveCaptureFrame = false,
+  docAutoCaptureFrame = false,
   idealCameraHeight,
   buttonType,
   onButtonClick,
@@ -58,6 +59,7 @@ const CameraPure = ({
   <div
     className={classNames(style.camera, {
       [style.docLiveCaptureFrame]: docLiveCaptureFrame,
+      [style.docAutoCaptureFrame]: docAutoCaptureFrame,
     })}
   >
     {renderTitle}

--- a/src/components/Camera/style.scss
+++ b/src/components/Camera/style.scss
@@ -9,6 +9,7 @@
 
   &.docAutoCaptureFrame {
     display: block;
+    justify-content: flex-start;
   }
 }
 

--- a/src/components/Confirm/Confirm.js
+++ b/src/components/Confirm/Confirm.js
@@ -181,6 +181,7 @@ class Confirm extends Component {
     this.setState({ uploadInProgress: true })
     const {
       blob,
+      filename,
       documentType: type,
       variant,
       challengeData,
@@ -212,7 +213,7 @@ class Confirm extends Component {
       // API does not support 'residence_permit' type but does accept 'unknown'
       // See https://documentation.onfido.com/#document-types
       const data = {
-        file: blob,
+        file: { blob, filename },
         type: type === 'residence_permit' ? 'unknown' : type,
         side,
         validations,

--- a/src/components/Photo/DocumentAutoCapture.js
+++ b/src/components/Photo/DocumentAutoCapture.js
@@ -7,7 +7,6 @@ import { DocumentOverlay } from '../Overlay'
 import Camera from '../Camera'
 import CameraError from '../CameraError'
 import { postToBackend } from '~utils/sdkBackend'
-import style from '../Camera/style.scss'
 
 const maxAttempts = 3
 
@@ -119,7 +118,7 @@ export default class DocumentAutoCapture extends Component {
     return (
       <Camera
         {...this.props}
-        className={style.docAutoCaptureFrame}
+        docAutoCaptureFrame={true}
         webcamRef={(c) => (this.webcam = c)}
         renderError={
           hasError ? (


### PR DESCRIPTION
# Task
 Fix issue where documents are submitted to Onfido API without filename or file type.
 Fix dev regression where document auto-capture frame was displayed at the bottom of the flex container.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
