### PR TITLE
Get latest version of language translations copy from Lokalise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Fixed
 
+- Public: Get latest copy from Lokalise with various grammar, punctuation fixes. Also reverts French, Spanish translations for some Proof of Address copy in these languages' locale files (Proof of Address is only supported for English)
+
 ## [6.7.1] - 2021-03-26
 
 ### Fixed

--- a/src/locales/de_DE/de_DE.json
+++ b/src/locales/de_DE/de_DE.json
@@ -4,7 +4,7 @@
             "country_not_found": "Land nicht gefunden"
         },
         "alert": {
-            "another_doc": "Dokumente aus diesem Land werden derzeit nicht unterstützt. <fallback>Versuchen Sie es mit einem anderen Dokumententyp<\/fallback>"
+            "another_doc": "Dokumente aus diesem Land werden derzeit nicht unterstützt. <fallback>Versuchen Sie es mit einem anderen Dokumententyp<\/fallback>."
         },
         "button_primary": "Dokument einreichen",
         "search": {
@@ -21,29 +21,29 @@
         "list_item_doc_one": "Dokument hochgeladen",
         "list_item_selfie": "Selfie hochgeladen",
         "list_item_video": "Video hochgeladen",
-        "subtitle": "Wir sind jetzt bereit, Ihre Identität zu überprüfen.",
-        "title": "Großartig, das ist alles, was wir brauchen."
+        "subtitle": "Wir sind jetzt bereit, Ihre Identität zu überprüfen",
+        "title": "Großartig, das ist alles, was wir brauchen"
     },
     "cross_device_error_desktop": {
-        "subtitle": "Der Link funktioniert nur auf mobilen Geräten.",
-        "title": "Etwas ist schiefgelaufen."
+        "subtitle": "Der Link funktioniert nur auf mobilen Geräten",
+        "title": "Etwas ist schiefgelaufen"
     },
     "cross_device_error_restart": {
-        "subtitle": "Sie müssen Ihre Verifizierung auf Ihrem Computer neu starten.",
-        "title": "Etwas ist schiefgelaufen."
+        "subtitle": "Sie müssen Ihre Verifizierung auf Ihrem Computer neu starten",
+        "title": "Etwas ist schiefgelaufen"
     },
     "cross_device_intro": {
         "button_primary": "Sicherheitslink erhalten",
         "list_accessibility": "Erforderliche Schritte zur weiteren Verifizierung auf Ihrem Mobiltelefon",
-        "list_item_finish": "Überprüfen Sie alle Eingaben und Daten, um die Einreichung abzuschließen.",
-        "list_item_open_link": "Öffnen Sie den Link und führen Sie die Aktionen aus.",
-        "list_item_send_phone": "Senden Sie einen Sicherheitslink an Ihr Mobiltelefon.",
-        "subtitle": "So geht's:",
-        "title": "Fahren Sie mit Ihrem Mobiltelefon fort."
+        "list_item_finish": "Überprüfen Sie alle Eingaben und Daten, um die Einreichung abzuschließen",
+        "list_item_open_link": "Öffnen Sie den Link und führen Sie die Aktionen aus",
+        "list_item_send_phone": "Senden Sie einen Sicherheitslink an Ihr Mobiltelefon",
+        "subtitle": "So geht’s:",
+        "title": "Fahren Sie mit Ihrem Mobiltelefon fort"
     },
     "cross_device_return": {
-        "body": "Die Aktualisierung Ihres Computers kann einige Sekunden dauern.",
-        "subtitle": "Sie können nun zu Ihrem Computer zurückkehren, um fortzufahren.",
+        "body": "Die Aktualisierung Ihres Computers kann einige Sekunden dauern",
+        "subtitle": "Sie können nun zu Ihrem Computer zurückkehren, um fortzufahren",
         "title": "Uploads erfolgreich!"
     },
     "doc_confirmation": {
@@ -54,7 +54,7 @@
             "crop_title": "Abgeschnittenes Bild erkannt",
             "glare_detail": "Versuchen Sie, sich von direktem Licht zu entfernen",
             "glare_title": "Spiegelung erkannt",
-            "no_doc_detail": "Stellen Sie sicher, dass das gesamte Dokument auf dem Foto zu sehen ist.",
+            "no_doc_detail": "Stellen Sie sicher, dass das gesamte Dokument auf dem Foto zu sehen ist",
             "no_doc_title": "Kein Dokument erkannt."
         },
         "body_bank_statement": "Make sure details are clear to read, with no blur or glare",
@@ -84,7 +84,7 @@
         "button_bill_detail": "Gas, electricity, water, landline, or broadband",
         "button_government_letter": "Government Letter",
         "button_government_letter_detail": "Any government issued letter eg. Benefits entitlement, Voting letters, Tax letters, etc",
-        "button_id": "Personalausweis",
+        "button_id": "Nationaler Personalausweis",
         "button_id_detail": "Vorder- und Rückseite",
         "button_license": "Führerschein",
         "button_license_detail": "Vorder- und Rückseite",
@@ -104,7 +104,7 @@
     "doc_submit": {
         "button_link_upload": "oder Foto hochladen – keine Scans oder Kopien",
         "button_primary": "Weiter am Mobiltelefon",
-        "subtitle": "Machen Sie ein Foto mit Ihrem Mobiltelefon.",
+        "subtitle": "Machen Sie ein Foto mit Ihrem Mobiltelefon",
         "title_bank_statement": "Submit statement",
         "title_benefits_letter": "Submit letter",
         "title_bill": "Submit bill",
@@ -119,8 +119,8 @@
         "title_tax_letter": "Submit letter"
     },
     "error_unsupported_browser": {
-        "subtitle_android": "Starten Sie den Prozess auf der neuesten Version von Google Chrome neu.",
-        "subtitle_ios": "Starten Sie den Prozess mit der neuesten Version von Safari neu.",
+        "subtitle_android": "Starten Sie den Prozess auf der neuesten Version von Google Chrome neu",
+        "subtitle_ios": "Starten Sie den Prozess mit der neuesten Version von Safari neu",
         "title_android": "Nicht unterstützter Browser",
         "title_ios": "Nicht unterstützter Browser"
     },
