### PR TITLE
Remove hardcoded eu region API url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 - Public: Fixed custom SDK body text color set in `customUI.colorContentBody` option not getting applied to Country Selector text input if an element level text colour has been set in host app/site's stylesheet.
 - UI: Fixed Country Selector dropdown menu closing on clicking on scrollbar.
+- Internal: Auth - Fetch correct API url from the redux store
 
 ## [6.13.0] - 2021-08-23
 

--- a/src/components/Auth/Auth.tsx
+++ b/src/components/Auth/Auth.tsx
@@ -1,7 +1,7 @@
 import { h, FunctionComponent } from 'preact'
 import { AuthCheckProcessor } from './AuthCheckProcessor'
 import { FaceTecSDK } from '~auth-sdk/FaceTecSDK.js/FaceTecSDK'
-import { getAuthCustomization } from './AuthConfig'
+import { getAuthCustomization, getAuthConfig } from './AuthConfig'
 import { FaceTecStrings } from './assets/FaceTecStrings'
 import type { WithLocalisedProps } from '~types/hocs'
 import type { StepComponentBaseProps } from '~types/routers'
@@ -10,7 +10,7 @@ import Loader from './assets/loaderSvg'
 import style from './style.scss'
 import { useLocales } from '~locales'
 import { useSdkOptions } from '~contexts'
-import { getAuthConfig } from '~utils/http'
+import { getUrlsFromJWT } from '~utils/jwt'
 
 type Props = StepComponentBaseProps & WithLocalisedProps
 
