### PR TITLE
Fix/cx 6531 remove redundant locale keys in type definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 - UI: Fix camera view not lining up with Document Live Capture overlay.
 - Public: Fix file selector "capture" prop for WebSDK inside iOS WebView
+- Remove old locale key type definitions that are no longer used/exist in code base.
 
 ### Changed
 

--- a/src/components/utils/localesMapping.ts
+++ b/src/components/utils/localesMapping.ts
@@ -117,7 +117,6 @@ type ImageQualityResults = 'cutoff' | 'blur' | 'glare' | 'good'
 
 type ImageQualityGuideLocale = {
   label: string
-  alt: string
 }
 
 export const IMAGE_QUALITY_GUIDE_LOCALES_MAPPING: Record<
@@ -126,19 +125,15 @@ export const IMAGE_QUALITY_GUIDE_LOCALES_MAPPING: Record<
 > = {
   cutoff: {
     label: 'upload_guide.image_detail_cutoff_label',
-    alt: 'upload_guide.image_detail_cutoff_alt',
   },
   blur: {
     label: 'upload_guide.image_detail_blur_label',
-    alt: 'upload_guide.image_detail_blur_alt',
   },
   glare: {
     label: 'upload_guide.image_detail_glare_label',
-    alt: 'upload_guide.image_detail_glare_alt',
   },
   good: {
     label: 'upload_guide.image_detail_good_label',
-    alt: 'upload_guide.image_detail_good_alt',
   },
 }
 


### PR DESCRIPTION
# Problem
[localesMapping.ts](https://github.com/onfido/onfido-sdk-ui/blob/6.9.0/src/components/utils/localesMapping.ts) is referencing keys for Image Quality Guide screen's image alt text - `image_detail_good_alt`, `image_detail_glare_alt`, and `image_detail_cutoff_alt`. These keys have been removed following PR #1201 as alt text is not required on images (duplicating description in labels that screen readers already read out). Addresses #1455 

# Solution
Remove references to locale keys that are no longer in code base

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