@@ -133,7 +133,7 @@
         "close": "Schließen",
         "errors": {
             "interrupted_flow_error": {
-                "instruction": "Starten Sie den Prozess auf einem anderen Gerät neu.",
+                "instruction": "Starten Sie den Prozess auf einem anderen Gerät neu",
                 "message": "Kamera nicht erkannt"
             },
             "invalid_size": {
@@ -141,48 +141,48 @@
                 "message": "Dateigröße überschritten."
             },
             "invalid_type": {
-                "instruction": "Versuchen Sie einen anderen Dateityp zu verwenden.",
-                "message": "Datei nicht hochgeladen."
+                "instruction": "Versuchen Sie einen anderen Dateityp zu verwenden",
+                "message": "Datei nicht hochgeladen"
             },
             "lazy_loading": {
-                "message": "Beim Laden der Komponente ist ein Fehler aufgetreten."
+                "message": "Beim Laden der Komponente ist ein Fehler aufgetreten"
             },
             "multiple_faces": {
-                "instruction": "Nur Ihr Gesicht kann im Selfie zu sehen sein.",
+                "instruction": "Nur Ihr Gesicht kann im Selfie zu sehen sein",
                 "message": "Mehrere Gesichter gefunden"
             },
             "no_face": {
-                "instruction": "Ihr Gesicht muss im Selfie zu sehen sein.",
+                "instruction": "Ihr Gesicht muss im Selfie zu sehen sein",
                 "message": "Kein Gesicht gefunden"
             },
             "request_error": {
-                "instruction": "Bitte versuchen Sie es erneut.",
+                "instruction": "Bitte versuchen Sie es erneut",
                 "message": "Verbindung unterbrochen"
             },
             "sms_failed": {
-                "instruction": "Kopieren Sie den Link auf Ihr Mobiltelefon.",
-                "message": "Etwas ist schiefgelaufen."
+                "instruction": "Kopieren Sie den Link auf Ihr Mobiltelefon",
+                "message": "Etwas ist schiefgelaufen"
             },
             "sms_overuse": {
-                "instruction": "Kopieren Sie den Link auf Ihr Mobiltelefon.",
+                "instruction": "Kopieren Sie den Link auf Ihr Mobiltelefon",
                 "message": "Zu viele fehlgeschlagene Versuche"
             },
             "unsupported_file": {
-                "instruction": "Versuchen Sie es mit einer JPG- oder PNG-Datei.",
-                "message": "Dateityp nicht unterstützt."
+                "instruction": "Versuchen Sie es mit einer JPG- oder PNG-Datei",
+                "message": "Dateityp nicht unterstützt"
             }
         },
