### PR TITLE
Task/cx 6284 resolve ms edge failure

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -80,7 +80,6 @@ const firefoxOptions = new firefox.Options()
 const safariOptions = new safari.Options().setAcceptInsecureCerts(false)
 
 const edgeOptions = new edge.Options()
-  .setEdgeChromium(true)
   .setAcceptInsecureCerts(true)
   .addArguments('allow-file-access-from-files')
   .addArguments('use-fake-device-for-media-stream')


### PR DESCRIPTION
# Problem
- The UI tests were failing to run on CI
# Solution
- It appears that .setEdgeChromium is no longer a valid function, so I've removed it.
## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
