### PR TITLE
Hotfix/camera permissions screen mobile layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ## [next-version]
 
+### Fixed
+
+- UI: Fixed Camera Permissions Primer screen rendering issue on Safari 14.1 (desktop) without changing existing SDK layout structure.
+
 ## [6.10.1] - 2021-07-05
 
 ### Changed

--- a/src/components/CameraPermissions/Primer/index.tsx
+++ b/src/components/CameraPermissions/Primer/index.tsx
@@ -1,6 +1,5 @@
 import { h, FunctionComponent } from 'preact'
 import classNames from 'classnames'
-import ScreenLayout from 'components/Theme/ScreenLayout'
 import PageTitle from 'components/PageTitle'
 import { Button } from '@onfido/castor-react'
 import { trackComponent } from 'Tracker'
@@ -17,8 +16,18 @@ type PermissionsProps = {
 type Props = PermissionsProps & WithLocalisedProps & WithTrackingProps
 
 const Permissions: FunctionComponent<Props> = ({ onNext, translate }) => (
-  <ScreenLayout
-    actions={
+  <div className={theme.fullHeightContainer}>
+    <PageTitle
+      title={translate('permission.title_cam')}
+      subTitle={translate('permission.subtitle_cam')}
+    />
+    <div className={classNames(style.bodyWrapper, theme.scrollableContent)}>
+      <div className={style.image}>
+        <div className={style.graphic} />
+      </div>
+      <p className={style.instructions}>{translate('permission.body_cam')}</p>
+    </div>
+    <div className={classNames(theme.contentMargin, style.actions)}>
       <Button
         variant="primary"
         className={classNames(theme['button-centered'], theme['button-lg'])}
@@ -27,21 +36,8 @@ const Permissions: FunctionComponent<Props> = ({ onNext, translate }) => (
       >
         {translate('permission.button_primary_cam')}
       </Button>
-    }
-  >
-    <div className={theme.fullHeightContainer}>
-      <PageTitle
-        title={translate('permission.title_cam')}
-        subTitle={translate('permission.subtitle_cam')}
-      />
-      <div className={classNames(style.bodyWrapper)}>
-        <div className={style.image}>
-          <div className={style.graphic} />
-        </div>
-        <p className={style.instructions}>{translate('permission.body_cam')}</p>
-      </div>
     </div>
-  </ScreenLayout>
+  </div>
 )
 
 export default trackComponent(localised(Permissions))

--- a/src/components/CameraPermissions/Primer/style.scss
+++ b/src/components/CameraPermissions/Primer/style.scss
@@ -25,6 +25,11 @@
   width: 100%;
   padding: 10 * $unit-small;
   margin: auto;
+
+  // To fix Safari flexbox rendering issue by forcing the div to be rendered in a new composite laye,
+  // see https://stackoverflow.com/questions/65524383/flexbox-bug-on-safari -> https://stackoverflow.com/questions/19169089/weird-css-stretching-issue-in-ios7-safari-and-chrome
+  transform: translateZ(0);
+
   @media (--small-viewport) {
     max-width: 79 * $unit-x-small;
   }

--- a/src/components/CameraPermissions/Primer/style.scss
+++ b/src/components/CameraPermissions/Primer/style.scss
@@ -17,8 +17,14 @@
   height: auto;
   width: 100%;
   font-size: var(--font-size-small);
+  display: flex;
+  flex-direction: column;
+  flex: 2 1 32 * $unit-x-small;
   min-height: 32 * $unit-x-small;
   max-width: 105.01 * $unit-x-small;
+  width: 100%;
+  padding: 10 * $unit-small;
+  margin: auto;
   @media (--small-viewport) {
     max-width: 79 * $unit-x-small;
   }
@@ -26,6 +32,7 @@
 
 .reasons {
   font-size: var(--font-size-small);
+
   text-align: center;
   min-height: 42 * $unit-small;
 }
@@ -46,6 +53,7 @@
   @media (--small-viewport) {
     background-size: contain;
     flex-grow: 1; // prevents container height collapsing on iOS devices
+    height: 100%;
   }
 }
 

--- a/src/components/CameraPermissions/Primer/style.scss
+++ b/src/components/CameraPermissions/Primer/style.scss
@@ -26,7 +26,7 @@
   padding: 10 * $unit-small;
   margin: auto;
 
-  // To fix Safari flexbox rendering issue by forcing the div to be rendered in a new composite laye,
+  // To fix Safari flexbox rendering issue by forcing the div to be rendered in a new composite layer,
   // see https://stackoverflow.com/questions/65524383/flexbox-bug-on-safari -> https://stackoverflow.com/questions/19169089/weird-css-stretching-issue-in-ios7-safari-and-chrome
   transform: translateZ(0);
 

--- a/src/components/PageTitle/style.scss
+++ b/src/components/PageTitle/style.scss
@@ -30,7 +30,7 @@
   margin: 32 * $unit 0 16 * $unit;
   flex-shrink: 0;
 
-  // To fix Safari flexbox rendering issue by forcing the div to be rendered in a new composite laye,
+  // To fix Safari flexbox rendering issue by forcing the div to be rendered in a new composite layer,
   // see https://stackoverflow.com/questions/65524383/flexbox-bug-on-safari -> https://stackoverflow.com/questions/19169089/weird-css-stretching-issue-in-ios7-safari-and-chrome
   transform: translateZ(0);
 

--- a/src/components/PageTitle/style.scss
+++ b/src/components/PageTitle/style.scss
@@ -29,6 +29,11 @@
 .titleWrapper {
   margin: 32 * $unit 0 16 * $unit;
   flex-shrink: 0;
+
+  // To fix Safari flexbox rendering issue by forcing the div to be rendered in a new composite laye,
+  // see https://stackoverflow.com/questions/65524383/flexbox-bug-on-safari -> https://stackoverflow.com/questions/19169089/weird-css-stretching-issue-in-ios7-safari-and-chrome
+  transform: translateZ(0);
+
   @media (--small-viewport) {
     margin: 0 0 16 * $unit;
   }


### PR DESCRIPTION
# Problem
When fixing Safari desktop rendering issue for Camera Permission screen in release `6.10.1`, a regression was introduced that affects the layout on some devices, integrations.

Screenshot of regression
<img width="350" src="https://user-images.githubusercontent.com/2497081/124792234-bc02c380-df44-11eb-9b34-34a64ec9fb45.png" />

Screenshot of original issue this fixes 
<img width="350" src="https://user-images.githubusercontent.com/2497081/124791082-a640ce80-df43-11eb-87ff-478bef150b93.png" />

# Solution
Revert use of ScreenLayout component originally used to fix this issue and use an alternative method that avoids any change in existing SDK layout structure instead.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
