### PR TITLE
Remove duplicated customisation option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,6 @@ A number of options are available to allow you to customize the SDK:
   | `colorContentDocTypeButton`      | Change Document Type Button text color                   |
   | `colorBackgroundDocTypeButton`   | Change background color of Document Type Button          |
   | `colorBorderDocTypeButton`       | Change color of Document Type Button border              |
-  | `colorBorderDocTypeButton`       | Change color of Document Type Button border              |
   | `colorBorderDocTypeButtonHover`  | Change color of Document Type Button border on hover     |
   | `colorBorderDocTypeButtonActive` | Change color of Document Type Button border on click/tap |
 


### PR DESCRIPTION
# Problem
Under the UI customisation options documentation in the `README` there is a duplicated Document Type Buttons option `colorBorderDocTypeButton`.

# Solution
Remove the duplicated option in `README`

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [x] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