-        "lazy_load_placeholder": "Wird geladen …",
+        "lazy_load_placeholder": "Wird geladen…",
         "loading": "Wird geladen"
     },
     "get_link": {
-        "alert_wrong_number": "Überprüfen Sie, ob Ihre Nummer korrekt ist.",
+        "alert_wrong_number": "Überprüfen Sie, ob Ihre Nummer korrekt ist",
         "button_copied": "Kopiert",
         "button_copy": "Kopieren",
         "button_submit": "Link senden",
         "info_qr_how": "So scannen Sie einen QR-Code",
-        "info_qr_how_list_item_camera": "Richten Sie die Kamera Ihres Telefons auf den QR-Code.",
-        "info_qr_how_list_item_download": "Wenn es nicht funktioniert, laden Sie einen QR-Code-Scanner von Google Play oder aus dem App Store herunter.",
+        "info_qr_how_list_item_camera": "Richten Sie die Kamera Ihres Telefons auf den QR-Code",
+        "info_qr_how_list_item_download": "Wenn es nicht funktioniert, laden Sie einen QR-Code-Scanner von Google Play oder aus dem App Store herunter",
         "link_divider": "oder",
         "link_qr": "QR-Code scannen",
         "link_sms": "Link per SMS erhalten",
@@ -190,11 +190,11 @@
         "loader_sending": "Senden",
         "number_field_input_placeholder": "Mobiltelefonnummer eingeben",
         "number_field_label": "Geben Sie Ihre Mobiltelefonnummer ein:",
-        "subtitle_qr": "Scannen Sie den QR-Code mit Ihrem Mobiltelefon.",
-        "subtitle_sms": "Senden Sie diesen einmaligen Link an Ihr Mobiltelefon.",
-        "subtitle_url": "Öffnen Sie den Link auf Ihrem Mobiltelefon.",
+        "subtitle_qr": "Scannen Sie den QR-Code mit Ihrem Mobiltelefon",
+        "subtitle_sms": "Senden Sie diesen einmaligen Link an Ihr Mobiltelefon",
+        "subtitle_url": "Öffnen Sie den Link auf Ihrem Mobiltelefon",
         "title": "Holen Sie sich Ihren Sicherheitslink",
-        "url_field_label": "Kopieren Sie den Link in Ihren mobilen Browser."
+        "url_field_label": "Kopieren Sie den Link in Ihren mobilen Browser"
     },
     "linked_computer": {
         "button_primary": "Fortfahren",
@@ -236,15 +236,15 @@
         "button_primary": "Aktualisieren",
         "info": "Wiederherstellen",
         "list_header_cam": "Befolgen Sie diese Schritte, um den Kamerazugriff wiederherzustellen:",
-        "list_item_action_cam": "Aktualisieren Sie diese Seite, um den Identitätsüberprüfungsprozess neu zu starten.",
-        "list_item_how_to_cam": "Gewähren Sie den Zugriff auf Ihre Kamera über Ihre Browsereinstellungen.",
+        "list_item_action_cam": "Aktualisieren Sie diese Seite, um den Identitätsüberprüfungsprozess neu zu starten",
+        "list_item_how_to_cam": "Gewähren Sie den Zugriff auf Ihre Kamera über Ihre Browsereinstellungen",
         "subtitle_cam": "Kamerazugriff wiederherstellen, um Gesichtsverifizierung fortzusetzen",
-        "title_cam": "Kamerazugriff wird verweigert."
+        "title_cam": "Kamerazugriff wird verweigert"
     },
     "permission": {
-        "body_cam": "Wir können Sie nicht verifizieren, ohne Ihre Kamera zu benutzen.",
+        "body_cam": "Wir können Sie nicht verifizieren, ohne Ihre Kamera zu benutzen",
         "button_primary_cam": "Kamera aktivieren",
-        "subtitle_cam": "Wenn Sie dazu aufgefordert werden, müssen Sie den Kamerazugriff aktivieren, um fortzufahren.",
+        "subtitle_cam": "Wenn Sie dazu aufgefordert werden, müssen Sie den Kamerazugriff aktivieren, um fortzufahren",
         "title_cam": "Zugriff auf Kamera erlauben"
     },
     "photo_upload": {
@@ -283,24 +283,24 @@
         "list_matches_signup": "<strong>Matches<\/strong> the address you used on signup",
         "list_most_recent": "Is your most <strong>recent<\/strong> document",
         "list_shows_address": "Shows your <strong>current<\/strong> address",
-        "subtitle": "You'll need a document that:",
-        "title": "Let's verify your %{country} address"
+        "subtitle": "You’ll need a document that:",
+        "title": "Let’s verify your %{country} address"
     },
     "selfie_capture": {
         "alert": {
             "camera_inactive": {
                 "detail": "Überprüfen Sie, ob die Kamera verbunden und funktionsfähig ist. Sie können <fallback>die Überprüfung auch auf Ihrem Telefon fortsetzen.<\/fallback>",
-                "detail_no_fallback": "Stellen Sie sicher, dass Ihr Gerät über eine funktionierende Kamera verfügt.",
+                "detail_no_fallback": "Stellen Sie sicher, dass Ihr Gerät über eine funktionierende Kamera verfügt",
                 "title": "Kamera funktioniert nicht?"
             },
             "camera_not_working": {
                 "detail": "Die Verbindung kann unterbrochen werden. <fallback>Versuchen Sie stattdessen, Ihr Telefon zu benutzen<\/fallback>.",
-                "detail_no_fallback": "Stellen Sie sicher, dass die Kamera Ihres Geräts funktioniert.",
-                "title": "Kamera funktioniert nicht."
+                "detail_no_fallback": "Stellen Sie sicher, dass die Kamera Ihres Geräts funktioniert",
+                "title": "Kamera funktioniert nicht"
             },
             "timeout": {
-                "detail": "Denken Sie daran, Stopp zu drücken, wenn Sie fertig sind. <fallback>Video-Aktionen wiederholen<\/fallback>",
-                "title": "Sieht aus, als hätten Sie zu lange gebraucht."
+                "detail": "Denken Sie daran, Stopp zu drücken, wenn Sie fertig sind. <fallback>Video-Aktionen wiederholen<\/fallback>.",
+                "title": "Sieht aus, als hätten Sie zu lange gebraucht"
             }
         },
         "button_accessibility": "Ein Foto machen",
@@ -315,38 +315,35 @@
     "selfie_intro": {
         "button_primary": "Fortfahren",
         "list_accessibility": "Tipps für ein gutes Selfie",
-        "list_item_face_forward": "Richten Sie Ihr Gesicht nach vorne und stellen Sie sicher, dass Ihre Augen deutlich sichtbar sind.",
-        "list_item_no_glasses": "Nehmen Sie Ihre Brille ab, falls erforderlich.",
-        "subtitle": "Wir werden es mit Ihrem Dokument vergleichen.",
+        "list_item_face_forward": "Richten Sie Ihr Gesicht nach vorne und stellen Sie sicher, dass Ihre Augen deutlich sichtbar sind",
+        "list_item_no_glasses": "Nehmen Sie Ihre Brille ab, falls erforderlich",
+        "subtitle": "Wir werden es mit Ihrem Dokument vergleichen",
         "title": "Ein Selfie aufnehmen"
     },
     "sms_sent": {
         "info": "Tipps",
-        "info_link_expire": "Ihr Link läuft in einer Stunde ab.",
-        "info_link_window": "Lassen Sie dieses Fenster geöffnet, während Sie Ihr Mobiltelefon bedienen.",
+        "info_link_expire": "Ihr Link läuft in einer Stunde ab",
+        "info_link_window": "Lassen Sie dieses Fenster geöffnet, während Sie Ihr Mobiltelefon bedienen",
         "link": "Link erneut senden",
-        "subtitle": "Wir haben einen sicheren Link an %{number} gesendet.",
-        "subtitle_minutes": "Dieser Vorgang kann einige Minuten dauern.",
-        "title": "Überprüfen Sie Ihr Mobiltelefon."
+        "subtitle": "Wir haben einen sicheren Link an %{number} gesendet",
+        "subtitle_minutes": "Dieser Vorgang kann einige Minuten dauern",
+        "title": "Überprüfen Sie Ihr Mobiltelefon"
     },
     "switch_phone": {
         "info": "Tipps",
-        "info_link_expire": "Ihr mobiler Link läuft in einer Stunde ab.",
-        "info_link_refresh": "Diese Seite nicht aktualisieren.",
-        "info_link_window": "Lassen Sie dieses Fenster geöffnet, während Sie Ihr Mobiltelefon bedienen.",
+        "info_link_expire": "Ihr mobiler Link läuft in einer Stunde ab",
+        "info_link_refresh": "Diese Seite nicht aktualisieren",
+        "info_link_window": "Lassen Sie dieses Fenster geöffnet, während Sie Ihr Mobiltelefon bedienen",
         "link": "Abbrechen",
-        "subtitle": "Wenn Sie fertig sind, gelangen Sie zum nächsten Schritt.",
+        "subtitle": "Wenn Sie fertig sind, gelangen Sie zum nächsten Schritt",
         "title": "Mit Ihrem Mobiltelefon verbunden"
     },
     "upload_guide": {
         "button_primary": "Foto hochladen",
         "image_detail_blur_alt": "Beispiel eines verschwommenen Dokuments",
         "image_detail_blur_label": "Alle Details müssen klar sein - nichts verschwommen",
-        "image_detail_cutoff_alt": "Beispiel eines abgeschnittenen Dokuments",
         "image_detail_cutoff_label": "Alle Details anzeigen - einschließlich der unteren 2 Zeilen",
-        "image_detail_glare_alt": "Beispiel eines Dokuments mit Blendung",
         "image_detail_glare_label": "Entfernen Sie sich von direktem Licht - keine Blendung",
-        "image_detail_good_alt": "Beispiel für ein Dokument",
         "image_detail_good_label": "Das Foto sollte Ihr Dokument deutlich zeigen",
         "subtitle": "Scans und Fotokopien werden nicht akzeptiert",
         "title": "Fotoseite des Reisepasses hochladen"
@@ -363,18 +360,18 @@
     },
     "video_capture": {
         "body": "Positionieren Sie Ihr Gesicht im Oval",
-        "body_next": "Wenn Sie fertig sind, klicken Sie auf Weiter.",
-        "body_record": "Drücken Sie auf Aufnahme und folgen Sie den Anweisungen.",
-        "body_stop": "Wenn Sie fertig sind, drücken Sie Stopp.",
+        "body_next": "Wenn Sie fertig sind, klicken Sie auf Weiter",
+        "body_record": "Drücken Sie auf Aufnahme und folgen Sie den Anweisungen",
+        "body_stop": "Wenn Sie fertig sind, drücken Sie Stopp",
         "button_primary_next": "Weiter",
         "button_record_accessibility": "Aufnahme starten",
         "button_stop_accessibility": "Aufnahme stoppen",
         "frame_accessibility": "Ansicht von der Kamera",
         "header": {
-            "challenge_digit_instructions": "Sprechen Sie jede Ziffer laut aus.",
+            "challenge_digit_instructions": "Sprechen Sie jede Ziffer laut aus",
             "challenge_turn_left": "links",
             "challenge_turn_right": "rechts",
-            "challenge_turn_template": "Schauen Sie über Ihre %{side} Schulter."
+            "challenge_turn_template": "Schauen Sie über Ihre %{side} Schulter"
         },
         "status": "Aufnahme"
     },
@@ -385,9 +382,9 @@
     "video_intro": {
         "button_primary": "Fortfahren",
         "list_accessibility": "Aktionen zum Aufzeichnen eines Selfie-Videos",
-        "list_item_actions": "Wir bitten Sie, sich bei der Durchführung von <strong>zwei einfachen Handlungen<\/strong> zu filmen.",
-        "list_item_speak": "Eine Aktion wird sein, <strong>etwas laut auszusprechen<\/strong>.",
-        "title": "Lassen Sie uns sicherstellen, dass sich niemand für Sie ausgibt."
+        "list_item_actions": "Wir bitten Sie, sich bei der Durchführung von <strong>zwei einfachen Handlungen<\/strong> zu filmen",
+        "list_item_speak": "Eine Aktion wird sein, <strong>etwas laut auszusprechen<\/strong>",
+        "title": "Lassen Sie uns sicherstellen, dass sich niemand für Sie ausgibt"
     },
     "welcome": {
         "description_p_1": "Um ein Bankkonto zu eröffnen, müssen wir Ihre Identität überprüfen.",

--- a/src/locales/en_US/en_US.json
+++ b/src/locales/en_US/en_US.json
@@ -21,16 +21,16 @@
         "list_item_doc_one": "Document uploaded",
         "list_item_selfie": "Selfie uploaded",
         "list_item_video": "Video uploaded",
-        "subtitle": "We're now ready to verify your identity",
-        "title": "Great, that's everything we need"
+        "subtitle": "We’re now ready to verify your identity",
+        "title": "Great, that’s everything we need"
     },
     "cross_device_error_desktop": {
         "subtitle": "The link only works on mobile devices",
-        "title": "Something's gone wrong"
+        "title": "Something’s gone wrong"
     },
     "cross_device_error_restart": {
-        "subtitle": "You'll need to restart your verification on your computer",
-        "title": "Something's gone wrong"
+        "subtitle": "You’ll need to restart your verification on your computer",
+        "title": "Something’s gone wrong"
     },
     "cross_device_intro": {
         "button_primary": "Get secure link",
@@ -38,7 +38,7 @@
         "list_item_finish": "Check back here to finish the submission",
         "list_item_open_link": "Open the link and complete the tasks",
         "list_item_send_phone": "Send a secure link to your phone",
-        "subtitle": "Here's how to do it:",
+        "subtitle": "Here’s how to do it:",
         "title": "Continue on your phone"
     },
     "cross_device_return": {
@@ -86,7 +86,7 @@
         "button_government_letter_detail": "Any government issued letter eg. Benefits entitlement, Voting letters, Tax letters, etc",
         "button_id": "Identity card",
         "button_id_detail": "Front and back",
-        "button_license": "Driver's license",
+        "button_license": "Driver’s license",
         "button_license_detail": "Front and back",
         "button_passport": "Passport",
         "button_passport_detail": "Face photo page",
@@ -161,7 +161,7 @@
             },
             "sms_failed": {
                 "instruction": "Copy the link to your phone",
-                "message": "Something's gone wrong"
+                "message": "Something’s gone wrong"
             },
             "sms_overuse": {
                 "instruction": "Copy the link to your phone",
@@ -283,8 +283,8 @@
         "list_matches_signup": "<strong>Matches<\/strong> the address you used on signup",
         "list_most_recent": "Is your most <strong>recent<\/strong> document",
         "list_shows_address": "Shows your <strong>current<\/strong> address",
-        "subtitle": "You'll need a document that:",
-        "title": "Let's verify your %{country} address"
+        "subtitle": "You’ll need a document that:",
+        "title": "Let’s verify your %{country} address"
     },
     "selfie_capture": {
         "alert": {
@@ -295,11 +295,11 @@
             },
             "camera_not_working": {
                 "detail": "It may be disconnected. <fallback>Try using your phone instead<\/fallback>.",
-                "detail_no_fallback": "Make sure your device's camera works",
+                "detail_no_fallback": "Make sure your device’s camera works",
                 "title": "Camera not working"
             },
             "timeout": {
-                "detail": "Remember to press stop when you're done. <fallback>Redo video actions<\/fallback>",
+                "detail": "Remember to press stop when you’re done. <fallback>Redo video actions<\/fallback>",
                 "title": "Looks like you took too long"
             }
         },
@@ -317,7 +317,7 @@
         "list_accessibility": "Tips to take a good selfie",
         "list_item_face_forward": "Face forward and make sure your eyes are clearly visible",
         "list_item_no_glasses": "Remove your glasses, if necessary",
-        "subtitle": "We'll compare it with your document",
+        "subtitle": "We’ll compare it with your document",
         "title": "Take a selfie"
     },
     "sms_sent": {
@@ -325,28 +325,25 @@
         "info_link_expire": "Your link will expire in one hour",
         "info_link_window": "Keep this window open while using your mobile",
         "link": "Resend link",
-        "subtitle": "We've sent a secure link to %{number}",
+        "subtitle": "We’ve sent a secure link to %{number}",
         "subtitle_minutes": "It may take a few minutes to arrive",
         "title": "Check your mobile"
     },
     "switch_phone": {
         "info": "Tips",
         "info_link_expire": "Your mobile link will expire in one hour",
-        "info_link_refresh": "Don't refresh this page",
+        "info_link_refresh": "Don’t refresh this page",
         "info_link_window": "Keep this window open while using your mobile",
         "link": "Cancel",
-        "subtitle": "Once you've finished we'll take you to the next step",
+        "subtitle": "Once you’ve finished we’ll take you to the next step",
         "title": "Connected to your mobile"
     },
     "upload_guide": {
         "button_primary": "Upload photo",
         "image_detail_blur_alt": "Example of a blurry document",
         "image_detail_blur_label": "All details must be clear — nothing blurry",
-        "image_detail_cutoff_alt": "Example of a cut-off document",
         "image_detail_cutoff_label": "Show all details — including the bottom 2 lines",
-        "image_detail_glare_alt": "Example of a document with glare",
         "image_detail_glare_label": "Move away from direct light — no glare",
-        "image_detail_good_alt": "Document example",
         "image_detail_good_label": "The photo should clearly show your document",
         "subtitle": "Scans and photocopies are not accepted",
         "title": "Upload passport photo page"
@@ -363,9 +360,9 @@
     },
     "video_capture": {
         "body": "Position your face in the oval",
-        "body_next": "When you're done, press next",
+        "body_next": "When you’re done, press next",
         "body_record": "Press record and follow the instructions",
-        "body_stop": "When you're done, press stop",
+        "body_stop": "When you’re done, press stop",
         "button_primary_next": "Next",
         "button_record_accessibility": "Start recording",
         "button_stop_accessibility": "Stop recording",
@@ -385,9 +382,9 @@
     "video_intro": {
         "button_primary": "Continue",
         "list_accessibility": "Actions to record a selfie video",
-        "list_item_actions": "We'll ask you to film yourself performing <strong>2 simple actions<\/strong>",
+        "list_item_actions": "We’ll ask you to film yourself performing <strong>2 simple actions<\/strong>",
         "list_item_speak": "One will involve <strong>speaking out loud<\/strong>",
-        "title": "Let's make sure nobody's impersonating you"
+        "title": "Let’s make sure nobody’s impersonating you"
     },
     "welcome": {
         "description_p_1": "To open a bank account, we will need to verify your identity.",

--- a/src/locales/es_ES/es_ES.json
+++ b/src/locales/es_ES/es_ES.json
@@ -57,16 +57,16 @@
             "no_doc_detail": "Asegúrese de que todo el documento esté en la foto",
             "no_doc_title": "Documento no detectado"
         },
-        "body_bank_statement": "Asegúrese de que los datos de su tarjeta se puedan leer claramente, sin borrosidades ni brillo",
-        "body_benefits_letter": "Asegúrese de que los datos de su tarjeta se puedan leer claramente, sin borrosidades ni brillo",
-        "body_bill": "Asegúrese de que los datos de su tarjeta se puedan leer claramente, sin borrosidades ni brillo",
+        "body_bank_statement": "Make sure details are clear to read, with no blur or glare",
+        "body_benefits_letter": "Make sure details are clear to read, with no blur or glare",
+        "body_bill": "Make sure details are clear to read, with no blur or glare",
         "body_id": "Asegúrese de que los datos de su tarjeta se puedan leer claramente, sin borrosidades ni brillo",
         "body_image_medium": "Nos llevará más tiempo verificarle si no podemos leerla",
         "body_image_poor": "Para poder verificar que es usted, necesitamos una foto de mejor calidad",
         "body_license": "Asegúrese de que los datos de su licencia se puedan leer claramente, sin borrosidades ni brillo",
         "body_passport": "Asegúrese de que los datos de su pasaporte se puedan leer claramente, sin borrosidades ni brillo",
         "body_permit": "Asegúrese de que los detalles de su permiso sean legibles, la imagen sea nítida y que no tenga brillo",
-        "body_tax_letter": "Asegúrese de que los datos de su tarjeta se puedan leer claramente, sin borrosidades ni brillo",
+        "body_tax_letter": "Make sure details are clear to read, with no blur or glare",
         "button_close": "Cerrar",
         "button_primary_redo": "Reintentar",
         "button_primary_upload": "Confirmar",
@@ -84,7 +84,7 @@
         "button_bill_detail": "Gas, electricity, water, landline, or broadband",
         "button_government_letter": "Government Letter",
         "button_government_letter_detail": "Any government issued letter eg. Benefits entitlement, Voting letters, Tax letters, etc",
-        "button_id": "Tarjeta de identificación",
+        "button_id": "Documento Nacional de Identidad",
         "button_id_detail": "Frente y reverso",
         "button_license": "Licencia de conducir",
         "button_license_detail": "Frente y reverso",
@@ -229,7 +229,7 @@
         }
     },
     "outro": {
-        "body": "Gracias.",
+        "body": "Gracias",
         "title": "Verificación completa"
     },
     "permission_recovery": {
@@ -267,7 +267,7 @@
         "button_primary": "Continuar",
         "instructions": {
             "address": "Current address",
-            "full_name": "Nombre completo",
+            "full_name": "Full name",
             "issue_date": "Issue date or summary period",
             "label": "Make sure it clearly shows:",
             "logo": "Logo"
@@ -279,12 +279,12 @@
         "subtitle_tax_letter": "Must be issued in the <strong>last 12 months<\/strong>"
     },
     "poa_intro": {
-        "button_primary": "Iniciar la verificación",
+        "button_primary": "Start verification",
         "list_matches_signup": "<strong>Matches<\/strong> the address you used on signup",
         "list_most_recent": "Is your most <strong>recent<\/strong> document",
         "list_shows_address": "Shows your <strong>current<\/strong> address",
-        "subtitle": "You'll need a document that:",
-        "title": "Let's verify your %{country} address"
+        "subtitle": "You’ll need a document that:",
+        "title": "Let’s verify your %{country} address"
     },
     "selfie_capture": {
         "alert": {
@@ -303,7 +303,7 @@
                 "title": "Parece que ha demorado demasiado"
             }
         },
-        "button_accessibility": "Tome una foto",
+        "button_accessibility": "Tomar foto",
         "frame_accessibility": "Vista desde la cámara",
         "title": "Tome una selfie"
     },
