### PR TITLE
Add missing URL query option in CONTRIBUTING doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Fixed
 
-- UI: Fix camera view not lining up with Document Live Capture overlay.
+- UI: Fix camera view not lining up with Document Live Capture overlay and fix image distortion on some devices' live camera view by maintaining camera view aspect ratio.
 - Public: Fix file selector "capture" prop for WebSDK inside iOS WebView
 - Public: Fix `CROSS_DEVICE_START` user analytic event for integrators never being dispatched when user switches to the Cross Device flow
 - UI: Update copy in Face Liveness Video intro screen from 25s to 20s to reflect the correct time limit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,7 @@ Some of the SDK configuration options can also be previewed in the demo app by u
 | `useModal`                  | `true`,`false`      | `false` | Preview SDK as modal                                             |
 | `language`                  | `en`,`es`,`de`,`fr` | `en`    | Preview SDK in a different language                              |
 | `useWebcam`                 | `true`,`false`      | `false` | Enable the document auto capture feature for the `document` step |
+| `useLiveDocumentCapture`    | `true`,`false`      | `false` | Enable the live capture feature for the `document` step          |
 | `poa`                       | `true`,`false`      | `false` | Enable the `poa` flow                                            |
 | `oneDoc`                    | `true`,`false`      | `false` | Preselect `passport` as the only document type                   |
 | `region`                    | `US`,`CA`,`EU`      | `EU`    | Generate JWT for a supported region with SDK Token Factory       |


### PR DESCRIPTION
# Problem
CONTRIBUTING document is missing the `useLiveDocumentCapture` URL query parameter option for the Web SDK Demo App. 
CHANGELOG also needs to be clearer about the fix made for Document Live Capture camera view in PR #1477 

# Solution
- Update CONTRIBUTING document to include `useLiveDocumentCapture` option
- Update CHANGELOG note for Document Live Capture fix

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [x] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
