### PR TITLE
run unit tests before integration/ui tests to save time & costs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,6 +74,10 @@ jobs:
             NODE_ENV=staging npm run build
           fi
 
+      - name: Run unit tests
+        if: matrix.NODE_ENV == 'test'
+        run: npm run test:unit
+
       - name: Run integration tests
         if: matrix.NODE_ENV == 'test'
         run: npm run test:integration
@@ -81,10 +85,6 @@ jobs:
       - name: Run UI tests
         if: matrix.NODE_ENV == 'test'
         run: npm run test:ui
-
-      - name: Run unit tests
-        if: matrix.NODE_ENV == 'test'
-        run: npm run test:unit
 
       - name: Create Surge Domain
         if: ${{ matrix.NODE_ENV == 'production' || matrix.NODE_ENV == 'staging' }}


### PR DESCRIPTION
# Problem

UI tests are executed before unit tests. Fail early, therefore move the cheapest job first.

# Solution

Change order of test execution

## Checklist

- [n/a] Has the CHANGELOG been updated?
- [n/a] Has the README been updated?
- [n/a] Has the CONTRIBUTING doc been updated?
- [n/a] Has the RELEASE_GUIDELINES been updated?
- [n/a] Has the TESTING_GUIDELINES been updated?
- [n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [n/a] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a] Have any new automated tests been implemented or the existing ones changed?
- [n/a] Have any new manual tests been written down or the existing ones changed?
- [n/a] Have any new strings been translated or the existing ones changed?