### PR TITLE
Feature/cx 5307 customisations modal background, border, info header pills

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,11 @@ A number of options are available to allow you to customize the SDK:
   | `colorContentAlertErrorLinkHover`  | Change error popup fallback Link background on hover     |
   | `colorContentAlertErrorLinkActive` | Change error popup fallback Link background on click/tap |
 
+  | Info Header/Highlight Pills | Description                                                                                      |
+  | --------------------------- | ------------------------------------------------------------------------------------------------ |
+  | `colorBackgroundInfoPill`   | Change background color of Cross Device, Camera/Mic Permissions screens' information header pill |
+  | `colorContentInfoPill`      | Change text color of Cross Device, Camera/Mic Permissions screens' information header pill       |
+
 - **`steps {List} optional`**
 
   List of the different steps and their custom options. Each step can either be specified as a string (when no customization is required) or an object (when customization is required):

--- a/README.md
+++ b/README.md
@@ -393,7 +393,12 @@ A number of options are available to allow you to customize the SDK:
 
 - **`customUI {Object} optional`**
 
-  If you would like to customise the SDK, this can be done by providing the `customUI` option with an object with the corresponding CSS values (e.g. RGBA colour values, border radius values) for the following UI element options:
+  If you would like to customise the SDK, this can be done by providing the `customUI` option with an object with the corresponding CSS values (e.g. RGBA colour values, border radius values - see example configurations below) for the following UI element options:
+
+  | Modal (SDK main container)    | Description                          |
+  | ----------------------------- | ------------------------------------ |
+  | `colorBackgroundSurfaceModal` | Change background color of SDK modal |
+  | `colorBorderSurfaceModal`     | Change color of SDK modal border     |
 
   | Primary Buttons                      | Description                                            |
   | ------------------------------------ | ------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -399,6 +399,20 @@ A number of options are available to allow you to customize the SDK:
   | ----------------------------- | ------------------------------------ |
   | `colorBackgroundSurfaceModal` | Change background color of SDK modal |
   | `colorBorderSurfaceModal`     | Change color of SDK modal border     |
+  | `borderWidthSurfaceModal`     | Change border width of SDK modal     |
+  | `borderStyleSurfaceModal`     | Change border style of SDK modal     |
+  | `borderRadiusSurfaceModal`    | Change border radius of SDK modal    |
+
+  Example configuration with the different CSS colour value variations, border style that can be used:
+
+  ```javascript
+  customUI: {
+      "colorBackgroundSurfaceModal": "#fafafa",
+      "colorBorderSurfaceModal": "rgb(132 59 98)",
+      "borderWidthSurfaceModal": "6px",
+      "borderStyleSurfaceModal": "groove",
+    }
+  ```
 
   | Primary Buttons                      | Description                                            |
   | ------------------------------------ | ------------------------------------------------------ |

--- a/src/components/CameraPermissions/Recover/style.scss
+++ b/src/components/CameraPermissions/Recover/style.scss
@@ -19,12 +19,9 @@
   margin: 0 0 8 * $unit-small;
 }
 
