### PR TITLE
Update Auth endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ import { init } from 'onfido-sdk-ui/dist/onfidoAuth.min.js'
 var Onfido = require('onfido-sdk-ui/dist/onfidoAuth.min.js')
 ```
 
-In addition to the alternative way of importing Auth, the integrator should also set the following code on the webpack/loader of their application:
+In addition to the alternative way of importing Auth, you should also set the following code in the loader (Webpack) of your application:
 
 ```javascript
 new CopyPlugin({
@@ -178,7 +178,7 @@ new CopyPlugin({
 })
 ```
 
-This will fetch the core authentication technology from the SDK into your application. Using web workers for authentication enables the best performance achievable, without constraining the user usability.
+This will fetch the core authentication technology from the SDK into your application. Using web workers for authentication enables the best performance achievable, without compromising on usability.
 
 The CSS style will be included inline with the JS code when the library is imported.
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,9 @@ import { init } from 'onfido-sdk-ui/dist/onfidoAuth.min.js'
 var Onfido = require('onfido-sdk-ui/dist/onfidoAuth.min.js')
 ```
 
-In addition to the alternative way of importing Auth, you should also set the following code in the loader (Webpack) of your application:
+In addition to the alternative way of importing Auth, you need to have an `auth-sdk/` folder in your public assets folder, and copy the contents of `node_modules/onfido-sdk-ui/dist/auth-sdk` into it.
+
+If you are using Webpack on your application, you can automate this by adding:
 
 ```javascript
 new CopyPlugin({

--- a/README.md
+++ b/README.md
@@ -165,6 +165,21 @@ import { init } from 'onfido-sdk-ui/dist/onfidoAuth.min.js'
 var Onfido = require('onfido-sdk-ui/dist/onfidoAuth.min.js')
 ```
 
+In addition to the alternative way of importing Auth, the integrator should also set the following code on the webpack/loader of their application:
+
+```javascript
+new CopyPlugin({
+  patterns: [
+    {
+      from: `../../node_modules/onfido-sdk-ui/dist/auth-sdk`,
+      to: `${__dirname}/bin/src/auth-sdk`,
+    },
+  ],
+})
+```
+
+This will fetch the core authentication technology from the SDK into your application. Using web workers for authentication enables the best performance achievable, without constraining the user usability.
+
 The CSS style will be included inline with the JS code when the library is imported.
 
 ⚠️ Note: The library is **Browser only**, it does not support the **Node Context**.

--- a/src/components/Auth/AuthCheckProcessor.ts
+++ b/src/components/Auth/AuthCheckProcessor.ts
@@ -96,7 +96,7 @@ export class AuthCheckProcessor implements FaceTecFaceScanProcessor {
     // Part 5:  Make the Networking Call to the Onfido Servers.
     //
     this.latestNetworkRequest = new XMLHttpRequest()
-    this.latestNetworkRequest.open('POST', `${BaseURL}/auth_3d`)
+    this.latestNetworkRequest.open('POST', `${BaseURL}/v3/auth_3d`)
     this.latestNetworkRequest.setRequestHeader(
       'Authorization',
       `Bearer ${this.sdkToken}`

--- a/src/components/utils/http.ts
+++ b/src/components/utils/http.ts
@@ -43,7 +43,7 @@ export const getAuthConfig = (
   }
   const request = new XMLHttpRequest()
 
-  request.open('POST', `${process.env.AUTH_URL}/auth_3d/session`)
+  request.open('POST', `${process.env.AUTH_URL}/v3/auth_3d/session`)
 
   request.setRequestHeader('Authorization', token)
   request.setRequestHeader('Application-Id', 'com.onfido.onfidoAuth')

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -216,7 +216,7 @@ const basePlugins = (bundle_name = '') => [
       // ref: https://en.wikipedia.org/wiki/Base32
       // NOTE: please leave the BASE_32_VERSION be! It is updated automatically by
       // the release script 🤖
-      BASE_32_VERSION: 'CE',
+      BASE_32_VERSION: 'CD',
       PRIVACY_FEATURE_ENABLED: false,
       JWT_FACTORY: CONFIG.JWT_FACTORY,
       US_JWT_FACTORY: CONFIG.US_JWT_FACTORY,

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -127,7 +127,7 @@ const PROD_CONFIG = {
   SMS_DELIVERY_URL: 'https://telephony.onfido.com',
   PUBLIC_PATH: `https://assets.onfido.com/web-sdk-releases/${packageJson.version}/`,
   USER_CONSENT_URL: 'https://assets.onfido.com/consent/user_consent.html',
-  AUTH_URL: 'https://edge.api.onfido.com/v3',
+  AUTH_URL: 'https://api.eu.onfido.com',
   RESTRICTED_XDEVICE_FEATURE_ENABLED: true,
   WOOPRA_DOMAIN,
 }
@@ -216,7 +216,7 @@ const basePlugins = (bundle_name = '') => [
       // ref: https://en.wikipedia.org/wiki/Base32
       // NOTE: please leave the BASE_32_VERSION be! It is updated automatically by
       // the release script 🤖
-      BASE_32_VERSION: 'CD',
+      BASE_32_VERSION: 'CF',
       PRIVACY_FEATURE_ENABLED: false,
       JWT_FACTORY: CONFIG.JWT_FACTORY,
       US_JWT_FACTORY: CONFIG.US_JWT_FACTORY,


### PR DESCRIPTION
Endpoint for `AUTH_URL` needs to be updated to use `api.eu.onfido.com` rather than `edge.api.onfido.com`. EU region should be considered as a fallback.

`README.md` has also been updated in order to cater for integration constraints from using web workers.

## Checklist

- [n/a] Has the CHANGELOG been updated?
- [x] Has the README been updated?
- [n/a] Has the CONTRIBUTING doc been updated?
- [n/a] Has the RELEASE_GUIDELINES been updated?
- [n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [n/a] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a] Have any new automated tests been implemented or the existing ones changed?
- [n/a] Have any new manual tests been written down or the existing ones changed?
- [n/a] Have any new strings been translated or the existing ones changed?
