### PR TITLE
stop taking snapshots when selfie is being taken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Public: Added `autoFocusOnInitialScreenTitle` SDK configuration option for integrators to override SDK auto focusing on the SDK's initial screen title on loading. This default behaviour might not be desirable for some host apps or sites as this could cause the browser to focus on the SDK when there is content or form inputs outside of the SDK that the end user should see, fill in first.
 - Upgrade `react-phone-number-input` to v3.1.38
 - Revert change which returns document type as 'unknown' in `onComplete` callback payload if Residence Permit selected. API now supports that document type for document uploads.
+- Change the behavior when `useMultipleSelfieCapture` feature is enable to stop capturing periodic snapshots once the final selfie is being captured.
 
 ## [6.15.5] - 2021-12-2
 

--- a/src/components/Photo/Selfie.js
+++ b/src/components/Photo/Selfie.js
@@ -87,6 +87,9 @@ export default class SelfieCapture extends Component {
   }
 
   takeSelfie = () => {
+    // If we are already taking the selfie, we should stop taking snapshots to prevent them from being the
+    // same as the Selfie itself, causing the multiframe feature to fail.
+    this.stopSnapshots()
     this.setState({ isProcessingSelfie: true, isCaptureButtonDisabled: true })
     screenshot(this.webcam, this.handleSelfie)
   }
@@ -107,13 +110,17 @@ export default class SelfieCapture extends Component {
     }
   }
 
-  componentWillUnmount() {
+  stopSnapshots() {
     if (this.snapshotIntervalId) {
       clearInterval(this.snapshotIntervalId)
     }
     if (this.initialSnapshotTimeoutId) {
       clearTimeout(this.initialSnapshotTimeoutId)
     }
+  }
+
+  componentWillUnmount() {
+    this.stopSnapshots()
   }
 
   render() {


### PR DESCRIPTION
# Problem

In some rare cases, a concurrency problem seems to be happening when `useMultipleSelfieCapture` feature is enabled and we take periodic snapshots to compare with the Selfie where the snapshot and the Selfie are the same.

# Solution

Immediately stop taking snapshots once the Selfie is being taken to avoid that a snapshot is taken at the same time as the Selfie, causing the binaries to be exactly the same.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
