### PR TITLE
Explicitly set button type for Send Link button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ## [next-version]
 
+### Fixed
+
+- UI: Set the 'Send link' Button component on Cross Device Send SMS Link screen as `type="button"`to prevent the Button component defaulting to a `submit` type button when SDK is embedded within a `form` element.
+
 ## [6.15.4] - 2021-11-25
 
 ### Fixed

--- a/src/components/CameraPermissions/Primer/index.tsx
+++ b/src/components/CameraPermissions/Primer/index.tsx
@@ -29,6 +29,7 @@ const Permissions: FunctionComponent<Props> = ({ onNext, translate }) => (
     </div>
     <div className={classNames(theme.contentMargin, style.actions)}>
       <Button
+        type="button"
         variant="primary"
         className={classNames(theme['button-centered'], theme['button-lg'])}
         onClick={onNext}

--- a/src/components/Confirm/Actions.js
+++ b/src/components/Confirm/Actions.js
@@ -8,6 +8,7 @@ import style from './style.scss'
 
 const RetakeAction = localised(({ retakeAction, translate, singleAction }) => (
   <Button
+    type="button"
     onClick={retakeAction}
     variant={singleAction ? 'primary' : 'secondary'}
     className={
@@ -30,6 +31,7 @@ const RetakeAction = localised(({ retakeAction, translate, singleAction }) => (
 const ConfirmAction = localised(
   ({ confirmAction, isUploading, translate, error }) => (
     <Button
+      type="button"
       variant="primary"
       className={classNames(theme['button-sm'], {
         [theme.vertical]: isButtonGroupStacked(),

--- a/src/components/CountrySelector/index.tsx
+++ b/src/components/CountrySelector/index.tsx
@@ -170,6 +170,7 @@ class CountrySelection extends Component<Props, State> {
       <ScreenLayout
         actions={
           <Button
+            type="button"
             variant="primary"
             className={classNames(theme['button-centered'], theme['button-lg'])}
             disabled={

--- a/src/components/DocumentVideo/CaptureControls/__tests__/index.test.tsx
+++ b/src/components/DocumentVideo/CaptureControls/__tests__/index.test.tsx
@@ -49,6 +49,7 @@ const MockedDocumentVideo: FunctionComponent<MockedDocumentVideoProps> = ({
       />
       {withRestartButton && (
         <button
+          type="button"
           id="restartFlow"
           onClick={() =>
             setFlowRestartTrigger((prevTrigger) => prevTrigger + 1)

--- a/src/components/DocumentVideo/PaperIdFlowSelector/index.tsx
+++ b/src/components/DocumentVideo/PaperIdFlowSelector/index.tsx
@@ -34,7 +34,11 @@ const IdFlowButton: FunctionComponent<IdFlowButtonProps> = ({
   const { [idType]: titleKey } = BUTTON_COPY_BY_ID_TYPE
 
   return (
-    <button className={style[idType]} onClick={() => onClick(idType)}>
+    <button
+      type="button"
+      className={style[idType]}
+      onClick={() => onClick(idType)}
+    >
       <span className={style.icon} />
       <span className={style.text}>{translate(titleKey)}</span>
       <span className={style.chevron} />

--- a/src/components/EnlargedPreview/index.js
+++ b/src/components/EnlargedPreview/index.js
@@ -96,6 +96,7 @@ class EnlargedPreview extends Component {
           )}
         </div>
         <button
+          type="button"
           aria-labelledby="onfido-preview-button-label"
           className={classNames(style.button, style['button-overlay'])}
           onClick={this.toggle}

--- a/src/components/VideoCapture/__tests__/index.test.tsx
+++ b/src/components/VideoCapture/__tests__/index.test.tsx
@@ -67,6 +67,7 @@ const MockedCaptureControls: FunctionComponent<VideoOverlayProps> = ({
   onStop,
 }) => (
   <button
+    type="button"
     id="record-video"
     disabled={disableInteraction}
     onClick={isRecording ? onStop : onStart}

--- a/src/components/crossDevice/ClientIntro/index.tsx
+++ b/src/components/crossDevice/ClientIntro/index.tsx
@@ -31,6 +31,7 @@ const CrossDeviceClientIntro: FunctionComponent<Props> = ({
     <ScreenLayout
       actions={
         <Button
+          type="button"
           variant="primary"
           className={classNames(theme['button-centered'], theme['button-lg'])}
           onClick={nextStep}

--- a/src/components/crossDevice/CrossDeviceLink/index.js
+++ b/src/components/crossDevice/CrossDeviceLink/index.js
@@ -286,6 +286,7 @@ class CrossDeviceLinkUI extends Component {
               />
             </div>
             <Button
+              type="button"
               variant="primary"
               className={classNames(style.btn, { [style.sending]: sending })}
               onClick={this.handleSendSmsLinkClick}

--- a/src/demo/demo.tsx
+++ b/src/demo/demo.tsx
@@ -9,7 +9,9 @@ const Step1: FunctionComponent = () => (
   <div>
     <p className="qa-first-step-text">This is the first step</p>
     <Link to="/dummy-step-2">
-      <button className="qa-step-two-btn">Start</button>
+      <button type="button" className="qa-step-two-btn">
+        Start
+      </button>
     </Link>
   </div>
 )
@@ -20,7 +22,9 @@ const Step2: FunctionComponent = () => (
       This is a dummy step added to the demo app history
     </p>
     <Link to="/id-verification">
-      <button className="qa-start-verification-btn">Go to SDK</button>
+      <button type="button" className="qa-start-verification-btn">
+        Go to SDK
+      </button>
     </Link>
   </div>
 )


### PR DESCRIPTION
# Problem

The `Send link` button on the Cross Device flow's Send SMS screen does not have `type="button"` explicitly set for the `button` element so on integrations where the SDK is embedded within a `form` element the button defaults to a submit button behaviour on some browsers.

# Solution

Set `type="button"` for the Send Link button

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
