### PR TITLE
Improvement/Disable noisy ESLint checks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
     '@typescript-eslint/no-var-requires': 'warn',
     '@typescript-eslint/ban-ts-comment': 'warn',
     /* Temporary disabled rules for React development */
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
     'react/no-did-mount-set-state': 'warn',
     'react/no-did-update-set-state': 'warn',
     /* @TODO decide a better way for props validation: PropTypes or typing system? */


### PR DESCRIPTION
# Problem

The current `eslint` configuration reports a lot of warnings:

```
✖ 789 problems (0 errors, 789 warnings)
```

which is both noisy and helpless in tracing and watching build logs.

The biggest portion comes from `@typescript-eslint/explicit-module-boundary-types` rule which reflects the fact that our TypeScript coverage is still low

# Solution

Disable `@typescript-eslint/explicit-module-boundary-types` ESLint rule to minimise the noise from `eslint` reports.

After doing this, it reports a much shorter list of decent checks:

```
✖ 48 problems (0 errors, 48 warnings)
```

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [n/a] Has the CHANGELOG been updated?
- [n/a] Has the README been updated?
- [n/a] Has the CONTRIBUTING doc been updated?
- [n/a] Has the RELEASE_GUIDELINES been updated?
- [n/a] Has the TESTING_GUIDELINES been updated?
- [n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [n/a] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a] Have any new automated tests been implemented or the existing ones changed?
- [n/a] Have any new manual tests been written down or the existing ones changed?
- [n/a] Have any new strings been translated or the existing ones changed?