### PR TITLE
Chore/update links to `demoUtils.js` file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ Some of the SDK configuration options can also be previewed in the demo app by u
 | `autoFocusOnInitialScreenTitle`           | `true`,`false`      | `true`  | Override SDK's default focus behaviour to auto focus on each screen's title. This override only applies to the initial screen's title. |
 
 Usage example: https://localhost:8080?faceVideo=true&language=de
-Please refer to [this file](./src/demo/demoUtils.js) for more available options.
+Please refer to [this file](./src/demo/demoUtils.ts) for more available options.
 
 ## WebSDK inside native or React Native apps
 

--- a/src/demo/README.md
+++ b/src/demo/README.md
@@ -16,4 +16,4 @@ in of custom SDK options, if the sidebar isn't precise enough.
 
 You can put in query params to quickly configure the SDK as you like. You can
 see the params that have an impact easily in `getInitSdkOptions`, in the
-`demoUtils.js` file.
+`demoUtils.ts` file.


### PR DESCRIPTION
# Problem

Web SDK's `CONTRIBUTING` and the Demo App's `README` have references to a `demoUtils.js` file that is now named `demoUtils.ts` following conversion to TypeScript so the links are outdated.

# Solution

Update references to `demoUtils.js` to `demoUtils.ts`

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [x] Has the README been updated? (for Demo App only)
- [x] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
