### PR TITLE
All documents should have filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ## [next-version]
 
+### Added
+
+- Internal: Added default filename for all document uploads if filename is not present.
+
 ## [6.7.1] - 2021-03-26
 
 ### Fixed

--- a/src/components/Confirm/Confirm.js
+++ b/src/components/Confirm/Confirm.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact'
 import { trackException, sendEvent } from '../../Tracker'
-import { isOfMimeType } from '~utils/blob'
+import { isOfMimeType, mimeType } from '~utils/blob'
 import {
   uploadDocument,
   uploadLivePhoto,
@@ -220,10 +220,18 @@ class Confirm extends Component {
           : {}),
       }
       const issuingCountry = this.getIssuingCountry()
-      // API does not support 'residence_permit' type but does accept 'unknown'
-      // See https://documentation.onfido.com/#document-types
+
+      // Make sure documents always have a filename
+      // A `filename` might have been defined when the capture is created
+      // if filename is not present, check if `blob` has a property `name` (only available for File types, which come from the html5 file picker)
+      // alternatively use default filename
+      //
+      const blobName =
+        filename || blob.name || `document_capture.${mimeType(blob)}`
       const data = {
-        file: { blob, filename },
+        file: { blob, filename: blobName },
+        // API does not support 'residence_permit' type but does accept 'unknown'
+        // See https://documentation.onfido.com/#document-types
         type: type === 'residence_permit' ? 'unknown' : type,
         side,
         validations,

--- a/src/components/Confirm/__tests__/Confirm.test.tsx
+++ b/src/components/Confirm/__tests__/Confirm.test.tsx
@@ -31,6 +31,7 @@ const defaultProps = {
       switchSeconds: 0,
     },
     snapshot: new Blob(),
+    blob: new Blob(),
   },
   isDecoupledFromAPI: true,
   resetSdkFocus: jest.fn(),


### PR DESCRIPTION
# Problem
When a filename is not defined in the FormData upload, it will default to `blob`

# Solution
Make sure all files/blobs include a filename

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
