### PR TITLE
Reset redux store when SDK is unmounted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ## [next-version]
 
+### Fixed:
+
+- Public: Fix issue where multiple SDK instances were sharing the same Redux store values. This was resulting in duplicate cross-device links across multiple instances. With this change, the redux store is reset every time one SDK instance is unmounted via the `tearDown()` function.
+
 ## [6.15.3] - 2021-11-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ## [next-version]
 
-### Fixed:
+### Fixed
 
 - Public: Fix issue where multiple SDK instances were sharing the same Redux store values. This was resulting in duplicate cross-device links across multiple instances. With this change, the redux store is reset every time one SDK instance is unmounted via the `tearDown()` function.
 

--- a/src/components/App/ModalApp.tsx
+++ b/src/components/App/ModalApp.tsx
@@ -86,13 +86,15 @@ class ModalApp extends Component<Props> {
   }
 
   componentWillUnmount() {
-    const { roomId, socket } = this.props
+    const { roomId, socket, actions } = this.props
+    // clean up event listeners, socket and redux store after tearDown is invoked and the SDK is unmounted
     if (socket) {
       roomId && socket.emit('leave', { roomId })
       socket.close()
     }
     this.events.removeAllListeners(['complete', 'error'])
     Tracker.uninstall()
+    actions.reset()
   }
 
   jwtValidation = (


### PR DESCRIPTION
# Problem
Currently, when the SDK is unmounted using the tearDown() function the redux store is not wiped out and if a client initialise the SDK again old values in the store might still be present.

# Solution
Make sure the redux store is reset when the SDK is unmounted 

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