+/* Camera Permission "Recovery" header pill, has subtle differences to the Theme header pill */
 .recovery {
-  /* TODO: CX-5306 - SDK Customisation - This is the "Recovery" header pill */
-  color: $color-white; // Header pill text colour
-  background: var(--color-primary); // Header pill background colour
-  border-radius: 14 * $unit-small;
-  font-weight: 600;
+  @include header-highlight-pill(14);
   left: 20 * $unit-small;
   line-height: 24 * $unit-small;
   padding: 0 15 * $unit-small;

--- a/src/components/CameraPermissions/Recover/style.scss
+++ b/src/components/CameraPermissions/Recover/style.scss
@@ -2,10 +2,7 @@
 
 .instructions {
   font-size: var(--font-size-small);
-
   text-align: left;
-  border-radius: 3 * $unit-small;
-  border: 1px solid rgba(var(--ods-color-neutral-050));
   margin: 30 * $unit-small 0 24 * $unit-small;
   position: relative;
   padding: 24 * $unit-small 24 * $unit-small 12 * $unit-small;

--- a/src/components/CameraPermissions/Recover/style.scss
+++ b/src/components/CameraPermissions/Recover/style.scss
@@ -5,7 +5,7 @@
 
   text-align: left;
   border-radius: 3 * $unit-small;
-  border: 1px solid var(--color-background);
+  border: 1px solid rgba(var(--ods-color-neutral-050));
   margin: 30 * $unit-small 0 24 * $unit-small;
   position: relative;
   padding: 24 * $unit-small 24 * $unit-small 12 * $unit-small;

--- a/src/components/CameraPermissions/Recover/style.scss
+++ b/src/components/CameraPermissions/Recover/style.scss
@@ -19,7 +19,6 @@
   margin: 0 0 8 * $unit-small;
 }
 
-/* Camera Permission "Recovery" header pill, has subtle differences to the Theme header pill */
 .recovery {
   @extend %header-highlight-pill;
   position: absolute;

--- a/src/components/CameraPermissions/Recover/style.scss
+++ b/src/components/CameraPermissions/Recover/style.scss
@@ -21,12 +21,10 @@
 
 /* Camera Permission "Recovery" header pill, has subtle differences to the Theme header pill */
 .recovery {
-  @include header-highlight-pill(14);
-  left: 20 * $unit-small;
-  line-height: 24 * $unit-small;
-  padding: 0 15 * $unit-small;
+  @extend %header-highlight-pill;
   position: absolute;
   top: 0;
+  left: 20 * $unit-small;
   transform: translateY(-50%);
 }
 

--- a/src/components/CountrySelector/style.scss
+++ b/src/components/CountrySelector/style.scss
@@ -92,7 +92,7 @@ $_sdk-font-size: var(--font-size-small);
 $_sdk-line-height: 18 * $unit-small;
 $_sdk-text-color: $color-body-text;
 
-$_sdk-border-style: 1px solid rgba(var(--ods-color-border-input));
+$_sdk-input-border-style: 1px solid rgba(var(--ods-color-border-input));
 $_sdk-input-horizontal-padding: 8 * $unit-small;
 $_sdk-input-vertical-padding: 12 * $unit-small;
 $_sdk-input-icon-padding: 34 * $unit-small;
@@ -120,7 +120,7 @@ $_sdk-option-border-bottom: 0;
 .custom__hint,
 .custom__input {
   height: 100%;
-  border: $_sdk-border-style;
+  border: $_sdk-input-border-style;
   border-radius: 4 * $unit;
   box-sizing: border-box;
   margin-bottom: 0; /* BUG: Safari 10 on macOS seems to add an implicit margin. */
@@ -161,7 +161,7 @@ $_sdk-option-border-bottom: 0;
 
 .custom__menu {
   background-color: #fff;
-  border: $_sdk-border-style;
+  border: $_sdk-input-border-style;
   border-top: 0;
   color: $_sdk-text-color;
   margin: 0;

--- a/src/components/CountrySelector/style.scss
+++ b/src/components/CountrySelector/style.scss
@@ -92,7 +92,7 @@ $_sdk-font-size: var(--font-size-small);
 $_sdk-line-height: 18 * $unit-small;
 $_sdk-text-color: $color-body-text;
 
-$_sdk-border-style: 1px solid $color-input-border;
+$_sdk-border-style: 1px solid rgba(var(--ods-color-border-input));
 $_sdk-input-horizontal-padding: 8 * $unit-small;
 $_sdk-input-vertical-padding: 12 * $unit-small;
 $_sdk-input-icon-padding: 34 * $unit-small;

--- a/src/components/DocumentSelector/style.scss
+++ b/src/components/DocumentSelector/style.scss
@@ -86,8 +86,8 @@ $selector-button-box-shadow: 0 0 0 2px;
   margin-bottom: 6 * $unit-small;
 }
 
+/* .tag class used for PoA document type buttons, i.e. "e-statements accepted" text */
 .tag {
-  /* .tag class used for PoA document type buttons, i.e. "e-statements accepted" text */
   display: inline-block;
   font-size: var(--font-size-small);
   padding: 0 12 * $unit-small;

--- a/src/components/DocumentSelector/style.scss
+++ b/src/components/DocumentSelector/style.scss
@@ -87,12 +87,10 @@ $selector-button-box-shadow: 0 0 0 2px;
 }
 
 .tag {
-  /* .tag class used by PoA documents only */
+  /* .tag class used for PoA document type buttons, i.e. "e-statements accepted" text */
   display: inline-block;
-  background-color: var(--color-background);
   font-size: var(--font-size-small);
   padding: 0 12 * $unit-small;
-  border-radius: 12 * $unit-small;
   margin-left: -12 * $unit-small;
   margin-top: 2 * $unit-small;
 }

--- a/src/components/Modal/style.scss
+++ b/src/components/Modal/style.scss
@@ -58,12 +58,13 @@ $modal-animation-duration: 200ms;
   height: 600 * $unit;
   text-align: center;
   max-height: calc(100% + #{4 * $unit});
+  background-color: var(--osdk-color-background-surface-modal);
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--osdk-color-border-surface-modal);
   border-radius: 8 * $unit;
-  border: 1px solid $color-border;
 
   font-family: var(--font-family-body) !important;
-  background-color: var(--color-background);
-
   color: $color-body-text;
   font-weight: var(--font-weight-body);
   line-height: 1.5;

--- a/src/components/Modal/style.scss
+++ b/src/components/Modal/style.scss
@@ -59,10 +59,10 @@ $modal-animation-duration: 200ms;
   text-align: center;
   max-height: calc(100% + #{4 * $unit});
   background-color: var(--osdk-color-background-surface-modal);
-  border-width: 1px;
-  border-style: solid;
   border-color: var(--osdk-color-border-surface-modal);
-  border-radius: 8 * $unit;
+  border-width: var(--osdk-border-width-surface-modal);
+  border-style: var(--osdk-border-style-surface-modal);
+  border-radius: var(--osdk-border-radius-surface-modal);
 
   font-family: var(--font-family-body) !important;
   color: $color-body-text;

--- a/src/components/PhoneNumberInput/style.scss
+++ b/src/components/PhoneNumberInput/style.scss
@@ -1,7 +1,8 @@
 @import '../Theme/constants';
 
+/* "Loading" phone number input placeholder text */
 .loading {
-  color: $color-tips-pill;
+  color: rgba(var(--ods-color-content-placeholder));
   font-size: var(--font-size-large);
   line-height: 1.6;
   margin: 8 * $unit-large;

--- a/src/components/Theme/constants.scss
+++ b/src/components/Theme/constants.scss
@@ -48,7 +48,6 @@ $color-white: rgba(var(--ods-color-neutral-white));
 $color-black: rgba(var(--ods-color-neutral-black));
 
 $color-icon-temporary: rgba(var(--ods-color-neutral-300));
-$color-border: rgba(var(--ods-color-neutral-600));
 $color-divider: rgba(var(--ods-color-neutral-400));
 $color-body-text: rgba(var(--ods-color-neutral-800));
 $color-title-text: rgba(var(--ods-color-neutral-800));
@@ -97,7 +96,7 @@ $sm-btn-width-sm-screen: 160 * $unit-small;
 
 %overflow-drop-shadow {
   @media (--shorter-viewport) {
-    background-color: var(--color-background);
+    background-color: rgba(var(--ods-color-neutral-050));
     bottom: 0;
     box-shadow: 0 -5px 10px -5px #7b7b7b;
     left: -1em;

--- a/src/components/Theme/constants.scss
+++ b/src/components/Theme/constants.scss
@@ -53,10 +53,6 @@ $color-body-text: rgba(var(--ods-color-neutral-800));
 $color-title-text: rgba(var(--ods-color-neutral-800));
 $color-subtitle-text: $color-body-text;
 
-/* TODO: CX-5306 - "Tips" and "Recovery" header pills background, text colours should be the same */
-$color-tips-pill: #5d6b78;
-$color-input-border: #667080;
-
 /* Transparent colors */
 $color-transparent: transparent;
 $color-help-container: rgba(var(--ods-color-neutral-600));

--- a/src/components/Theme/constants.scss
+++ b/src/components/Theme/constants.scss
@@ -131,11 +131,13 @@ $sm-btn-width-sm-screen: 160 * $unit-small;
   }
 }
 
-@mixin header-highlight-pill($border-radius) {
-  border-radius: $border-radius * $unit-small;
+%header-highlight-pill {
+  border-radius: 14 * $unit-small;
   background-color: var(--osdk-color-background-info-pill);
   color: var(--osdk-color-content-info-pill);
   font-family: inherit;
   font-size: var(--font-size-small);
   font-weight: 600;
+  line-height: 24 * $unit-small;
+  padding: 0 14 * $unit-small;
 }

--- a/src/components/Theme/constants.scss
+++ b/src/components/Theme/constants.scss
@@ -134,3 +134,12 @@ $sm-btn-width-sm-screen: 160 * $unit-small;
     padding: 0 $smaller-text-margin;
   }
 }
+
+@mixin header-highlight-pill($border-radius) {
+  border-radius: $border-radius * $unit-small;
+  background-color: var(--osdk-color-background-info-pill);
+  color: var(--osdk-color-content-info-pill);
+  font-family: inherit;
+  font-size: var(--font-size-small);
+  font-weight: 600;
+}

--- a/src/components/Theme/style.scss
+++ b/src/components/Theme/style.scss
@@ -234,12 +234,7 @@ $logo-height: 32 * $unit;
 
 /* Header Pill element in Camera Permission Recovery, Cross Device Connected screens */
 .header {
-  border-radius: 10 * $unit-small;
-  background-color: var(--osdk-color-background-info-pill);
-  color: var(--osdk-color-content-info-pill);
-  font-family: inherit;
-  font-size: var(--font-size-small);
-  font-weight: 600;
+  @include header-highlight-pill(10);
   position: absolute;
   margin-top: -10 * $unit-small;
   margin-left: 10 * $unit-small;

--- a/src/components/Theme/style.scss
+++ b/src/components/Theme/style.scss
@@ -244,7 +244,7 @@ $logo-height: 32 * $unit;
 .help {
   padding: 24 * $unit 16 * $unit 16 * $unit;
   text-align: left;
-  box-shadow: inset 0 0 0 1 * $unit $color-help-container;
+  box-shadow: inset 0 0 0 1 * $unit var(--osdk-color-border-surface-modal);
   border-radius: 8 * $unit;
   margin-bottom: 24 * $unit;
 }

--- a/src/components/Theme/style.scss
+++ b/src/components/Theme/style.scss
@@ -232,10 +232,12 @@ $logo-height: 32 * $unit;
   height: 64 * $unit;
 }
 
+/* Header Pill element in Camera Permission Recovery, Cross Device Connected screens */
 .header {
   border-radius: 10 * $unit-small;
-  background-color: $color-tips-pill;
-  color: $color-white;
+  background-color: var(--osdk-color-background-info-pill);
+  color: var(--osdk-color-content-info-pill);
+  font-family: inherit;
   font-size: var(--font-size-small);
   font-weight: 600;
   position: absolute;

--- a/src/components/Theme/style.scss
+++ b/src/components/Theme/style.scss
@@ -234,13 +234,13 @@ $logo-height: 32 * $unit;
 
 /* Header Pill element in Camera Permission Recovery, Cross Device Connected screens */
 .header {
-  @include header-highlight-pill(10);
+  @extend %header-highlight-pill;
   position: absolute;
   margin-top: -10 * $unit-small;
   margin-left: 10 * $unit-small;
-  padding: 0 14 * $unit-small;
 }
 
+/* Cross Device Connected screen Tips info box */
 .help {
   padding: 24 * $unit 16 * $unit 16 * $unit;
   text-align: left;

--- a/src/components/Theme/tokens.scss
+++ b/src/components/Theme/tokens.scss
@@ -146,6 +146,10 @@
   --osdk-color-background-link-active: rgba(
     var(--ods-color-background-action-active)
   );
+
+  /* Header/Highlight Pills */
+  --osdk-color-background-info-pill: rgba(var(--ods-color-background-info));
+  --osdk-color-content-info-pill: rgba(var(--ods-content-inverse-main));
 }
 
 /* stylelint-enable function-parentheses-space-inside */

--- a/src/components/Theme/tokens.scss
+++ b/src/components/Theme/tokens.scss
@@ -40,9 +40,11 @@
   --font-weight-subtitle: 600;
   --font-weight-body: 500;
 
-  /* General UI element background color settings */
+  /* Modal (SDK Container) */
+  --osdk-color-background-surface-modal: rgba(
+    var(--ods-color-background-surface)
+  );
   --osdk-color-border-surface-modal: rgba(var(--ods-color-neutral-600));
-  --color-background: rgba(var(--ods-color-neutral-050));
 
   /* Warning/Info Message */
   --osdk-color-background-alert-info: rgba(var(--ods-color-primary-500));

--- a/src/components/Theme/tokens.scss
+++ b/src/components/Theme/tokens.scss
@@ -45,6 +45,9 @@
     var(--ods-color-background-surface)
   );
   --osdk-color-border-surface-modal: rgba(var(--ods-color-neutral-600));
+  --osdk-border-width-surface-modal: 1px;
+  --osdk-border-style-surface-modal: solid;
+  --osdk-border-radius-surface-modal: calc(8 * var(--unit));
 
   /* Warning/Info Message */
   --osdk-color-background-alert-info: rgba(var(--ods-color-primary-500));

--- a/src/components/Theme/tokens.scss
+++ b/src/components/Theme/tokens.scss
@@ -149,7 +149,7 @@
 
   /* Header/Highlight Pills */
   --osdk-color-background-info-pill: rgba(var(--ods-color-background-info));
-  --osdk-color-content-info-pill: rgba(var(--ods-content-inverse-main));
+  --osdk-color-content-info-pill: rgba(var(--ods-color-content-inverse-main));
 }
 
 /* stylelint-enable function-parentheses-space-inside */

--- a/src/components/crossDevice/CrossDeviceLink/style.scss
+++ b/src/components/crossDevice/CrossDeviceLink/style.scss
@@ -51,19 +51,19 @@ $parent-width: 432;
 
 .inputContainer {
   height: 100%;
-  border: 1px solid $color-input-border;
+  border: 1px solid rgba(var(--ods-color-border-input));
   border-top-left-radius: 4 * $unit;
   border-bottom-left-radius: 4 * $unit;
   border-right: 0;
-  background-color: $color-white;
+  background-color: rgba(var(--ods-color-neutral-white));
   float: left;
-  box-shadow: 0 -0.1 * $unit 0 * $unit 0 * $unit $color-input-border;
+  box-shadow: 0 -0.1 * $unit 0 * $unit 0 * $unit rgba(var(--ods-color-border-input));
 }
 
 .fieldError {
   border: 1px solid rgba(var(--ods-color-content-negative));
   border-right: 0;
-  box-shadow: 0 -0.1 * $unit 0 * $unit 0 * $unit var(--ods-color-content-negative);
+  box-shadow: 0 -0.1 * $unit 0 * $unit 0 * $unit rgba(var(--ods-color-content-negative));
 }
 
 .numberError {

--- a/src/demo/custom-ui-config.json
+++ b/src/demo/custom-ui-config.json
@@ -1,5 +1,6 @@
 {
-  "colorContentButtonPrimaryText": "#333",
+  "colorBorderSurfaceModal": "rgb(3 3 3)",
+  "colorContentButtonPrimaryText": "#000",
   "colorBackgroundButtonPrimary": "#ffb997",
   "colorBorderButtonPrimary": "#b23a48",
   "colorBackgroundButtonPrimaryHover": "#f67e7d",

--- a/src/demo/custom-ui-config.json
+++ b/src/demo/custom-ui-config.json
@@ -1,5 +1,8 @@
 {
-  "colorBorderSurfaceModal": "rgb(3 3 3)",
+  "colorBackgroundSurfaceModal": "#fafafa",
+  "colorBorderSurfaceModal": "#b23a48",
+  "borderWidthSurfaceModal": "6px",
+  "borderStyleSurfaceModal": "groove",
   "colorContentButtonPrimaryText": "#000",
   "colorBackgroundButtonPrimary": "#ffb997",
   "colorBorderButtonPrimary": "#b23a48",

--- a/src/demo/custom-ui-config.json
+++ b/src/demo/custom-ui-config.json
@@ -18,5 +18,7 @@
   "colorBorderLinkUnderline": "#b23a48",
   "colorContentLinkTextHover": "#5c374c",
   "colorBackgroundLinkHover": "rgb(255 238 170 / 92%)",
-  "colorBackgroundLinkActive": "#b23a48"
+  "colorBackgroundLinkActive": "#b23a48",
+  "colorBackgroundInfoPill": "#ffb997",
+  "colorContentInfoPill": "#333"
 }

--- a/src/types/ui-customisation-options.ts
+++ b/src/types/ui-customisation-options.ts
@@ -1,4 +1,8 @@
 export type UICustomizationOptions = {
+  // Modal (SDK Container)
+  colorBackgroundSurfaceModal?: string
+  colorBorderSurfaceModal?: string
+
   // Primary Button
   colorContentButtonPrimaryText?: string
   colorBackgroundButtonPrimary?: string

--- a/src/types/ui-customisation-options.ts
+++ b/src/types/ui-customisation-options.ts
@@ -45,4 +45,8 @@ export type UICustomizationOptions = {
   colorBackgroundAlertError?: string
   colorBackgroundAlertErrorLinkHover?: string
   colorBackgroundAlertErrorLinkActive?: string
+
+  // Header/Highlight Pills
+  colorBackgroundInfoPill?: string
+  colorContentInfoPill?: string
 }

--- a/src/types/ui-customisation-options.ts
+++ b/src/types/ui-customisation-options.ts
@@ -2,6 +2,8 @@ export type UICustomizationOptions = {
   // Modal (SDK Container)
   colorBackgroundSurfaceModal?: string
   colorBorderSurfaceModal?: string
+  borderWidthSurfaceModal?: string
+  borderStyleSurfaceModal?: string
 
   // Primary Button
   colorContentButtonPrimaryText?: string


### PR DESCRIPTION
# Task
We want to offer customers supported customisation options for the Web SDK so that they can customise 
- the background colour of the SDK modal container 
- the SDK modal, information container border style, colour
- information header pills
<img width="350" alt="Default Web SDK Cross Device Flow - Mobile Device Connected screen" src="https://user-images.githubusercontent.com/2497081/109629502-cb5ba580-7b3b-11eb-8d52-72c32a4baafd.png"/><img width="350" alt="Default Web SDK Camera Permission Recovery screen" src="https://user-images.githubusercontent.com/2497081/109633893-89812e00-7b40-11eb-8031-1012c9998ace.png">

<img width="350" alt="Customised Web SDK Cross Device Flow - Mobile Device Connected screen" src="https://user-images.githubusercontent.com/2497081/109640609-9d309280-7b48-11eb-95f0-a30fc75c1457.png"/><img width="350" alt="Customised Web SDK Camera Permission Recovery screen" src="https://user-images.githubusercontent.com/2497081/109640573-930e9400-7b48-11eb-954c-13d803402df7.png"/>


## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [x] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
