### PR TITLE
iOS Safari - Cross Device Uploads Success screen icon missing

### DIFF
--- a/src/components/crossDevice/ClientSuccess/style.scss
+++ b/src/components/crossDevice/ClientSuccess/style.scss
@@ -4,9 +4,9 @@
   @extend %icon-circle-background;
   height: 144 * $unit;
   width: 144 * $unit;
+  margin: 50 * $unit auto;
   background-size: contain;
   background-image: url('./assets/return-to-computer-large.svg');
-  margin: 50 * $unit auto;
 }
 
 .text {

--- a/src/components/crossDevice/ClientSuccess/style.scss
+++ b/src/components/crossDevice/ClientSuccess/style.scss
@@ -4,6 +4,11 @@
   @extend %icon-circle-background;
   height: 144 * $unit;
   width: 144 * $unit;
+  /*
+   * NOTE: iOS Safari has a strange bug where SVG background images are not displayed on some iOS devices
+   *       if margin, background image properties are not declared before the background-image
+   *       ref: http://geoffmuskett.com/strange-bug-on-ios-svg-background-images-no-showing/
+   */
   margin: 50 * $unit auto;
   background-size: contain;
   background-image: url('./assets/return-to-computer-large.svg');


### PR DESCRIPTION
# Problem
On some iOS 14 devices, the icon on the Cross Device - Uploads Successful screen is not visible. This is confirmed to happen on iPhone XS Max, iPhone 12 Mini but not iPhone SE 2nd Gen. 

![image](https://user-images.githubusercontent.com/2497081/112332093-5cdcb400-8cb1-11eb-836d-413bec773751.png)

# Solution
Apparently the order of the properties matters to Safari. 
Solution was based on [solution for an old, strange bug on iOS](http://geoffmuskett.com/strange-bug-on-ios-svg-background-images-no-showing/) for the same problem (background image SVG not showing)

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