@@ -341,12 +341,9 @@
     "upload_guide": {
         "button_primary": "Subir foto",
         "image_detail_blur_alt": "Ejemplo de un documento borroso",
-        "image_detail_blur_label": "Todos los detalles deben ser claros, nada borroso.",
-        "image_detail_cutoff_alt": "Ejemplo de un documento cortado",
+        "image_detail_blur_label": "Todos los detalles deben ser claros, nada borroso",
         "image_detail_cutoff_label": "Mostrar todos los detalles, incluidas las dos líneas inferiores",
-        "image_detail_glare_alt": "Ejemplo de un documento con reflejo",
         "image_detail_glare_label": "Aléjese de la luz directa, sin reflejos",
-        "image_detail_good_alt": "Ejemplo de documento",
         "image_detail_good_label": "La foto debe mostrar claramente su documento",
         "subtitle": "No se aceptan fotos escaneadas ni fotocopias",
         "title": "Subir la página del pasaporte con su foto"

--- a/src/locales/fr_FR/fr_FR.json
+++ b/src/locales/fr_FR/fr_FR.json
@@ -9,8 +9,8 @@
         "button_primary": "Envoyer le document",
         "search": {
             "accessibility": "Choisissez le pays",
-            "input_placeholder": "par exemple, les États-Unis",
-            "label": "Rechercher un pays"
+            "input_placeholder": "ex : États-Unis",
+            "label": "Chercher un pays"
         },
         "title": "Sélectionnez votre pays"
     },
