### PR TITLE
Task/cx 6848 add ff to list of e2e browsers

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
-      - name: Run e2e tests on Chrome, Safari and MS Edge (local) (Firefox to follow)
+      - name: Run e2e tests on Chrome, Safari, MS Edge and Firefox (local)
         run: npm run test:e2e:local

--- a/test/prode2elocal.json
+++ b/test/prode2elocal.json
@@ -15,6 +15,10 @@
         {
           "browserName": "MicrosoftEdge",
           "remote": false
+        },
+        {
+          "browserName": "firefox",
+          "remote": false
         }
       ]
     }


### PR DESCRIPTION
# Problem
FF is not part of the current list of browsers that run as part of the small set of e2e tests that run against latest-surge.
# Solution
Add FF to the list
## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