@@ -25,6 +25,7 @@ const AuthCapture: FunctionComponent<Props> = (props) => {
   const [, { findStep }] = useSdkOptions()
   const { translate } = useLocales()
   const retries = findStep('auth')?.options?.retries || 3
+  const apiUrl = getUrlsFromJWT(props.token).onfido_api_url
 
   const [authConfig, setAuthConfig] = useState<AuthConfigType>({
     token: '',
@@ -37,6 +38,7 @@ const AuthCapture: FunctionComponent<Props> = (props) => {
   const onLivenessCheckPressed = useCallback(() => {
     if (authConfig.token && props.token && props.nextStep) {
       new AuthCheckProcessor(
+        apiUrl,
         authConfig,
         retries,
         props.token,
@@ -79,6 +81,7 @@ const AuthCapture: FunctionComponent<Props> = (props) => {
     }
     const getConfig = () => {
       getAuthConfig(
+        apiUrl,
         `Bearer ${props.token}`,
         (success) => {
           const response = JSON.parse(success)

--- a/src/components/Auth/Auth.tsx
+++ b/src/components/Auth/Auth.tsx
@@ -10,7 +10,6 @@ import Loader from './assets/loaderSvg'
 import style from './style.scss'
 import { useLocales } from '~locales'
 import { useSdkOptions } from '~contexts'
-import { getUrlsFromJWT } from '~utils/jwt'
 
 type Props = StepComponentBaseProps & WithLocalisedProps
 
@@ -25,7 +24,7 @@ const AuthCapture: FunctionComponent<Props> = (props) => {
   const [, { findStep }] = useSdkOptions()
   const { translate } = useLocales()
   const retries = findStep('auth')?.options?.retries || 3
-  const apiUrl = getUrlsFromJWT(props.token).onfido_api_url
+  const apiUrl = props.urls.onfido_api_url
 
   const [authConfig, setAuthConfig] = useState<AuthConfigType>({
     token: '',

--- a/src/components/Auth/AuthCheckProcessor.ts
+++ b/src/components/Auth/AuthCheckProcessor.ts
@@ -1,5 +1,4 @@
 import { EventEmitter2 } from 'eventemitter2'
-import { BaseURL } from './AuthConfig'
 import { FaceTecSDK } from '~auth-sdk/FaceTecSDK.js/FaceTecSDK'
 import type {
   FaceTecSessionResult,
@@ -17,6 +16,7 @@ type AuthConfigType = {
 export class AuthCheckProcessor implements FaceTecFaceScanProcessor {
   latestNetworkRequest = new XMLHttpRequest()
   success
+  apiUrl
   sdkToken
   nextStep
   goBack
@@ -26,14 +26,16 @@ export class AuthCheckProcessor implements FaceTecFaceScanProcessor {
   maxRetries
 
   constructor(
+    apiUrl: string,
     authConfig: AuthConfigType,
     maxRetries: number,
-    sdkToken: string | undefined,
+    sdkToken: string,
     nextStep: () => void,
     goBack: () => void,
     events?: EventEmitter2.emitter
   ) {
     this.sdkToken = sdkToken
+    this.apiUrl = apiUrl
     this.success = false
     this.nextStep = nextStep
     this.goBack = goBack
@@ -96,7 +98,7 @@ export class AuthCheckProcessor implements FaceTecFaceScanProcessor {
     // Part 5:  Make the Networking Call to the Onfido Servers.
     //
     this.latestNetworkRequest = new XMLHttpRequest()
-    this.latestNetworkRequest.open('POST', `${BaseURL}/v3/auth_3d`)
+    this.latestNetworkRequest.open('POST', `${this.apiUrl}/v3/auth_3d`)
     this.latestNetworkRequest.setRequestHeader(
       'Authorization',
       `Bearer ${this.sdkToken}`

--- a/src/components/Auth/AuthCheckProcessor.ts
+++ b/src/components/Auth/AuthCheckProcessor.ts
@@ -26,7 +26,7 @@ export class AuthCheckProcessor implements FaceTecFaceScanProcessor {
   maxRetries
 
   constructor(
-    apiUrl: string,
+    apiUrl: string | undefined,
     authConfig: AuthConfigType,
     maxRetries: number,
     sdkToken: string,

--- a/src/components/Auth/AuthConfig.tsx
+++ b/src/components/Auth/AuthConfig.tsx
@@ -170,7 +170,7 @@ export const getAuthCustomization = (
 }
 
 export const getAuthConfig = (
-  apiUrl: string,
+  apiUrl: string | undefined,
   token: string,
   onSuccess: SuccessCallback<string>,
   onError: (error: ApiRawError) => void

--- a/src/components/Auth/AuthConfig.tsx
+++ b/src/components/Auth/AuthConfig.tsx
@@ -1,11 +1,11 @@
 import { loader } from './assets/loader'
 import { success } from './assets/success'
 import { borderRadius, color } from '@onfido/castor'
+import type { ApiRawError, SuccessCallback } from '~types/api'
 import { FaceTecCustomization } from '~auth-sdk/FaceTecSDK.js/FaceTecCustomization'
 import { FaceTecSDK } from '~auth-sdk/FaceTecSDK.js/FaceTecSDK'
 import { UICustomizationOptions } from '../../types/ui-customisation-options'
 
-export const BaseURL = process.env.AUTH_URL
 export const getAuthCustomization = (
   dimMode: boolean,
   customUI?: UICustomizationOptions
@@ -167,4 +167,29 @@ export const getAuthCustomization = (
   defaultCustomization.resultScreenCustomization.customActivityIndicatorAnimation = loaderSVG
 
   return defaultCustomization
+}
+
+export const getAuthConfig = (
+  apiUrl: string,
+  token: string,
+  onSuccess: SuccessCallback<string>,
+  onError: (error: ApiRawError) => void
+): void => {
+  const body = {
+    sdk_type: 'onfido_web_sdk',
+  }
+  const request = new XMLHttpRequest()
+
+  request.open('POST', `${apiUrl}/v3/auth_3d/session`)
+
+  request.setRequestHeader('Authorization', token)
+  request.setRequestHeader('Application-Id', 'com.onfido.onfidoAuth')
+  request.setRequestHeader('Content-Type', 'application/json')
+
+  request.onreadystatechange = function () {
+    if (this.readyState === XMLHttpRequest.DONE) {
+      onSuccess(this.responseText)
+    } else onError(request)
+  }
+  request.send(JSON.stringify(body))
 }

--- a/src/components/utils/http.ts
+++ b/src/components/utils/http.ts
@@ -37,27 +37,3 @@ export const performHttpReq = <T>(
 
   request.send(payload)
 }
-
-export const getAuthConfig = (
-  token: string,
-  onSuccess: SuccessCallback<string>,
-  onError: (error: ApiRawError) => void
-): void => {
-  const body = {
-    sdk_type: 'onfido_web_sdk',
-  }
-  const request = new XMLHttpRequest()
-
-  request.open('POST', `${process.env.AUTH_URL}/v3/auth_3d/session`)
-
-  request.setRequestHeader('Authorization', token)
-  request.setRequestHeader('Application-Id', 'com.onfido.onfidoAuth')
-  request.setRequestHeader('Content-Type', 'application/json')
-
-  request.onreadystatechange = function () {
-    if (this.readyState === XMLHttpRequest.DONE) {
-      onSuccess(this.responseText)
-    } else onError(request)
-  }
-  request.send(JSON.stringify(body))
-}

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -127,7 +127,6 @@ const PROD_CONFIG = {
   SMS_DELIVERY_URL: 'https://telephony.onfido.com',
   PUBLIC_PATH: `https://assets.onfido.com/web-sdk-releases/${packageJson.version}/`,
   USER_CONSENT_URL: 'https://assets.onfido.com/consent/user_consent.html',
-  AUTH_URL: 'https://api.eu.onfido.com',
   RESTRICTED_XDEVICE_FEATURE_ENABLED: true,
   WOOPRA_DOMAIN,
 }
@@ -162,7 +161,6 @@ const STAGING_CONFIG = {
   MOBILE_URL: '/',
   SMS_DELIVERY_URL: 'https://telephony.eu-west-1.dev.onfido.xyz',
   PUBLIC_PATH: '/',
-  AUTH_URL: 'https://api-gateway.eu-west-1.dev.onfido.xyz/',
   RESTRICTED_XDEVICE_FEATURE_ENABLED: false,
   WOOPRA_DOMAIN: WOOPRA_DEV_DOMAIN,
 


### PR DESCRIPTION
https://onfido.atlassian.net/browse/BIOMANU-1341

# Problem

Auth component is using hardcoded API URL

# Solution

The correct url to call can be fetched from the sdkToken used to initialize
the OnfidoAuth sdk.

This commit removes the EU BaseURL that was being used allowing the auth
sdk to be used in any given region.
## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
