### PR TITLE
Fix incorrect changelog for 6.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This change log file is based on best practices from [Keep a Changelog](http://k
 This project adheres to [Semantic Versioning](http://semver.org/). Breaking changes result in a different MAJOR version. UI changes that might break customizations on top of the SDK will be treated as breaking changes too.
 This project adheres to the Node [default version scheme](https://docs.npmjs.com/misc/semver).
 
+## [next-version]
+
+### Fixed
+
+- UI: Fixed the text placement to be below the primary button in the Document Upload screen.
+
 ## [6.12.0] - 2021-08-10
 
 ### Fixed
@@ -15,20 +21,6 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Public: Fix `CROSS_DEVICE_START` user analytic event for integrators never being dispatched when user switches to the Cross Device flow
 - UI: Update copy in Face Liveness Video intro screen from 25s to 20s to reflect the correct time limit
 - Remove old locale key type definitions that are no longer used/exist in code base.
-
-### Changed
-
-- UI: Accessibility - Make "Tips" heading in Cross Device SMS Sent and Mobile Connected screens a level 3 heading.
-- UI: Accessibility - Change Cross Device Send Link alternate option text to be an ARIA heading level 2
-
-### Fixed
-
-- UI: Fix camera view not lining up with Document Live Capture overlay and fix image distortion on some devices' live camera view by maintaining camera view aspect ratio.
-- Public: Fix file selector "capture" prop for WebSDK inside iOS WebView
-- Public: Fix `CROSS_DEVICE_START` user analytic event for integrators never being dispatched when user switches to the Cross Device flow
-- UI: Update copy in Face Liveness Video intro screen from 25s to 20s to reflect the correct time limit
-- Remove old locale key type definitions that are no longer used/exist in code base.
-- UI: Fixed the text placement to be below the primary button in the Document Upload screen.
 
 ### Changed
 


### PR DESCRIPTION
# Problem

There was a mistake with auto-merge in #1530 

# Solution

Cherry-pick the new changelog to `[next-version]`

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [n/a] Has the CHANGELOG been updated?
- [n/a] Has the README been updated?
- [n/a] Has the CONTRIBUTING doc been updated?
- [n/a] Has the RELEASE_GUIDELINES been updated?
- [n/a] Has the TESTING_GUIDELINES been updated?
- [n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [n/a] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a] Have any new automated tests been implemented or the existing ones changed?
- [n/a] Have any new manual tests been written down or the existing ones changed?
- [n/a] Have any new strings been translated or the existing ones changed?
