### PR TITLE
Add ARIA image role, label for QR code image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Added
 
+- UI: Accessibility - Add ARIA role `img` and an ARIA label for the generated cross device secure link QR code image
+
 ### Changed
 
 - UI: Accessibility - Add ARIA role `button` to "Resend link" and "Cancel" links on Cross Device flow SMS Sent, Mobile Connected screens.

--- a/src/components/crossDevice/CrossDeviceLink/index.js
+++ b/src/components/crossDevice/CrossDeviceLink/index.js
@@ -290,7 +290,7 @@ class CrossDeviceLinkUI extends Component {
 
   renderQrCodeSection = () => (
     <div className={style.qrCodeSection}>
-      <div className={style.qrCodeContainer}>
+      <div className={style.qrCodeContainer} role="img" aria-label="QR code">
         <QRCodeGenerator url={this.getMobileUrl()} size={144} />
       </div>
       <QRCodeHowTo />


### PR DESCRIPTION
# Problem
QR Code image is missing an alternative text.

# Solution
As we do not have control of and there is no way to set an alternative text for the generated QR code image, added an ARIA `img` role and ARIA label to the QR code's container `<div>` element.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
