### PR TITLE
Access cross-device link multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Fixed
 
 - UI: Fixed the text placement to be below the primary button in the Document Upload screen.
+- Public: Fixed cross-device connection issue when cross-device link is accessed multiple times.
 
 ## [6.12.0] - 2021-08-10
 

--- a/src/components/App/ModalApp.tsx
+++ b/src/components/App/ModalApp.tsx
@@ -78,7 +78,11 @@ class ModalApp extends Component<Props> {
   }
 
   componentWillUnmount() {
-    this.props.socket && this.props.socket.close()
+    const { roomId, socket } = this.props
+    if (socket) {
+      roomId && socket.emit('leave', { roomId })
+      socket.close()
+    }
     this.events.removeAllListeners(['complete', 'error'])
     Tracker.uninstall()
   }

--- a/src/components/crossDevice/MobileFlow.js
+++ b/src/components/crossDevice/MobileFlow.js
@@ -17,8 +17,7 @@ class MobileFlow extends Component {
     this.props.socket.off('get config')
     this.props.socket.off('client success')
     this.props.socket.off('user analytics')
-    const { socket, roomId, actions } = this.props
-    socket.emit('leave', { roomId })
+    const { actions } = this.props
     actions.mobileConnected(false)
   }
 


### PR DESCRIPTION
# Problem
The cross-device link can only be opened once. When attempting to open it a second time the user sees a loading screen.

# Solution
Only disconnect cross-device communication when the SDK is unmounted, instead of disconnecting when the cross-device component is unmounted.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
