### PR TITLE
Fix/add variant field to document response

### DIFF
--- a/src/types/sdk.ts
+++ b/src/types/sdk.ts
@@ -1,5 +1,5 @@
 import type { SupportedLanguages, LocaleConfig } from './locales'
-import type { StepConfig, StepTypes } from './steps'
+import type { RequestedVariant, StepConfig, StepTypes } from './steps'
 import type { EnterpriseFeatures } from './enterprise'
 import type { UICustomizationOptions } from './ui-customisation-options'
 
@@ -7,11 +7,12 @@ type DocumentResponse = {
   id: string
   side: string
   type: string
+  variant: RequestedVariant
 }
 
 type FaceResponse = {
   id: string
-  variant: string
+  variant: RequestedVariant
 }
 
 export type SdkResponse = {


### PR DESCRIPTION
# Problem

The `DocumentResponse` type declaration is missing a `variant` field of type `RequestedVariant`

# Solution

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [n/a] Has the README been updated?
- [n/a] Has the CONTRIBUTING doc been updated?
- [n/a] Has the RELEASE_GUIDELINES been updated?
- [n/a] Has the TESTING_GUIDELINES been updated?
- [n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [n/a] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a] Have any new automated tests been implemented or the existing ones changed?
- [n/a] Have any new manual tests been written down or the existing ones changed?
- [n/a] Have any new strings been translated or the existing ones changed?
