### PR TITLE
Use ScreenLayout for SelfieIntro

### DIFF
--- a/src/components/Photo/SelfieIntro.js
+++ b/src/components/Photo/SelfieIntro.js
@@ -1,6 +1,7 @@
 import { h } from 'preact'
 import { Button } from '@onfido/castor-react'
 import classNames from 'classnames'
+import ScreenLayout from '../Theme/ScreenLayout'
 import PageTitle from '../PageTitle'
 import { localised } from '../../locales'
 import { trackComponent } from '../../Tracker'
@@ -32,6 +33,17 @@ const InstructionsPure = ({ listScreenReaderText, instructions }) => (
   </div>
 )
 
+const Actions = ({ nextStep, translate }) => (
+  <Button
+    variant="primary"
+    className={classNames(theme['button-centered'], theme['button-lg'])}
+    onClick={nextStep}
+    data-onfido-qa="selfie-continue-btn"
+  >
+    {translate('selfie_intro.button_primary')}
+  </Button>
+)
+
 const Intro = ({ translate, nextStep }) => {
   const instructions = [
     {
@@ -43,28 +55,21 @@ const Intro = ({ translate, nextStep }) => {
       text: translate('selfie_intro.list_item_no_glasses'),
     },
   ]
+  const actions = <Actions {...{ nextStep, translate }} />
 
   return (
-    <div className={theme.fullHeightContainer}>
-      <PageTitle
-        title={translate('selfie_intro.title')}
-        subTitle={translate('selfie_intro.subtitle')}
-      />
-      <InstructionsPure
-        listScreenReaderText={translate('selfie_intro.list_accessibility')}
-        instructions={instructions}
-      />
-      <div className={classNames(theme.contentMargin, style.buttonContainer)}>
-        <Button
-          variant="primary"
-          className={classNames(theme['button-centered'], theme['button-lg'])}
-          onClick={nextStep}
-          data-onfido-qa="selfie-continue-btn"
-        >
-          {translate('selfie_intro.button_primary')}
-        </Button>
+    <ScreenLayout actions={actions}>
+      <div className={theme.fullHeightContainer}>
+        <PageTitle
+          title={translate('selfie_intro.title')}
+          subTitle={translate('selfie_intro.subtitle')}
+        />
+        <InstructionsPure
+          listScreenReaderText={translate('selfie_intro.list_accessibility')}
+          instructions={instructions}
+        />
       </div>
-    </div>
+    </ScreenLayout>
   )
 }
 


### PR DESCRIPTION
# Problem
The Selfie Intro screen title and subtitle are partially hidden. See screenshot
<img width="634" alt="Screenshot 2021-03-24 at 14 58 28" src="https://user-images.githubusercontent.com/7127427/112332139-67974900-8cb1-11eb-8dd3-73f143817dd6.png">

# Solution
Use ScreenLayout for selfie intro screen

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
