### PR TITLE
Chore/revert temp integration tests fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,11 @@ This change log file is based on best practices from [Keep a Changelog](http://k
 This project adheres to [Semantic Versioning](http://semver.org/). Breaking changes result in a different MAJOR version. UI changes that might break customizations on top of the SDK will be treated as breaking changes too.
 This project adheres to the Node [default version scheme](https://docs.npmjs.com/misc/semver).
 
-## [next-next-version]
+## [next-version]
 
 ### Changed
 
 - Upgrade `react-phone-number-input` to v3.1.38
-
-## [next-version]
 
 ## [6.15.5] - 2021-12-2
 

--- a/src/components/utils/__integrations__/helpers/mockExpiredJwtAndResponse.js
+++ b/src/components/utils/__integrations__/helpers/mockExpiredJwtAndResponse.js
@@ -1,7 +1,7 @@
 export const EXPIRED_JWT_TOKEN =
   'eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2MDc3MDc1NTEsInBheWxvYWQiOiJycUFvMEtSbXdtWlViWFRLUHp2TXlTaGZtelNDNVhtRWM3aVZ4ZzJ5b2NQbEQrbk9rQmxtcHBaK0FCKzBcbkwveEtYRm4yeTBNZGxNNXRXVE5HeVNVSG5nPT1cbiIsInV1aWQiOiJpd29rRlZlZEcxOCIsImVudGVycHJpc2VfZmVhdHVyZXMiOnsiY29icmFuZCI6dHJ1ZSwiaGlkZU9uZmlkb0xvZ28iOnRydWV9LCJ1cmxzIjp7InRlbGVwaG9ueV91cmwiOiJodHRwczovL3RlbGVwaG9ueS5vbmZpZG8uY29tIiwiZGV0ZWN0X2RvY3VtZW50X3VybCI6Imh0dHBzOi8vc2RrLm9uZmlkby5jb20iLCJzeW5jX3VybCI6Imh0dHBzOi8vc3luYy5vbmZpZG8uY29tIiwiYXV0aF91cmwiOiJodHRwczovL2VkZ2UuYXBpLm9uZmlkby5jb20iLCJvbmZpZG9fYXBpX3VybCI6Imh0dHBzOi8vYXBpLm9uZmlkby5jb20iLCJob3N0ZWRfc2RrX3VybCI6Imh0dHBzOi8veGQub25maWRvLmNvbSJ9fQ.Ece4NQpZLsPzsgd6W4kDYNugW66W_Fl__jfz6d96WEI'
 
-export const ORIGINAL_EXPECTED_EXPIRED_TOKEN_ERROR = {
+export const EXPECTED_EXPIRED_TOKEN_ERROR = {
   status: 401,
   response: {
     error: {
@@ -10,14 +10,4 @@ export const ORIGINAL_EXPECTED_EXPIRED_TOKEN_ERROR = {
       type: 'expired_token',
     },
   },
-}
-
-// FIXME: This expected empty response is intended as a temporary solution only to unblock CI builds.
-//        API endpoints for /documents, /live_photos, /live_videos was changed with the intention of
-//        returning the generic 'authorization_error' response, but currently is only an empty response
-//        when received by the SDK on error from the use of an expired token.
-//        To be fixed by IX team, see IX-1967
-export const EXPECTED_EXPIRED_TOKEN_ERROR = {
-  status: 0,
-  response: {},
 }

--- a/src/components/utils/__integrations__/onfidoApi/selfie.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/selfie.integration.js
@@ -13,7 +13,6 @@ import {
 import { API_URL, PATH_TO_RESOURCE_FILES } from '../helpers/testUrls'
 import {
   EXPIRED_JWT_TOKEN,
-  ORIGINAL_EXPECTED_EXPIRED_TOKEN_ERROR,
   EXPECTED_EXPIRED_TOKEN_ERROR,
 } from '../helpers/mockExpiredJwtAndResponse'
 
@@ -156,7 +155,7 @@ describe('API uploadSnapshot endpoint', () => {
     expect.hasAssertions()
     const onErrorCallback = (error) => {
       try {
-        expect(error).toEqual(ORIGINAL_EXPECTED_EXPIRED_TOKEN_ERROR)
+        expect(error).toEqual(EXPECTED_EXPIRED_TOKEN_ERROR)
         done()
       } catch (err) {
         done(err)
@@ -277,7 +276,7 @@ describe.skip('API sendMultiframeSelfie endpoint', () => {
     expect.hasAssertions()
     const onErrorCallback = (error) => {
       try {
-        expect(error).toEqual(ORIGINAL_EXPECTED_EXPIRED_TOKEN_ERROR)
+        expect(error).toEqual(EXPECTED_EXPIRED_TOKEN_ERROR)
         done()
       } catch (err) {
         done(err)

--- a/src/components/utils/__integrations__/onfidoApi/video.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/video.integration.js
@@ -8,7 +8,6 @@ import {
 import { API_URL, PATH_TO_RESOURCE_FILES } from '../helpers/testUrls'
 import {
   EXPIRED_JWT_TOKEN,
-  ORIGINAL_EXPECTED_EXPIRED_TOKEN_ERROR,
   EXPECTED_EXPIRED_TOKEN_ERROR,
 } from '../helpers/mockExpiredJwtAndResponse'
 
@@ -182,7 +181,7 @@ describe('API requestChallenges endpoint', () => {
     expect.hasAssertions()
     const onErrorCallback = (error) => {
       try {
-        expect(error).toEqual(ORIGINAL_EXPECTED_EXPIRED_TOKEN_ERROR)
+        expect(error).toEqual(EXPECTED_EXPIRED_TOKEN_ERROR)
         done()
       } catch (err) {
         done(err)


### PR DESCRIPTION
# Problem

Changes to the error response returned by API endpoints for uploading `documents`/`live_photos`/`live_videos` on attempting to upload a file with an expired JWT token has been reverted. 

# Solution

Revert temporary solution introduced in PR #1641 

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
