### PR TITLE
Add option to focus on Welcome title

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ The custom options are:
 - `title` (string)
 - `descriptions` ([string])
 - `nextButton` (string)
+- `focused` (boolean)
 
 #### userConsent
 

--- a/src/components/PageTitle/index.tsx
+++ b/src/components/PageTitle/index.tsx
@@ -12,6 +12,7 @@ type Props = {
   smaller?: boolean
   subTitle?: string
   title: string
+  focused?: boolean
 }
 
 const PageTitle: FunctionComponent<Props> = ({
@@ -19,6 +20,7 @@ const PageTitle: FunctionComponent<Props> = ({
   subTitle,
   smaller,
   className,
+  focused
 }) => {
   const isFullScreen = useSelector<RootState, boolean | undefined>(
     (state) => state.globals.isFullScreen
@@ -26,7 +28,7 @@ const PageTitle: FunctionComponent<Props> = ({
   const containerRef = useRef<HTMLSpanElement>(null)
 
   useEffect(() => {
-    containerRef.current && containerRef.current.focus()
+    containerRef.current && focused && containerRef.current.focus()
   }, [title, subTitle])
 
   return (

--- a/src/components/Welcome/index.tsx
+++ b/src/components/Welcome/index.tsx
@@ -62,6 +62,7 @@ const Welcome: FunctionComponent<StepComponentBaseProps> = ({
     title: customTitle,
     descriptions: customDescriptions,
     nextButton: customNextButtonLabel,
+    focused,
   } = welcomeStep?.options || {}
 
   const documentStep = findStep('document')
@@ -78,7 +79,10 @@ const Welcome: FunctionComponent<StepComponentBaseProps> = ({
 
   return (
     <ScreenLayout actions={actions} className={style.container}>
-      <PageTitle title={welcomeTitle} subTitle={welcomeSubTitle} />
+      <PageTitle
+        title={welcomeTitle}
+        subTitle={welcomeSubTitle}
+        focused={focused}/>
       {forDocVideo ? (
         <DocVideoContent captureSteps={captureSteps} />
       ) : (

--- a/src/types/steps.ts
+++ b/src/types/steps.ts
@@ -47,6 +47,7 @@ export type StepOptionWelcome = {
   title?: string
   descriptions?: string[]
   nextButton?: string
+  focused?: boolean
 }
 
 export type StepOptionAuth = { retries?: number }


### PR DESCRIPTION
# Problem

https://github.com/onfido/onfido-sdk-ui/issues/1539

# Solution

Add a `focused` property to the Welcome step.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [x] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
