### PR TITLE
re-instate previously failing test

### DIFF
--- a/test/specs/scenarios/accessibility.js
+++ b/test/specs/scenarios/accessibility.js
@@ -157,8 +157,7 @@ export const accessibilityScenarios = async (lang = 'en_US') => {
         runAccessibilityTest(driver)
       })
 
-      // @FIXME: consistently fails due to accessibility test auto timing out
-      it.skip('should verify accessibility for the cross device submit screen', async () => {
+      it('should verify accessibility for the cross device submit screen', async () => {
         goToPassportUploadScreen(
           driver,
           welcome,


### PR DESCRIPTION
# Problem
- The test was previously failing.

# Solution
- Re-enable failing test. Verified working on chrome, firefox, safari, MS Edge.
 
## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [x] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