@@ -22,7 +22,7 @@
         "list_item_selfie": "Selfie envoyé",
         "list_item_video": "Vidéo envoyée",
         "subtitle": "Nous sommes maintenant prêts à vérifier votre identité",
-        "title": "Merci, c'est tout ce dont nous avons besoin"
+        "title": "Merci, c’est tout ce dont nous avons besoin"
     },
     "cross_device_error_desktop": {
         "subtitle": "Le lien ne fonctionne que sur les appareils mobiles",
@@ -33,9 +33,9 @@
         "title": "Quelque chose ne va pas"
     },
     "cross_device_intro": {
-        "button_primary": "Obtenez un lien sécurisé",
+        "button_primary": "Obtenir un lien sécurisé",
         "list_accessibility": "Étapes requises pour continuer la vérification sur votre mobile",
-        "list_item_finish": "Revenez ici pour finaliser l'envoi",
+        "list_item_finish": "Revenez ici pour finaliser l’envoi",
         "list_item_open_link": "Ouvrez le lien et complétez les tâches",
         "list_item_send_phone": "Envoyez un lien sécurisé vers votre téléphone",
         "subtitle": "Voici comment faire :",
@@ -49,30 +49,30 @@
     "doc_confirmation": {
         "alert": {
             "blur_detail": "Assurez-vous que tout est bien net",
-            "blur_title": "L'image n'est pas claire",
-            "crop_detail": "Assurez-vous que l'intégralité du document est visible",
-            "crop_title": "Image coupée détectée",
+            "blur_title": "L’image est floue",
+            "crop_detail": "Assurez-vous que l’intégralité du document est visible",
+            "crop_title": "Image tronquée détectée",
             "glare_detail": "Éloignez-vous de la lumière directe",
             "glare_title": "Attention aux reflets",
             "no_doc_detail": "Assurez-vous que le document entier est sur la photo",
             "no_doc_title": "Aucun document détecté"
         },
-        "body_bank_statement": "Assurez-vous que les détails sont lisibles, sans flou ni reflets",
-        "body_benefits_letter": "Assurez-vous que les détails sont lisibles, sans flou ni reflets",
-        "body_bill": "Assurez-vous que les détails sont lisibles, sans flou ni reflets",
+        "body_bank_statement": "Make sure details are clear to read, with no blur or glare",
+        "body_benefits_letter": "Make sure details are clear to read, with no blur or glare",
+        "body_bill": "Make sure details are clear to read, with no blur or glare",
         "body_id": "Assurez-vous que les détails de votre carte sont lisibles, sans flou ni reflets",
         "body_image_medium": "Il faudra plus de temps pour vous vérifier si la lecture est impossible",
-        "body_image_poor": "Pour vous vérifier plus aisément, nous avons besoin d'une meilleure photo",
+        "body_image_poor": "Pour vous vérifier au mieux, nous avons besoin d’une meilleure photo",
         "body_license": "Assurez-vous que les détails de votre permis sont lisibles, sans flou ni reflets",
         "body_passport": "Assurez-vous que les détails de votre passeport sont lisibles, sans flou ni reflets",
         "body_permit": "Assurez-vous que votre carte est lisible, nette et sans reflets",
-        "body_tax_letter": "Assurez-vous que les détails sont lisibles, sans flou ni reflets",
+        "body_tax_letter": "Make sure details are clear to read, with no blur or glare",
         "button_close": "Fermer",
         "button_primary_redo": "Recommencer",
         "button_primary_upload": "Confirmer",
         "button_primary_upload_anyway": "Envoyer quand même",
         "button_secondary_redo": "Recommencer",
-        "button_zoom": "Agrandir l'image",
+        "button_zoom": "Agrandir l’image",
         "image_accessibility": "Photo de votre document",
         "title": "Vérifiez votre image"
     },
@@ -80,43 +80,43 @@
         "button_bank_statement": "Bank or building society statement",
         "button_benefits_letter": "Benefits Letter",
         "button_benefits_letter_detail": "Government authorised household benefits eg. Jobseeker allowance, Housing benefit, Tax credits",
-        "button_bill": "Facture",
-        "button_bill_detail": "Gaz, électricité, eau, ligne fixe ou Internet",
+        "button_bill": "Utility Bill",
+        "button_bill_detail": "Gas, electricity, water, landline, or broadband",
         "button_government_letter": "Government Letter",
         "button_government_letter_detail": "Any government issued letter eg. Benefits entitlement, Voting letters, Tax letters, etc",
-        "button_id": "Carte d'identité",
+        "button_id": "Carte nationale d’identité",
         "button_id_detail": "Recto et verso",
         "button_license": "Permis de conduire",
         "button_license_detail": "Recto et verso",
         "button_passport": "Passeport",
-        "button_passport_detail": "Page de votre passeport où figure votre photo",
+        "button_passport_detail": "Page de votre passeport contenant votre photo",
         "button_permit": "Carte de séjour",
         "button_permit_detail": "Recto et verso",
         "button_tax_letter": "Council Tax Letter",
-        "extra_estatements_ok": "relevés électroniques acceptés",
-        "extra_no_mobile": "Désolé, pas de factures de mobile",
+        "extra_estatements_ok": "e-statements accepted",
+        "extra_no_mobile": "Sorry, no mobile phone bills",
         "list_accessibility": "Documents que vous pouvez utiliser pour vérifier votre identité",
-        "subtitle": "Il doit s'agir d'une pièce d'identité officielle avec photo",
-        "subtitle_poa": "Voici les documents les plus susceptibles d'indiquer votre adresse de résidence actuelle",
-        "title": "Sélectionnez un document",
-        "title_poa": "Sélectionnez un document de %{country}"
+        "subtitle": "Il doit s’agir d’une pièce d’identité officielle avec photo",
+        "subtitle_poa": "These are the documents most likely to show your current home address",
+        "title": "Sélectionner un document",
+        "title_poa": "Select a %{country} document"
     },
     "doc_submit": {
-        "button_link_upload": "ou télécharger une photo - pas de scans ou de photocopies",
+        "button_link_upload": "ou envoyer une photo - pas de scans ou de photocopies",
         "button_primary": "Continuez sur votre mobile",
         "subtitle": "Prendre une photo avec votre téléphone",
-        "title_bank_statement": "Envoyer la déclaration",
-        "title_benefits_letter": "Envoyer la lettre",
+        "title_bank_statement": "Submit statement",
+        "title_benefits_letter": "Submit letter",
         "title_bill": "Submit bill",
         "title_government_letter": "Government Letter",
-        "title_id_back": "Envoyez votre carte d'identité (verso)",
-        "title_id_front": "Envoyer la carte d'identité (recto)",
+        "title_id_back": "Envoyez votre carte d’identité (verso)",
+        "title_id_front": "Envoyer la carte d’identité (recto)",
         "title_license_back": "Envoyer le permis (verso)",
         "title_license_front": "Envoyer le permis (recto)",
-        "title_passport": "Envoyez la page du passeport où figure votre photo",
+        "title_passport": "Envoyez la page du passeport contenant votre photo",
         "title_permit_back": "Envoyer la carte de séjour (verso)",
         "title_permit_front": "Envoyer la carte de séjour (recto)",
-        "title_tax_letter": "Envoyer la lettre"
+        "title_tax_letter": "Submit letter"
     },
     "error_unsupported_browser": {
         "subtitle_android": "Redémarrez le processus sur la dernière version de Google Chrome",
@@ -126,8 +126,8 @@
     },
     "generic": {
         "accessibility": {
-            "close_sdk_screen": "Fermer l'écran de vérification de l'identité",
-            "dismiss_alert": "Ignorer l'alerte"
+            "close_sdk_screen": "Fermer l’écran de vérification de l’identité",
+            "dismiss_alert": "Ignorer l’alerte"
         },
         "back": "retour",
         "close": "fermer",
@@ -141,11 +141,11 @@
                 "message": "La taille du fichier a été dépassée."
             },
             "invalid_type": {
-                "instruction": "Essayez d'utiliser un autre type de fichier.",
+                "instruction": "Essayez d’utiliser un autre type de fichier.",
                 "message": "Fichier non téléchargé."
             },
             "lazy_loading": {
-                "message": "Une erreur s'est produite lors du chargement du composant"
+                "message": "Une erreur s’est produite lors du chargement du composant"
             },
             "multiple_faces": {
                 "instruction": "Votre visage doit être visible sur le selfie",
@@ -168,7 +168,7 @@
                 "message": "Trop de tentatives infructueuses"
             },
             "unsupported_file": {
-                "instruction": "Essayez d'utiliser un fichier JPG ou PNG",
+                "instruction": "Essayez d’utiliser un fichier JPG ou PNG",
                 "message": "Type de fichier non pris en charge"
             }
         },
