### PR TITLE
Get IE 11 automation tests working on BrowserStack

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -21,7 +21,7 @@
           "os_version": "10",
           "resolution": "1920x1080",
           "remote": true,
-          "name": "multipleBrowsersDocumentUpload"
+          "name": "Firefox - multipleBrowsersDocumentUpload"
         },
         {
           "browserName": "Edge",
@@ -30,7 +30,16 @@
           "os_version": "10",
           "resolution": "1920x1080",
           "remote": true,
-          "name": "multipleBrowsersDocumentUpload"
+          "name": "Edge - multipleBrowsersDocumentUpload"
+        },
+        {
+          "browserName": "IE",
+          "browser_version": "11.0",
+          "os": "Windows",
+          "os_version": "10",
+          "resolution": "1920x1080",
+          "remote": true,
+          "name": "IE - multipleBrowsersDocumentUpload"
         }
       ]
     }

--- a/test/pageobjects/DocumentUpload.js
+++ b/test/pageobjects/DocumentUpload.js
@@ -6,23 +6,18 @@ class DocumentUpload extends BasePage {
   async crossDeviceHeader() {
     return this.$('.onfido-sdk-ui-crossDevice-SwitchDevice-header')
   }
-
   async switchToCrossDeviceButton() {
     return this.$('.onfido-sdk-ui-Uploader-crossDeviceButton')
   }
-
   async uploaderIcon() {
     return this.$('.onfido-sdk-ui-Uploader-icon')
   }
-
   async uploaderBtn() {
     return this.$('[data-onfido-qa="uploaderButtonLink"]')
   }
-
   async uploadInput() {
     return this.$('.onfido-sdk-ui-CustomFileInput-input')
   }
-
   async getUploadInput() {
     const input = this.uploadInput()
     this.driver.executeScript((el) => {

--- a/test/pageobjects/DocumentUpload.js
+++ b/test/pageobjects/DocumentUpload.js
@@ -18,6 +18,7 @@ class DocumentUpload extends BasePage {
   async uploadInput() {
     return this.$('.onfido-sdk-ui-CustomFileInput-input')
   }
+
   async getUploadInput() {
     const input = this.uploadInput()
     this.driver.executeScript((el) => {
@@ -86,4 +87,5 @@ class DocumentUpload extends BasePage {
     }
   }
 }
+
 export default DocumentUpload

--- a/test/pageobjects/DocumentUpload.js
+++ b/test/pageobjects/DocumentUpload.js
@@ -1,16 +1,20 @@
 import BasePage from './BasePage.js'
 import { verifyElementCopy } from '../utils/mochaw'
+import { browserName, isRemoteBrowser } from '../main'
 
 class DocumentUpload extends BasePage {
   async crossDeviceHeader() {
     return this.$('.onfido-sdk-ui-crossDevice-SwitchDevice-header')
   }
+
   async switchToCrossDeviceButton() {
     return this.$('.onfido-sdk-ui-Uploader-crossDeviceButton')
   }
+
   async uploaderIcon() {
     return this.$('.onfido-sdk-ui-Uploader-icon')
   }
+
   async uploaderBtn() {
     return this.$('[data-onfido-qa="uploaderButtonLink"]')
   }
@@ -18,6 +22,7 @@ class DocumentUpload extends BasePage {
   async uploadInput() {
     return this.$('.onfido-sdk-ui-CustomFileInput-input')
   }
+
   async getUploadInput() {
     const input = this.uploadInput()
     this.driver.executeScript((el) => {
@@ -79,6 +84,11 @@ class DocumentUpload extends BasePage {
   async clickUploadButton() {
     this.uploaderBtn().click()
   }
-}
 
+  async clickUploadButtonIfRemoteIe() {
+    if (browserName === 'IE' && isRemoteBrowser === true) {
+      await this.clickUploadButton()
+    }
+  }
+}
 export default DocumentUpload

--- a/test/specs/multipleBrowsersDocumentUpload.js
+++ b/test/specs/multipleBrowsersDocumentUpload.js
@@ -63,6 +63,7 @@ describe(
       documentSelector.clickOnIdentityCardIcon()
       countrySelector.selectSupportedCountry()
       countrySelector.clickSubmitDocumentButton()
+      documentUpload.clickUploadButtonIfRemoteIe()
       uploadFileAndClickConfirmButton(
         documentUpload,
         confirm,


### PR DESCRIPTION
# Problem
Currently, we don't actively run any automation tests against IE 11 on BrowserStack. 
# Solution
This initial change/addition will allow us to run an initial set of upload tests against IE 11 on BrowserStack.
## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [x] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
