### PR TITLE
Fix/IE11 UI issues

### DIFF
--- a/src/components/CameraPermissions/Primer/style.scss
+++ b/src/components/CameraPermissions/Primer/style.scss
@@ -42,7 +42,7 @@
 }
 
 .graphic {
-  background-color: $color-transparent;
+  background-color: transparent;
   background-image: url('./assets/allow.svg');
   background-repeat: no-repeat;
   background-size: 100%;

--- a/src/components/Overlay/style.scss
+++ b/src/components/Overlay/style.scss
@@ -1,7 +1,7 @@
 @import '../Theme/constants';
 
 %_overlay {
-  border: 1px solid var(--color-primary); /* Doc Autocapture border colour */
+  border: 1px solid rgba(var(--ods-color-primary-500)); /* Doc Autocapture border colour */
   position: absolute;
   bottom: 50%;
   left: 50%;

--- a/src/components/ProofOfAddress/PoAIntro/style.scss
+++ b/src/components/ProofOfAddress/PoAIntro/style.scss
@@ -23,7 +23,7 @@
 
   &::before {
     content: '';
-    background-color: var(--color-primary);
+    background-color: rgba(var(--ods-color-primary-500));
     border-radius: 50%;
     display: inline-block;
     height: 6 * $unit;

--- a/src/components/Theme/constants.scss
+++ b/src/components/Theme/constants.scss
@@ -58,9 +58,9 @@ $navigation-padding-sides-sm-screen: $padding-xs;
 $color-white: rgb(var(--ods-color-neutral-white));
 $color-black: rgb(var(--ods-color-neutral-black));
 
-$color-icon-temporary: rgba(var(--ods-color-neutral-300));
-$color-divider: rgba(var(--ods-color-neutral-400));
-$color-icons-connector-line: rgba(var(--ods-color-neutral-800));
+$color-icon-temporary: rgb(var(--ods-color-neutral-300));
+$color-divider: rgb(var(--ods-color-neutral-400));
+$color-icons-connector-line: rgb(var(--ods-color-neutral-800));
 
 /* Transparent colors */
 $color-modal-overlay: rgba(0, 0, 0, 0.6);
@@ -78,8 +78,8 @@ $color-small-button-active: rgba(15, 37, 54, 0.85);
 $camera-recording-status-icon-color: #dc2a2a;
 
 /* Live Camera Capture screens' Back, Close icon button background is not customisable */
-$color-fullscreen-icon-button-hover: rgba(var(--ods-color-neutral-400));
-$color-fullscreen-icon-button-active: rgba(var(--ods-color-neutral-600));
+$color-fullscreen-icon-button-hover: rgb(var(--ods-color-neutral-400));
+$color-fullscreen-icon-button-active: rgb(var(--ods-color-neutral-600));
 
 /* Primary/Secondary Button width variables */
 $lg-btn-width-lg-screen: 272 * $unit-small;
@@ -106,7 +106,7 @@ $modal-animation-duration: 200ms;
 
 %overflow-drop-shadow {
   @media (--shorter-viewport) {
-    background-color: rgba(var(--ods-color-neutral-050));
+    background-color: rgb(var(--ods-color-neutral-050));
     bottom: 0;
     box-shadow: 0 -5px 10px -5px #7b7b7b;
     left: -1em;

--- a/src/components/Theme/constants.scss
+++ b/src/components/Theme/constants.scss
@@ -1,3 +1,5 @@
+/* UNITS */
+
 /**
  * We want our units to be based on `em`, so that our SDK can accommodate for
  * the user changing their browser font size.
@@ -26,6 +28,8 @@ $unit-x-small: (1/11) * 1em;
  */
 $unit-rrui: 1em;
 
+/* MARGINS & PADDINGS */
+
 $large-text-margin: 32 * $unit;
 $small-text-margin: 24 * $unit;
 $smaller-text-margin: 16 * $unit;
@@ -43,31 +47,27 @@ $navigation-padding-sides: $padding-lg;
 $navigation-padding-top-sm-screen: $padding-sm;
 $navigation-padding-sides-sm-screen: $padding-xs;
 
+/* COLORS */
+/*
+ *  NOTE: Use rgb() notation instead of rgba() when using Castor basic color tokens.
+ *        The CSS color values do not have an opacity value. Only RGB.
+ *        Color reverts to browser default on IE11 which flags color value as invalid when rgba() used.
+ */
+
 /* Solid colors */
-/*  Use rgb() notation instead of rgba() as these colours do not have an opacity value.
-    Colour reverts to browser default on IE11 which is correctly flagging value as invalid if rgba() used. */
 $color-white: rgb(var(--ods-color-neutral-white));
 $color-black: rgb(var(--ods-color-neutral-black));
 
 $color-icon-temporary: rgba(var(--ods-color-neutral-300));
 $color-divider: rgba(var(--ods-color-neutral-400));
 $color-icons-connector-line: rgba(var(--ods-color-neutral-800));
-$color-body-text: rgba(var(--ods-color-neutral-800));
-$color-title-text: rgba(var(--ods-color-neutral-800));
-$color-subtitle-text: $color-body-text;
 
 /* Transparent colors */
-$color-transparent: transparent;
-$color-help-container: rgba(var(--ods-color-neutral-600));
 $color-modal-overlay: rgba(0, 0, 0, 0.6);
 $color-camera-overlay: rgba(0, 0, 0, 0.7);
 $color-camera-error-overlay: #1c1f21;
 $color-navbar-gradient-one: rgba(28, 31, 33, 0);
 $color-navbar-gradient-two: rgba(28, 31, 33, 0.35);
-
-/* Error message button colors */
-$color-error-button-hover: #ffb9b9;
-$color-error-button-active: #fce5e5;
 
 /* Doc/Face capture preview "Enlarge image" button colors */
 $color-small-button: rgba(15, 37, 54, 0.85);

--- a/src/components/Theme/tokens.scss
+++ b/src/components/Theme/tokens.scss
@@ -80,9 +80,6 @@
     var(--ods-color-background-negative-active)
   );
 
-  /* TODO: not really required now, should do a full check after Phase 1 customisations implemented to be sure */
-  --color-primary: rgba(var(--ods-color-primary-500));
-
   /* Icon background circle color */
   --osdk-color-background-icon: rgba(var(--ods-color-background-surface-alt));
 

--- a/src/components/Theme/tokens.scss
+++ b/src/components/Theme/tokens.scss
@@ -11,8 +11,12 @@
  *  https://github.com/onfido/castor/blob/main/packages/core/src/theme/themes/day.scss
  *  Where it does not, the basic color token, e.g. --ods-color-primary-500, should be used instead.
  *
- * Colors in color palette are RGB values but some also adds alpha level (or opacity),
- * so all color related CSS variables must be wrapped with rgba(), e.g. rgba((var(--castor-color-token))).
+ * Colors in theme color palette are RGB values but some also add a alpha level (opacity),
+ * so all color related CSS variables must be wrapped with rgba(), e.g. rgba((var(--castor-color-theme-token))).
+ *
+ * If using Castor basic color tokens, use the rgb() notation instead of rgba() notation.
+ * The CSS color values do not have an opacity value. Only RGB.
+ * Color reverts to browser default on IE11 which flags color value as invalid when rgba() used.
  */
 
 /* stylelint-disable function-parentheses-space-inside */
@@ -49,13 +53,13 @@
   --osdk-color-background-surface-modal: rgba(
     var(--ods-color-background-surface)
   );
-  --osdk-color-border-surface-modal: rgba(var(--ods-color-neutral-600));
+  --osdk-color-border-surface-modal: rgb(var(--ods-color-neutral-600));
   --osdk-border-width-surface-modal: 1px;
   --osdk-border-style-surface-modal: solid;
   --osdk-border-radius-surface-modal: calc(8 * var(--unit));
 
   /* Warning/Info Message */
-  --osdk-color-background-alert-info: rgba(var(--ods-color-primary-500));
+  --osdk-color-background-alert-info: rgb(var(--ods-color-primary-500));
 
   /* Warning/Info Message - fallback link */
   --osdk-color-content-alert-info: rgba(var(--ods-color-content-inverse-main));
@@ -132,15 +136,13 @@
   );
 
   /* Back, Close (modal) icon button colors */
-  --osdk-color-background-button-icon-hover: rgba(var(--ods-color-neutral-400));
-  --osdk-color-background-button-icon-active: rgba(
-    var(--ods-color-neutral-600)
-  );
+  --osdk-color-background-button-icon-hover: rgb(var(--ods-color-neutral-400));
+  --osdk-color-background-button-icon-active: rgb(var(--ods-color-neutral-600));
 
   /* Selfie Camera button colors */
-  --color-background-button-camera: rgba(var(--ods-color-neutral-white));
-  --color-background-button-camera-hover: rgba(var(--ods-color-primary-400));
-  --color-background-button-camera-active: rgba(var(--ods-color-primary-600));
+  --color-background-button-camera: rgb(var(--ods-color-neutral-white));
+  --color-background-button-camera-hover: rgb(var(--ods-color-primary-400));
+  --color-background-button-camera-active: rgb(var(--ods-color-primary-600));
 
   /* Link colors */
   --osdk-color-border-link-underline: rgba(var(--ods-color-border-action));

--- a/src/components/Theme/tokens.scss
+++ b/src/components/Theme/tokens.scss
@@ -116,7 +116,7 @@
   --osdk-color-border-button-secondary: rgba(var(--ods-color-border-action));
 
   /* Button group customisations */
-  --osdk-border-radius-button: var(--ods-border-radius-medium);
+  --osdk-border-radius-button: calc(4 * var(--unit));
   --osdk-button-group-stacked: false;
 
   /* Document Type Selectors option button colors */

--- a/src/components/Theme/tokens.scss
+++ b/src/components/Theme/tokens.scss
@@ -82,8 +82,6 @@
 
   /* TODO: not really required now, should do a full check after Phase 1 customisations implemented to be sure */
   --color-primary: rgba(var(--ods-color-primary-500));
-  --color-primary-hover: rgba(var(--ods-color-primary-400));
-  --color-primary-active: rgba(var(--ods-color-primary-600));
 
   /* Icon background circle color */
   --osdk-color-background-icon: rgba(var(--ods-color-background-surface-alt));


### PR DESCRIPTION
# Problem
There are some IE11 UI issues following the web customisation work now that we are using Castor's theme, basic color tokens (see screenshots & console style errors):

- Border radius of SDK modal container is not applied
- Document Type Selector background should be white by default but is light grey
- On Cross Device Intro, Selfie Intro screens the line connecting the step icons is not displayed
- Selfie Intro screen 2nd step's icon circles overflow area are visible
- The glare/blur/cutoff warning popup on Confirm screen’s default background colour is not applied

<img width="350" src="https://user-images.githubusercontent.com/2497081/110838842-d8466a80-829a-11eb-93af-03291504e1ad.png" alt="Screenshot of Document Type Selector screen on IE11" /><img width="350" src="https://user-images.githubusercontent.com/2497081/110838845-d9779780-829a-11eb-8d07-fe96aee91b59.png" alt="Screenshot of Cross Device Intro screen on IE11" /><img width="350" src="https://user-images.githubusercontent.com/2497081/110838847-d9779780-829a-11eb-80da-4d28bc6dcf97.png" alt="Screenshot of Document Capture Confirm screen with a Warning message popup on IE11" /><img width="350" src="https://user-images.githubusercontent.com/2497081/110838850-da102e00-829a-11eb-9fe7-70d7501d2c3b.png" alt="Screenshot of Selfie Intro screen on IE11" />

![Screenshot 2021-03-11 at 17 42 29](https://user-images.githubusercontent.com/2497081/110839870-f496d700-829b-11eb-838f-8cbcf5ff3e01.png)


# Solution
- Use SDK's own CSS variable unit calculation syntax for `border-radius` unit value as Castor's generated value also has nested calc() which [IE11 has a variety of known issues](https://caniuse.com/?search=calc())
- Use `rgb()` notation wherever Castor's basic colour tokens are being used as IE11 flags these values as invalid without an alpha value if using `rgba()` notation

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [n/a] Has the CHANGELOG been updated? - dev regression on IE11
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
