### PR TITLE
add @percy tags to tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:integration": "jest --verbose --testPathPattern=__integrations__",
     "test:unit": "jest --coverage --verbose --testPathPattern=__tests__",
     "test:ui": "babel-node test/main.js",
-    "test:percy": "CONFIG_FILE=percy.json PERCY=true percy exec npm run test:ui",
+    "test:percy": "MOCHA_GREP=@percy CONFIG_FILE=percy.json PERCY=true percy exec npm run test:ui",
     "mock-server:build": "cd ./test/mock-server && ./prepare.sh && docker build -t onfido-web-sdk:ui-mock-server .",
     "mock-server:run": "docker run -d --init --rm -p 8080:8080 onfido-web-sdk:ui-mock-server",
     "bundle-analyzer": "webpack-bundle-analyzer",

--- a/test/specs/scenarios/document.js
+++ b/test/specs/scenarios/document.js
@@ -56,7 +56,7 @@ export const documentScenarios = async (lang) => {
         passportUploadImageGuide.upload(filename)
       }
 
-      it('should display document upload screen on desktop browsers when useLiveDocumentCapture is enabled', async () => {
+      it('should display document upload screen on desktop browsers when useLiveDocumentCapture is enabled @percy', async () => {
         goToPassportUploadScreen(
           driver,
           welcome,
@@ -74,7 +74,7 @@ export const documentScenarios = async (lang) => {
         )
       })
 
-      it('should upload a passport and verify UI elements', async () => {
+      it('should upload a passport and verify UI elements @percy', async () => {
         goToPassportUploadScreen(
           driver,
           welcome,
@@ -92,7 +92,7 @@ export const documentScenarios = async (lang) => {
         )
       })
 
-      it('should upload driving licence and verify UI elements', async () => {
+      it('should upload driving licence and verify UI elements @percy', async () => {
         driver.get(baseUrl)
         welcome.continueToNextStep()
         documentSelector.clickOnDrivingLicenceIcon()
@@ -139,7 +139,7 @@ export const documentScenarios = async (lang) => {
         confirm.verifyMakeSureDrivingLicenceMessage(copy)
       })
 
-      it('should upload identity card and verify UI elements', async () => {
+      it('should upload identity card and verify UI elements @percy', async () => {
         driver.get(baseUrl)
         welcome.continueToNextStep()
         documentSelector.clickOnIdentityCardIcon()
@@ -175,7 +175,7 @@ export const documentScenarios = async (lang) => {
         confirm.verifyMakeSureIdentityCardMessage(copy)
       })
 
-      it('should upload residence permit and verify UI elements', async () => {
+      it('should upload residence permit and verify UI elements @percy', async () => {
         driver.get(baseUrl)
         welcome.continueToNextStep()
         documentSelector.clickOnResidencePermitIcon()
@@ -206,7 +206,7 @@ export const documentScenarios = async (lang) => {
         confirm.verifyMakeSureResidencePermitMessage(copy)
       })
 
-      it('should return no document message after uploading non-doc image', async () => {
+      it('should return no document message after uploading non-doc image @percy', async () => {
         goToPassportUploadScreen(
           driver,
           welcome,
@@ -226,7 +226,7 @@ export const documentScenarios = async (lang) => {
         )
       })
 
-      it('should upload a document on retry after uploading a non-doc image', async () => {
+      it('should upload a document on retry after uploading a non-doc image @percy', async () => {
         goToPassportUploadScreen(
           driver,
           welcome,
@@ -248,7 +248,7 @@ export const documentScenarios = async (lang) => {
         confirm.verifyCheckReadabilityMessage(copy)
       })
 
-      it('should return file size too large message for PDF document upload', async () => {
+      it('should return file size too large message for PDF document upload @percy', async () => {
         goToPassportUploadScreen(
           driver,
           welcome,
@@ -294,7 +294,7 @@ export const documentScenarios = async (lang) => {
         confirm.verifyUseAnotherFileError(copy)
       })
 
-      it('should return image quality message on front of doc', async () => {
+      it('should return image quality message on front of doc @percy', async () => {
         driver.get(baseUrl)
         welcome.continueToNextStep()
         documentSelector.clickOnDrivingLicenceIcon()
@@ -327,7 +327,7 @@ export const documentScenarios = async (lang) => {
         })
 
         // 2nd retake
-        it('should return a warning on the third attempt', async () => {
+        it('should return a warning on the third attempt @percy', async () => {
           uploadFileAndClickConfirmButton(
             documentUpload,
             confirm,

--- a/test/specs/scenarios/documentSelector.js
+++ b/test/specs/scenarios/documentSelector.js
@@ -14,7 +14,7 @@ export const documentSelectorScenarios = async (lang) => {
       const { welcome, documentSelector, basePage } = pageObjects
       const copy = basePage.copy(lang)
 
-      it('should verify UI elements on the document selection screen', async () => {
+      it('should verify UI elements on the document selection screen @percy', async () => {
         driver.get(`${localhostUrl}?language=${lang}`)
         welcome.continueToNextStep()
         documentSelector.verifyTitle(copy)

--- a/test/specs/scenarios/face.js
+++ b/test/specs/scenarios/face.js
@@ -112,7 +112,7 @@ export const faceScenarios = (lang) => {
       verificationComplete.checkBackArrowIsNotDisplayed()
     })
 
-    it('should take one selfie using the camera stream', async () => {
+    it('should take one selfie using the camera stream @percy', async () => {
       goToPassportUploadScreen(
         driver,
         welcome,
@@ -262,7 +262,7 @@ export const faceScenarios = (lang) => {
       crossDeviceIntro.verifyTitle(copy)
     })
 
-    it('should enter the liveness flow if I have a camera and liveness variant requested', async () => {
+    it('should enter the liveness flow if I have a camera and liveness variant requested @percy', async () => {
       goToPassportUploadScreen(
         driver,
         welcome,
@@ -291,7 +291,7 @@ export const faceScenarios = (lang) => {
       )
     })
 
-    it('should enter the liveness flow and display timeout notification after 10 seconds', async () => {
+    it('should enter the liveness flow and display timeout notification after 10 seconds @percy', async () => {
       goToPassportUploadScreen(
         driver,
         welcome,
@@ -321,7 +321,7 @@ export const faceScenarios = (lang) => {
       )
     })
 
-    it('should record a video with live challenge, play it and submit it', async () => {
+    it('should record a video with live challenge, play it and submit it @percy', async () => {
       goToPassportUploadScreen(
         driver,
         welcome,
@@ -359,7 +359,7 @@ export const faceScenarios = (lang) => {
       verificationComplete.checkBackArrowIsNotDisplayed()
     })
 
-    it('should hide the logo if using valid enterprise SDK Token and hideOnfidoLogo is enabled for liveness variant', async () => {
+    it('should hide the logo if using valid enterprise SDK Token and hideOnfidoLogo is enabled for liveness variant @percy', async () => {
       goToPassportUploadScreen(
         driver,
         welcome,
@@ -415,7 +415,7 @@ export const faceScenarios = (lang) => {
       )
     })
 
-    it('should show the cobrand text and logo if using valid enterprise SDK Token and showCobrand is enabled for liveness variant', async () => {
+    it('should show the cobrand text and logo if using valid enterprise SDK Token and showCobrand is enabled for liveness variant @percy', async () => {
       goToPassportUploadScreen(
         driver,
         welcome,

--- a/test/specs/scenarios/proofOfAddress.js
+++ b/test/specs/scenarios/proofOfAddress.js
@@ -59,7 +59,7 @@ export const proofOfAddressScenarios = async (lang = 'en_US') => {
         poaIntro.clickStartVerificationButton()
       }
 
-      it('should verify UI elements of PoA Intro screen', async () => {
+      it('should verify UI elements of PoA Intro screen @percy', async () => {
         driver.get(`${localhostUrl}?poa=true`)
         welcome.continueToNextStep()
         poaIntro.verifyTitle('Let’s verify your UK address')
@@ -76,7 +76,7 @@ export const proofOfAddressScenarios = async (lang = 'en_US') => {
         )
       })
 
-      it('should verify UI elements of PoA Document Selection screen', async () => {
+      it('should verify UI elements of PoA Document Selection screen @percy', async () => {
         goToPoADocumentSelectionScreen()
         poaDocumentSelection.verifyTitle('Select a UK document')
         poaDocumentSelection.verifySubtitle(copy)
@@ -87,7 +87,7 @@ export const proofOfAddressScenarios = async (lang = 'en_US') => {
         await takePercySnapshot(driver, 'Select a UK document screen')
       })
 
-      it('should verify UI elements of PoA Guidance for Bank Statement', async () => {
+      it('should verify UI elements of PoA Guidance for Bank Statement @percy', async () => {
         goToPoADocumentSelectionScreen()
         poaDocumentSelection.clickOnBankIcon()
         poaGuidance.verifyCopiesOnPoADocumentsGuidanceScreen(
@@ -98,7 +98,7 @@ export const proofOfAddressScenarios = async (lang = 'en_US') => {
         await takePercySnapshot(driver, 'Submit Statement screen')
       })
 
-      it('should verify UI elements of PoA Guidance for Utility Bill', async () => {
+      it('should verify UI elements of PoA Guidance for Utility Bill @percy', async () => {
         goToPoADocumentSelectionScreen()
         poaDocumentSelection.clickOnUtilityBillIcon()
         poaGuidance.verifyCopiesOnPoADocumentsGuidanceScreen(
@@ -109,7 +109,7 @@ export const proofOfAddressScenarios = async (lang = 'en_US') => {
         await takePercySnapshot(driver, 'Submit bill screen')
       })
 
-      it('should verify UI elements of PoA Guidance for Council Tax Letter', async () => {
+      it('should verify UI elements of PoA Guidance for Council Tax Letter @percy', async () => {
         goToPoADocumentSelectionScreen()
         poaDocumentSelection.clickOnCouncilTaxLetterIcon()
         poaGuidance.verifyCopiesOnPoADocumentsGuidanceScreen(
@@ -120,7 +120,7 @@ export const proofOfAddressScenarios = async (lang = 'en_US') => {
         await takePercySnapshot(driver, 'Submit council tax letter screen')
       })
 
-      it('should verify UI elements of PoA Guidance for Benefits Letter', async () => {
+      it('should verify UI elements of PoA Guidance for Benefits Letter @percy', async () => {
         goToPoADocumentSelectionScreen()
         poaDocumentSelection.clickOnBenefitsLetterIcon()
         poaGuidance.verifyCopiesOnPoADocumentsGuidanceScreen(
@@ -131,7 +131,7 @@ export const proofOfAddressScenarios = async (lang = 'en_US') => {
         await takePercySnapshot(driver, 'Submit benefit letter screen')
       })
 
-      it("should skip country selection screen with a preselected driver's license document type on PoA flow", async () => {
+      it("should skip country selection screen with a preselected driver's license document type on PoA flow @percy", async () => {
         driver.get(`${localhostUrl}?poa=true&oneDoc=driving_licence`)
         welcome.continueToNextStep()
         poaIntro.clickStartVerificationButton()
@@ -232,7 +232,7 @@ export const proofOfAddressScenarios = async (lang = 'en_US') => {
         verificationComplete.verifyUIElements(copy)
       })
 
-      it('should succesfully complete cross device e2e flow with PoA document and selfie upload', async () => {
+      it('should succesfully complete cross device e2e flow with PoA document and selfie upload @percy', async () => {
         const copyCrossDeviceLinkAndOpenInNewTab = async () => {
           const crossDeviceLinkText = crossDeviceLink
             .copyLinkTextContainer()

--- a/test/specs/scenarios/welcome.js
+++ b/test/specs/scenarios/welcome.js
@@ -21,7 +21,7 @@ export const welcomeScenarios = async (lang) => {
         expect(title).to.equal('Onfido SDK Demo')
       })
 
-      it('should verify UI elements on the welcome screen', async () => {
+      it('should verify UI elements on the welcome screen @percy', async () => {
         driver.get(`${localhostUrl}?language=${lang}`)
         welcome.verifyTitle(copy)
         welcome.verifySubtitle(copy)


### PR DESCRIPTION
# Problem
- The current tests marked for Percy take approximately 3 mins to run. However with the current implementation, we are running many tests that done need to be run.

# Solution
-  Add @percy tags to speed this up and explicitly only run the actually tagged @percy tickets.
## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [x] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
