### PR TITLE
Chore/audit dev dependency vulnerabilities also (v2)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,8 +48,8 @@ jobs:
         if: matrix.NODE_ENV == 'production'
         uses: oke-py/npm-audit-action@v1.7.2
         with:
-          audit_level: high
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          audit_level: moderate
+          # github_token: ${{ secrets.GITHUB_TOKEN }}
           issue_assignees: kopijunkie
           issue_labels: vulnerability
           dedupe_issues: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ jobs:
         if: matrix.NODE_ENV == 'production'
         uses: oke-py/npm-audit-action@v1.7.2
         with:
-          audit_level: moderate
+          audit_level: high
           github_token: ${{ secrets.GITHUB_TOKEN }}
           issue_assignees: kopijunkie
           issue_labels: vulnerability

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,7 +54,7 @@ jobs:
           issue_labels: vulnerability
           dedupe_issues: true
           # PR comment doesn't get created and job fails if vulnerabilites found in dev dependencies & json_flag is false (default)
-          json_flag: true 
+          json_flag: true
 
       - name: Run build
         # Legacy: For "$NODE_ENV" == "production" Surge uses the NODE_ENV=test + TEST_ENV=deployment

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,11 +49,12 @@ jobs:
         uses: oke-py/npm-audit-action@v1.7.2
         with:
           audit_level: moderate
-          production_flag: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
           issue_assignees: kopijunkie
           issue_labels: vulnerability
           dedupe_issues: true
+          # PR comment doesn't get created and job fails if vulnerabilites found in dev dependencies & json_flag is false (default)
+          json_flag: true 
 
       - name: Run build
         # Legacy: For "$NODE_ENV" == "production" Surge uses the NODE_ENV=test + TEST_ENV=deployment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ## [next-version]
 
+## Added
+
+## Changed
+
+- Internal: Include dev dependencies in `npm audit action` job in CI Github Action workflow
+
+## Fixed
+
 ## [6.8.0] - 2021-05-13
 
 ## Added


### PR DESCRIPTION
# Problem
We want to also check for moderate-high dev dependency vulnerabilities in our repo in the npm audit check Github Action job as our dev dependencies include some libraries that are bundled in the final SDK code. 

CI build `test` and `production` jobs seem to always get cancelled when dependencies found in dev dependencies. No Surge link is generated for first version PR #1439 

# Solution
- Revert change to npm audit check Github Action workflow config to enable `production_flag`.
- Enable `json_flag` as job was failing and not creating PR comment/issue as expected for dev dependency vulnerabilities found
- Set `audit_level` to high to check if CI build `test` and `production` jobs still get cancelled

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
