### PR TITLE
Bugfix/cx 5266 handle live_videos validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - UI: Added new Intro screen when user begins the Cross Device flow on their mobile device.
 - Public: Added SDK configuration options for integrators to customize product name, copy and/or logo image for the new Cross Device Mobile Client Intro screen.
 
+### Fixed
+
+- Public: Video element errors and validation errors returned by live_videos endpoint are handled by the Web SDK
+
 ## [6.13.0] - 2021-08-23
 
 ### Added

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -15,6 +15,10 @@ The **English**, **Spanish**, **German**, **French**, **Italian** and **Portugue
 - `cross_device_session_linked.subtitle`
 - `cross_device_session_linked.title`
 
+### Changed strings
+
+- `generic.errors.request_error.message`
+
 ## `6.11.1` -> `6.12.0`
 
 The **English**, **Spanish**, **German**, **French**, **Italian** and **Portuguese** copy for the following string(s) has changed:

--- a/src/components/CaptureViewer/CaptureVideoViewer.tsx
+++ b/src/components/CaptureViewer/CaptureVideoViewer.tsx
@@ -1,24 +1,33 @@
 import { h, FunctionComponent } from 'preact'
 import classNames from 'classnames'
 import { withBlobPreviewUrl } from './hocs'
+import { trackException } from '../../Tracker'
 import style from './style.scss'
 
 type CaptureVideoViewerProps = {
   ariaLabel: string
   className?: string
   previewUrl?: string
+  onVideoError: () => void
 }
 
 const CaptureVideoViewer: FunctionComponent<CaptureVideoViewerProps> = ({
   ariaLabel,
   className,
   previewUrl,
+  onVideoError,
 }) => (
   <div className={classNames(style.videoWrapper, className)}>
     <video
       aria-label={ariaLabel}
       className={style.video}
       src={previewUrl}
+      onError={(event) => {
+        const target = event.target as HTMLVideoElement
+        const error = target.error as MediaError
+        trackException(`${error.code} - ${error.message}`)
+        onVideoError()
+      }}
       controls
     />
   </div>

--- a/src/components/CaptureViewer/__tests__/CaptureVideoViewer.test.tsx
+++ b/src/components/CaptureViewer/__tests__/CaptureVideoViewer.test.tsx
@@ -8,6 +8,7 @@ jest.mock('~utils/objectUrl')
 const defaultProps = {
   ariaLabel: 'Fake aria-label',
   blob: new Blob([]),
+  onVideoError: jest.fn(),
 }
 
 describe('CaptureViewer', () => {

--- a/src/components/CaptureViewer/index.tsx
+++ b/src/components/CaptureViewer/index.tsx
@@ -14,6 +14,7 @@ type Props = {
   isFullScreen?: boolean
   imageAltTag?: string
   videoAriaLabel?: string
+  onVideoError: () => void
 }
 
 const CaptureViewer: FunctionComponent<Props> = ({

--- a/src/components/CaptureViewer/index.tsx
+++ b/src/components/CaptureViewer/index.tsx
@@ -14,7 +14,7 @@ type Props = {
   isFullScreen?: boolean
   imageAltTag?: string
   videoAriaLabel?: string
-  onVideoError: () => void
+  onVideoError?: () => void
 }
 
 const CaptureViewer: FunctionComponent<Props> = ({
@@ -24,7 +24,8 @@ const CaptureViewer: FunctionComponent<Props> = ({
   isFullScreen,
   imageAltTag,
   videoAriaLabel = 'Video preview',
-  onVideoError,
+  onVideoError = () =>
+    console.error('An unexpected Video Preview error has occurred'),
 }) => {
   if (isOfMimeType(['pdf'], blob)) {
     return <PdfViewer blob={blob} />

--- a/src/components/CaptureViewer/index.tsx
+++ b/src/components/CaptureViewer/index.tsx
@@ -23,6 +23,7 @@ const CaptureViewer: FunctionComponent<Props> = ({
   isFullScreen,
   imageAltTag,
   videoAriaLabel = 'Video preview',
+  onVideoError,
 }) => {
   if (isOfMimeType(['pdf'], blob)) {
     return <PdfViewer blob={blob} />
@@ -34,6 +35,7 @@ const CaptureViewer: FunctionComponent<Props> = ({
         ariaLabel={videoAriaLabel}
         blob={blob}
         className={className}
+        onVideoError={onVideoError}
       />
     )
   }

--- a/src/components/Confirm/Confirm.js
+++ b/src/components/Confirm/Confirm.js
@@ -30,6 +30,7 @@ const CALLBACK_TYPES = {
   video: 'onSubmitVideo',
   document: 'onSubmitDocument',
 }
+const UNEXPECTED_ERROR = 'REQUEST_ERROR'
 class Confirm extends Component {
   constructor(props) {
     super(props)
@@ -86,15 +87,17 @@ class Confirm extends Component {
       this.props.triggerOnError({ status, response })
       return this.props.crossDeviceClientError()
     } else if (status === 422) {
-      errorKey = this.onfidoErrorReduce(response.error) || 'REQUEST_ERROR'
+      errorKey = this.onfidoErrorReduce(response.error) || UNEXPECTED_ERROR
     } else {
       this.props.triggerOnError({ status, response })
       trackException(`${status} - ${response}`)
-      errorKey = 'REQUEST_ERROR'
+      errorKey = UNEXPECTED_ERROR
     }
 
     this.setError(errorKey)
   }
+
+  onVideoPreviewError = () => this.setError(UNEXPECTED_ERROR)
 
   imageQualityWarnings = (warnings) => {
     for (const warnKey in IMAGE_QUALITY_KEYS_MAP) {
@@ -387,6 +390,7 @@ class Confirm extends Component {
         documentType={documentType}
         poaDocumentType={poaDocumentType}
         forceRetake={error.type === 'error'}
+        onVideoError={this.onVideoPreviewError}
       />
     )
   }

--- a/src/components/Confirm/Confirm.js
+++ b/src/components/Confirm/Confirm.js
@@ -31,6 +31,7 @@ const CALLBACK_TYPES = {
   document: 'onSubmitDocument',
 }
 const UNEXPECTED_ERROR = 'REQUEST_ERROR'
+
 class Confirm extends Component {
   constructor(props) {
     super(props)

--- a/src/components/Confirm/Previews.js
+++ b/src/components/Confirm/Previews.js
@@ -61,6 +61,7 @@ const Previews = ({
   isFullScreen,
   isUploading,
   forceRetake,
+  onVideoError,
 }) => {
   const { translate } = useLocales()
   const methodNamespace = getNamespace(method, capture.variant)
@@ -131,6 +132,7 @@ const Previews = ({
             isFullScreen,
             imageAltTag,
             videoAriaLabel,
+            onVideoError,
           }}
         />
         {!isFullScreen && <p className={style.message}>{message}</p>}

--- a/src/components/Confirm/Previews.js
+++ b/src/components/Confirm/Previews.js
@@ -1,6 +1,6 @@
 import { h } from 'preact'
 import classNames from 'classnames'
-import { localised } from '../../locales'
+import { useLocales } from '../../locales'
 import CaptureViewer from '../CaptureViewer'
 import Actions from './Actions'
 import PageTitle from '../PageTitle'
@@ -50,89 +50,93 @@ const getNamespace = (method, variant) => {
   return 'doc_confirmation'
 }
 
-const Previews = localised(
-  ({
-    capture,
-    retakeAction,
-    confirmAction,
-    error,
-    method,
-    documentType,
-    poaDocumentType,
-    translate,
-    isFullScreen,
-    isUploading,
-    forceRetake,
-  }) => {
-    const methodNamespace = getNamespace(method, capture.variant)
-    /**
-     * Possible locale keys for `title`:
-     *  - doc_confirmation.title
-     *  - selfie_confirmation.title
-     *  - video_confirmation.title
-     */
-    const title = translate(`${methodNamespace}.title`)
+const Previews = ({
+  capture,
+  retakeAction,
+  confirmAction,
+  error,
+  method,
+  documentType,
+  poaDocumentType,
+  isFullScreen,
+  isUploading,
+  forceRetake,
+}) => {
+  const { translate } = useLocales()
+  const methodNamespace = getNamespace(method, capture.variant)
+  /**
+   * Possible locale keys for `title`:
+   *  - doc_confirmation.title
+   *  - selfie_confirmation.title
+   *  - video_confirmation.title
+   */
+  const title = translate(`${methodNamespace}.title`)
 
-    /**
-     * Possible locale keys for `imageAltTag`:
-     *  - doc_confirmation.image_accessibility
-     *  - selfie_confirmation.image_accessibility
-     */
-    const imageAltTag = translate(`${methodNamespace}.image_accessibility`)
-    const videoAriaLabel = translate('video_confirmation.video_accessibility')
-    const message = translate(
-      getMessageKey({
-        capture,
-        documentType,
-        poaDocumentType,
+  /**
+   * Possible locale keys for `imageAltTag`:
+   *  - doc_confirmation.image_accessibility
+   *  - selfie_confirmation.image_accessibility
+   */
+  const imageAltTag = translate(`${methodNamespace}.image_accessibility`)
+  const videoAriaLabel = translate('video_confirmation.video_accessibility')
+  const message = translate(
+    getMessageKey({
+      capture,
+      documentType,
+      poaDocumentType,
+      error,
+      forceRetake,
+      method,
+    })
+  )
+  const actions = (
+    <Actions
+      {...{
+        retakeAction,
+        confirmAction,
+        isUploading,
         error,
         forceRetake,
-        method,
-      })
-    )
-    const actions = (
-      <Actions
-        {...{
-          retakeAction,
-          confirmAction,
-          isUploading,
-          error,
-          forceRetake,
-        }}
-      />
-    )
+      }}
+    />
+  )
 
-    return (
-      <ScreenLayout actions={!isFullScreen && actions}>
-        <div
-          className={classNames(
-            style.previewsContainer,
-            theme.fullHeightContainer,
-            {
-              [style.previewsContainerIsFullScreen]: isFullScreen,
-            }
-          )}
-        >
-          {isFullScreen ? null : error.type ? (
-            <Error
-              {...{
-                error,
-                withArrow: true,
-                role: 'alert',
-                focusOnMount: false,
-              }}
-            />
-          ) : (
-            <PageTitle title={title} smaller={true} className={style.title} />
-          )}
-          <CaptureViewer
-            {...{ capture, method, isFullScreen, imageAltTag, videoAriaLabel }}
+  return (
+    <ScreenLayout actions={!isFullScreen && actions}>
+      <div
+        className={classNames(
+          style.previewsContainer,
+          theme.fullHeightContainer,
+          {
+            [style.previewsContainerIsFullScreen]: isFullScreen,
+          }
+        )}
+      >
+        {isFullScreen ? null : error.type ? (
+          <Error
+            {...{
+              error,
+              withArrow: true,
+              role: 'alert',
+              focusOnMount: false,
+            }}
           />
-          {!isFullScreen && <p className={style.message}>{message}</p>}
-        </div>
-      </ScreenLayout>
-    )
-  }
-)
+        ) : (
+          <PageTitle title={title} smaller={true} className={style.title} />
+        )}
+        <CaptureViewer
+          {...{
+            capture,
+            method,
+            isFullScreen,
+            imageAltTag,
+            videoAriaLabel,
+          }}
+        />
+        {!isFullScreen && <p className={style.message}>{message}</p>}
+      </div>
+    </ScreenLayout>
+  )
+}
 
 export default Previews

--- a/src/components/Confirm/Previews.js
+++ b/src/components/Confirm/Previews.js
@@ -1,6 +1,6 @@
 import { h } from 'preact'
 import classNames from 'classnames'
-import { useLocales } from '../../locales'
+import { localised } from '../../locales'
 import CaptureViewer from '../CaptureViewer'
 import Actions from './Actions'
 import PageTitle from '../PageTitle'
@@ -50,95 +50,97 @@ const getNamespace = (method, variant) => {
   return 'doc_confirmation'
 }
 
-const Previews = ({
-  capture,
-  retakeAction,
-  confirmAction,
-  error,
-  method,
-  documentType,
-  poaDocumentType,
-  isFullScreen,
-  isUploading,
-  forceRetake,
-  onVideoError,
-}) => {
-  const { translate } = useLocales()
-  const methodNamespace = getNamespace(method, capture.variant)
-  /**
-   * Possible locale keys for `title`:
-   *  - doc_confirmation.title
-   *  - selfie_confirmation.title
-   *  - video_confirmation.title
-   */
-  const title = translate(`${methodNamespace}.title`)
+const Previews = localised(
+  ({
+    capture,
+    retakeAction,
+    confirmAction,
+    error,
+    method,
+    documentType,
+    poaDocumentType,
+    translate,
+    isFullScreen,
+    isUploading,
+    forceRetake,
+    onVideoError,
+  }) => {
+    const methodNamespace = getNamespace(method, capture.variant)
+    /**
+     * Possible locale keys for `title`:
+     *  - doc_confirmation.title
+     *  - selfie_confirmation.title
+     *  - video_confirmation.title
+     */
+    const title = translate(`${methodNamespace}.title`)
 
-  /**
-   * Possible locale keys for `imageAltTag`:
-   *  - doc_confirmation.image_accessibility
-   *  - selfie_confirmation.image_accessibility
-   */
-  const imageAltTag = translate(`${methodNamespace}.image_accessibility`)
-  const videoAriaLabel = translate('video_confirmation.video_accessibility')
-  const message = translate(
-    getMessageKey({
-      capture,
-      documentType,
-      poaDocumentType,
-      error,
-      forceRetake,
-      method,
-    })
-  )
-  const actions = (
-    <Actions
-      {...{
-        retakeAction,
-        confirmAction,
-        isUploading,
+    /**
+     * Possible locale keys for `imageAltTag`:
+     *  - doc_confirmation.image_accessibility
+     *  - selfie_confirmation.image_accessibility
+     */
+    const imageAltTag = translate(`${methodNamespace}.image_accessibility`)
+    const videoAriaLabel = translate('video_confirmation.video_accessibility')
+    const message = translate(
+      getMessageKey({
+        capture,
+        documentType,
+        poaDocumentType,
         error,
         forceRetake,
-      }}
-    />
-  )
+        method,
+      })
+    )
+    const actions = (
+      <Actions
+        {...{
+          retakeAction,
+          confirmAction,
+          isUploading,
+          error,
+          forceRetake,
+        }}
+      />
+    )
 
-  return (
-    <ScreenLayout actions={!isFullScreen && actions}>
-      <div
-        className={classNames(
-          style.previewsContainer,
-          theme.fullHeightContainer,
-          {
-            [style.previewsContainerIsFullScreen]: isFullScreen,
-          }
-        )}
-      >
-        {isFullScreen ? null : error.type ? (
-          <Error
+    return (
+      <ScreenLayout actions={!isFullScreen && actions}>
+        <div
+          className={classNames(
+            style.previewsContainer,
+            theme.fullHeightContainer,
+            {
+              [style.previewsContainerIsFullScreen]: isFullScreen,
+            }
+          )}
+        >
+          {isFullScreen ? null : error.type ? (
+            <Error
+              {...{
+                error,
+                withArrow: true,
+                role: 'alert',
+                focusOnMount: false,
+              }}
+            />
+          ) : (
+            <PageTitle title={title} smaller={true} className={style.title} />
+          )}
+          <CaptureViewer
             {...{
-              error,
-              withArrow: true,
-              role: 'alert',
-              focusOnMount: false,
+              capture,
+              method,
+              isFullScreen,
+              imageAltTag,
+              videoAriaLabel,
+              onVideoError,
             }}
           />
-        ) : (
-          <PageTitle title={title} smaller={true} className={style.title} />
-        )}
-        <CaptureViewer
-          {...{
-            capture,
-            method,
-            isFullScreen,
-            imageAltTag,
-            videoAriaLabel,
-            onVideoError,
-          }}
-        />
-        {!isFullScreen && <p className={style.message}>{message}</p>}
-      </div>
-    </ScreenLayout>
-  )
-}
+          {!isFullScreen && <p className={style.message}>{message}</p>}
+        </div>
+      </ScreenLayout>
+    )
+  }
+)
 
 export default Previews

--- a/src/locales/de_DE/de_DE.json
+++ b/src/locales/de_DE/de_DE.json
@@ -284,7 +284,7 @@
             },
             "request_error": {
                 "instruction": "Bitte versuchen Sie es erneut",
-                "message": "Verbindung unterbrochen"
+                "message": "Etwas ist schiefgelaufen"
             },
             "sms_failed": {
                 "instruction": "Kopieren Sie den Link auf Ihr Mobiltelefon",

--- a/src/locales/en_US/en_US.json
+++ b/src/locales/en_US/en_US.json
@@ -284,7 +284,7 @@
             },
             "request_error": {
                 "instruction": "Please try again",
-                "message": "Connection lost"
+                "message": "Something’s gone wrong"
             },
             "sms_failed": {
                 "instruction": "Copy the link to your phone",

--- a/src/locales/es_ES/es_ES.json
+++ b/src/locales/es_ES/es_ES.json
@@ -284,7 +284,7 @@
             },
             "request_error": {
                 "instruction": "Inténtalo de nuevo",
-                "message": "Conexión perdida"
+                "message": "Algo salió mal"
             },
             "sms_failed": {
                 "instruction": "Copie el enlace a continuación en su dispositivo móvil",

--- a/src/locales/fr_FR/fr_FR.json
+++ b/src/locales/fr_FR/fr_FR.json
@@ -284,7 +284,7 @@
             },
             "request_error": {
                 "instruction": "Veuillez réessayer",
-                "message": "Connexion perdue"
+                "message": "Quelque chose ne va pas"
             },
             "sms_failed": {
                 "instruction": "Copier le lien sur votre mobile",

--- a/src/locales/it_IT/it_IT.json
+++ b/src/locales/it_IT/it_IT.json
@@ -197,7 +197,7 @@
             },
             "request_error": {
                 "instruction": "Riprova",
-                "message": "Connessione interrotta"
+                "message": "Si è verificato un errore"
             },
             "sms_failed": {
                 "instruction": "Copia il link nel tuo telefono",

--- a/src/locales/pt_PT/pt_PT.json
+++ b/src/locales/pt_PT/pt_PT.json
@@ -197,7 +197,7 @@
             },
             "request_error": {
                 "instruction": "Tente novamente",
-                "message": "Ligação perdida"
+                "message": "Ocorreu um erro"
             },
             "sms_failed": {
                 "instruction": "Copie a ligação para o seu telefone",


### PR DESCRIPTION
# Problem

When a user takes a video that is very short (and by very short I mean you literally have to click through the video buttons really really fast) and submit it, the Onfido API returns a validation error:

```
{"attachment_file_size":["File size must be larger than zero"],"attachment":["File size must be larger than zero"]}
```

The SDK does not have the `attachment_file_size` error in the list of validation errors, therefore the user might not see any error (they just see the spinner) or they see the generic error message that implies that the connection was lost.

This error or any errors from the `video` element in the Confirm screen's previewer should be handled by the SDK and displayed to the user so that they can be guided to retake the video. 

# Solution

For all unhandled API errors or unexpected SDK UI errors, user should see the generic "please try again" message (i.e currently - connection lost)
- the generic "connection lost, please try again" message should be updated to just say "something's gone wrong, please try again"

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [x] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
