### PR TITLE
Fix readme typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -962,7 +962,7 @@ Onfido.init({
   // Other options here
   enterpriseFeatures: {
     useCustomizedApiRequests: true,
-    onSubmitDocuments: (documentData) => {
+    onSubmitDocument: (documentData) => {
       // Your callback code here
     },
     onSubmitSelfie: (selfieData) => {


### PR DESCRIPTION
# Problem

There is a typo in the README documentation for the `useCustomizedApiRequests` enterprise feature.

# Solution

Fix typo.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
