### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ For the face step an object is returned with the `variant` used for the face cap
     }
 ```
 
-For the Auth step a data object is returned with parameters `sucess`, `token`, `type`, and `uuid`. The `success` variable informs whether or not the user was authenticated successfuly, whereas `token` is a JWT that can be used to validate the user authentication.
+For the Auth step a data object is returned with parameters `success`, `token`, `type`, and `uuid`. The `success` variable informs whether or not the user was authenticated successfuly, whereas `token` is a JWT that can be used to validate the user authentication.
 
 **Example of an auth `onComplete` data callback:**
 


### PR DESCRIPTION
Corrected a typo in the documentation.

# Problem
There was a typo in the documentation https://documentation.onfido.com/sdk/web/#oncomplete-function-optional? The line "For the Auth step a data object is returned with parameters sucess, token, type, and uuid." has a typo, success should have a double C
# Solution
Fixed the typo
## Checklist

_put `n/a` if item is not relevant to PR changes_

- [n/a] Has the CHANGELOG been updated?
- [X] Has the README been updated?
- [n/a] Has the CONTRIBUTING doc been updated?
- [n/a] Has the RELEASE_GUIDELINES been updated?
- [n/a] Has the TESTING_GUIDELINES been updated?
- [n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [n/a ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a] Have any new automated tests been implemented or the existing ones changed?
- [n/a] Have any new manual tests been written down or the existing ones changed?
- [n/a] Have any new strings been translated or the existing ones changed?
