### PR TITLE
Bugfix/update web sdk residence permit type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Changed
 
 - Upgrade `react-phone-number-input` to v3.1.38
+- Revert change to return document type as 'unknown' in `onComplete` callback payload if Residence Permit selected now that the API supports that document type for document uploads
 
 ## [6.15.5] - 2021-12-2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Changed
 
 - Upgrade `react-phone-number-input` to v3.1.38
-- Revert change to return document type as 'unknown' in `onComplete` callback payload if Residence Permit selected now that the API supports that document type for document uploads
+- Revert change which returns document type as 'unknown' in `onComplete` callback payload if Residence Permit selected. API now supports that document type for document uploads.
 
 ## [6.15.5] - 2021-12-2
 

--- a/src/components/Confirm/Confirm.js
+++ b/src/components/Confirm/Confirm.js
@@ -237,9 +237,7 @@ class Confirm extends Component {
         filename || blob?.name || `document_capture.${mimeType(blob)}`
       const data = {
         file: { blob, filename: blobName },
-        // API does not support 'residence_permit' type but does accept 'unknown'
-        // See https://documentation.onfido.com/#document-types
-        type: type === 'residence_permit' ? 'unknown' : type,
+        type,
         side,
         validations,
         sdkMetadata,


### PR DESCRIPTION
# Problem

The document type returned in the SDK's onComplete callback is being used by some customers for their check creation flow. API `/documents` endpoint previously did not support the `"residence_permit"` type so we had to replace it with `"unknown"`. Now that API support for this has been deployed to production, we can remove the code to do this type replacement.

# Solution

- Return `"residence_permit"` type as is
- Remove conditional to replace `"residence_permit"` type with `"unknown"`

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