@@ -181,11 +181,11 @@
         "button_copy": "Copier",
         "button_submit": "Envoyer le lien",
         "info_qr_how": "Comment scanner un QR code",
-        "info_qr_how_list_item_camera": "Pointez l'appareil photo de votre mobile sur le QR code",
-        "info_qr_how_list_item_download": "Si cela ne fonctionne pas, téléchargez un scanner de QR code sur Google Play ou l'App Store",
+        "info_qr_how_list_item_camera": "Pointez l’appareil photo de votre mobile sur le QR code",
+        "info_qr_how_list_item_download": "Si cela ne fonctionne pas, téléchargez un scanner de QR code sur Google Play ou l’App Store",
         "link_divider": "ou",
         "link_qr": "Scanner le QR code",
-        "link_sms": "Obtenez le lien par SMS",
+        "link_sms": "Obtenir le lien par SMS",
         "link_url": "Copier le lien",
         "loader_sending": "Envoi en cours",
         "number_field_input_placeholder": "Entrez votre numéro de mobile",
@@ -210,7 +210,7 @@
             "body_id_front": "Prenez une photo du recto de votre carte",
             "body_license_back": "Prenez une photo du verso de votre permis",
             "body_license_front": "Prenez une photo du recto de votre permis",
-            "body_passport": "Prenez une photo de la page du passeport où figure votre photo",
+            "body_passport": "Prenez une photo de la page du passeport contenant votre photo",
             "body_selfie": "Prenez un selfie"
         },
         "selfie_capture": {
@@ -225,7 +225,7 @@
         },
         "upload_guide": {
             "button_primary": "Prendre une photo",
-            "title": "Page du passeport où figure votre photo"
+            "title": "Page du passeport contenant votre photo"
         }
     },
     "outro": {
@@ -235,30 +235,30 @@
     "permission_recovery": {
         "button_primary": "Actualiser",
         "info": "Récupération",
-        "list_header_cam": "Suivez ces étapes pour autoriser l'accès à l'appareil photo :",
-        "list_item_action_cam": "Actualisez cette page pour redémarrer la vérification d'identité",
-        "list_item_how_to_cam": "Autorisez l'accès à l'appareil photo à partir des paramètres de votre navigateur",
-        "subtitle_cam": "Récupérez l'accès à l'appareil photo pour continuer la vérification",
-        "title_cam": "L'accès à l'appareil photo n'est pas autorisé"
+        "list_header_cam": "Suivez ces étapes pour autoriser l’accès à l’appareil photo :",
+        "list_item_action_cam": "Actualisez cette page pour redémarrer la vérification d’identité",
+        "list_item_how_to_cam": "Autorisez l’accès à l’appareil photo à partir des paramètres de votre navigateur",
+        "subtitle_cam": "Récupérez l’accès à l’appareil photo pour continuer la vérification",
+        "title_cam": "L’accès à l’appareil photo n’est pas autorisé"
     },
     "permission": {
         "body_cam": "Nous ne pouvons pas vous vérifier sans utiliser votre appareil photo",
-        "button_primary_cam": "Activer l'appareil photo",
-        "subtitle_cam": "Lorsque vous y serez invité, vous devez autoriser l'accès à l'appareil photo pour continuer",
-        "title_cam": "Autoriser l'accès à l'appareil photo"
+        "button_primary_cam": "Activer l’appareil photo",
+        "subtitle_cam": "Lorsque vous y serez invité, vous devez autoriser l’accès à l’appareil photo pour continuer",
+        "title_cam": "Autoriser l’accès à l’appareil photo"
     },
     "photo_upload": {
-        "body_bank_statement": "Fournissez la page entière du document pour de meilleurs résultats",
-        "body_benefits_letter": "Fournissez la page entière du document pour de meilleurs résultats",
-        "body_bill": "Fournissez la page entière du document pour de meilleurs résultats",
-        "body_government_letter": "Fournissez la page entière du document pour de meilleurs résultats",
+        "body_bank_statement": "Provide the whole document page for best results",
+        "body_benefits_letter": "Provide the whole document page for best results",
+        "body_bill": "Provide the whole document page for best results",
+        "body_government_letter": "Provide the whole document page for best results",
         "body_id_back": "Envoyez votre carte depuis votre ordinateur",
         "body_id_front": "Envoyez le recto de votre carte depuis votre ordinateur",
         "body_license_back": "Envoyez le verso de votre permis depuis votre ordinateur",
         "body_license_front": "Envoyez votre permis depuis votre ordinateur",
         "body_passport": "Envoyez votre passeport depuis votre ordinateur",
         "body_selfie": "Envoyez votre selfie depuis votre ordinateur",
-        "body_tax_letter": "Fournissez la page entière du document pour de meilleurs résultats",
+        "body_tax_letter": "Provide the whole document page for best results",
         "button_take_photo": "Prendre une photo",
         "button_upload": "Envoyer",
         "title_selfie": "Selfie"
@@ -266,10 +266,10 @@
     "poa_guidance": {
         "button_primary": "Continuer",
         "instructions": {
-            "address": "Adresse actuelle",
-            "full_name": "Nom complet",
+            "address": "Current address",
+            "full_name": "Full name",
             "issue_date": "Issue date or summary period",
-            "label": "Assurez-vous qu'il montre clairement:",
+            "label": "Make sure it clearly shows:",
             "logo": "Logo"
         },
         "subtitle_bank_statement": "Must be issued in the <strong>last 3 months<\/strong>",
@@ -279,27 +279,27 @@
         "subtitle_tax_letter": "Must be issued in the <strong>last 12 months<\/strong>"
     },
     "poa_intro": {
-        "button_primary": "Commencer la vérification",
-        "list_matches_signup": "<strong> Correspond à <\/strong> l'adresse que vous avez utilisée lors de l'inscription",
-        "list_most_recent": "Est votre document le plus <strong>récent<\/strong>",
-        "list_shows_address": "Indique votre adresse <strong>actuelle<\/strong>",
-        "subtitle": "Vous aurez besoin d'un document qui :",
-        "title": "Vérifions votre adresse %{country}"
+        "button_primary": "Start verification",
+        "list_matches_signup": "<strong>Matches<\/strong> the address you used on signup",
+        "list_most_recent": "Is your most <strong>recent<\/strong> document",
+        "list_shows_address": "Shows your <strong>current<\/strong> address",
+        "subtitle": "You’ll need a document that:",
+        "title": "Let’s verify your %{country} address"
     },
     "selfie_capture": {
         "alert": {
             "camera_inactive": {
-                "detail": "Vérifiez qu'il est connecté et fonctionnel. Vous pouvez également <fallback> continuer la vérification sur votre mobile <\/fallback>",
-                "detail_no_fallback": "Assurez-vous que votre appareil est équipé d'un appareil photo en état de marche",
-                "title": "L'appareil photo ne fonctionne pas ?"
+                "detail": "Vérifiez qu’il est connecté et fonctionnel. Vous pouvez également <fallback> continuer la vérification sur votre mobile <\/fallback>",
+                "detail_no_fallback": "Assurez-vous que votre appareil est équipé d’un appareil photo en état de marche",
+                "title": "L’appareil photo ne fonctionne pas ?"
             },
             "camera_not_working": {
-                "detail": "Il peut être déconnecté.<fallback> Essayez d'utiliser votre mobile à la place <\/fallback>.",
-                "detail_no_fallback": "Assurez-vous que l'appareil photo de votre mobile fonctionne",
-                "title": "L'appareil photo ne fonctionne pas"
+                "detail": "Il peut être déconnecté.<fallback> Essayez d’utiliser votre mobile à la place <\/fallback>.",
+                "detail_no_fallback": "Assurez-vous que l’appareil photo de votre mobile fonctionne",
+                "title": "L’appareil photo ne fonctionne pas"
             },
             "timeout": {
-                "detail": "Rappelez-vous d'appuyer sur stop lorsque vous avez terminé. <fallback>Refaire la vidéo<\/fallback>",
+                "detail": "Rappelez-vous d’appuyer sur stop lorsque vous avez terminé. <fallback>Refaire la vidéo<\/fallback>",
                 "title": "Le temps est écoulé"
             }
         },
@@ -315,7 +315,7 @@
     "selfie_intro": {
         "button_primary": "Continuer",
         "list_accessibility": "Conseils pour prendre un bon selfie",
-        "list_item_face_forward": "Regardez vers l'avant et assurez-vous que vos yeux sont bien visibles",
+        "list_item_face_forward": "Regardez vers l’avant et assurez-vous que vos yeux sont bien visibles",
         "list_item_no_glasses": "Retirez vos lunettes, si nécessaire",
         "subtitle": "Nous allons le comparer avec votre document",
         "title": "Prendre un selfie"
@@ -332,24 +332,21 @@
     "switch_phone": {
         "info": "Conseils",
         "info_link_expire": "Votre lien expirera dans une heure",
-        "info_link_refresh": "N'actualisez pas cette page",
+        "info_link_refresh": "N’actualisez pas cette page",
         "info_link_window": "Gardez cette fenêtre ouverte lorsque vous utilisez votre mobile",
         "link": "Annuler",
-        "subtitle": "Une fois que vous aurez terminé, nous vous emmènerons à l'étape suivante",
+        "subtitle": "Une fois que vous aurez terminé, nous vous emmènerons à l’étape suivante",
         "title": "Connecté à votre mobile"
     },
     "upload_guide": {
-        "button_primary": "Envoyer une photo",
+        "button_primary": "Envoyer la photo",
         "image_detail_blur_alt": "Exemple de document flou",
         "image_detail_blur_label": "Tous les détails doivent être clairs — rien ne doit être flou",
-        "image_detail_cutoff_alt": "Exemple de document tronqué",
         "image_detail_cutoff_label": "Afficher tous les détails — y compris les deux dernières lignes",
-        "image_detail_glare_alt": "Exemple de document avec reflets",
-        "image_detail_glare_label": "Éloignez-vous de la lumière directe — évitez l'éblouissement",
-        "image_detail_good_alt": "Exemple de document",
+        "image_detail_glare_label": "Éloignez-vous de la lumière directe — évitez les reflets",
         "image_detail_good_label": "La photo doit montrer clairement votre document",
-        "subtitle": "Les numérisations et photocopies ne sont pas acceptées",
-        "title": "Envoyez la page du passeport où figure votre photo"
+        "subtitle": "Les scans et photocopies ne sont pas acceptés",
+        "title": "Envoyez la page du passeport contenant votre photo"
     },
     "user_consent": {
         "button_primary": "Accept",
@@ -367,7 +364,7 @@
         "body_record": "Appuyez sur enregistrer et suivez les instructions",
         "body_stop": "Lorsque vous avez terminé, appuyez sur stop",
         "button_primary_next": "Suivant",
-        "button_record_accessibility": "Commencer l'enregistrement",
+        "button_record_accessibility": "Démarrer l’enregistrement",
         "button_stop_accessibility": "Arrêter l’enregistrement",
         "frame_accessibility": "Vue de la caméra",
         "header": {
@@ -376,7 +373,7 @@
             "challenge_turn_right": "droite",
             "challenge_turn_template": "Regardez par-dessus votre épaule %{side}"
         },
-        "status": "En cours d'enregistrement"
+        "status": "En cours d’enregistrement"
     },
     "video_confirmation": {
         "title": "Veuillez vérifier votre vidéo",
@@ -385,8 +382,8 @@
     "video_intro": {
         "button_primary": "Continuer",
         "list_accessibility": "Actions pour enregistrer une vidéo de votre visage",
-        "list_item_actions": "Nous allons vous demander de vous filmer en train d'exécuter <strong>2 actions simples<\/strong>",
-        "list_item_speak": "L'une d'entre elles consistera à <strong>parler à haute<\/strong> voix",
+        "list_item_actions": "Nous allons vous demander de vous filmer en train d’exécuter <strong>2 actions simples<\/strong>",
+        "list_item_speak": "L’une d’entre elles consistera à <strong>parler à haute<\/strong> voix",
         "title": "Assurons-nous que personne ne se fait passer pour vous"
     },
     "welcome": {

--- a/test/specs/scenarios/crossDevice.js
+++ b/test/specs/scenarios/crossDevice.js
@@ -221,7 +221,7 @@ export const crossDeviceScenarios = async (lang) => {
         crossDeviceMobileNotificationSent.verifyTitle(copy)
         if (lang === 'en_US') {
           crossDeviceMobileNotificationSent.verifySubmessage(
-            "We've sent a secure link to +447495023357"
+            'We’ve sent a secure link to +447495023357'
           )
         } else {
           crossDeviceMobileNotificationSent.verifySubmessage(

--- a/test/specs/scenarios/proofOfAddress.js
+++ b/test/specs/scenarios/proofOfAddress.js
@@ -58,7 +58,7 @@ export const proofOfAddressScenarios = async (lang = 'en_US') => {
       it('should verify UI elements of PoA Intro screen', async () => {
         driver.get(`${localhostUrl}?poa=true`)
         welcome.continueToNextStep()
-        poaIntro.verifyTitle("Let's verify your UK address")
+        poaIntro.verifyTitle('Let’s verify your UK address')
         poaIntro.verifyRequirementsHeader(copy)
         poaIntro.verifyFirstRequirement('Shows your current address')
         poaIntro.verifySecondRequirement(


### PR DESCRIPTION
# Problem
When downloading copy for a new feature, there was also a lot of changes to the translation files in general for existing copy already in production. 

- Most of the changes are related to the punctuation character(s) used & mostly affecting the French translations
- Some PoA copy has been translated to French in production & Spanish in development
- There are some grammar corrections/updates in all the translation files

# Solution
Get latest copy from Lokalise without any new copy intended for new features that are still in development

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
