### PR TITLE
changing from throw to invoking error callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Public: Merged `dist/onfidoAuth.6.min.js` to `onfidoAuth.min.js`
 - Public: Rearranged `dependencies` & `devDependencies` in `package.json` to reflect correct usage
 - Internal: Upgrade `minimist` to `v1.2.6` to fix vulnerability
+- Internal: Handle errors by callback instead of `throw` for `requestChallenges` and `postToBackend`
 
 ## [6.19.0] - 2022-03-14
 

--- a/src/components/utils/onfidoApi.ts
+++ b/src/components/utils/onfidoApi.ts
@@ -245,11 +245,19 @@ export const requestChallenges = (
   onError: ErrorCallback
 ): void => {
   if (!url) {
-    throw new Error('onfido_api_url not provided')
+    return onError({
+      response: {
+        message: 'onfido_api_url not provided',
+      },
+    })
   }
 
   if (!token) {
-    throw new Error('token not provided')
+    return onError({
+      response: {
+        message: 'token not provided',
+      },
+    })
   }
 
   const options: HttpRequestParams = {

--- a/src/components/utils/sdkBackend.ts
+++ b/src/components/utils/sdkBackend.ts
@@ -35,11 +35,19 @@ export const postToBackend = (
   errorCallback: ErrorCallback
 ): void => {
   if (!url) {
-    throw new Error('detect_document_url not provided')
+    return errorCallback({
+      response: {
+        message: 'detect_document_url not provided',
+      },
+    })
   }
 
   if (!token) {
-    throw new Error('token not provided')
+    return errorCallback({
+      response: {
+        message: 'token not provided',
+      },
+    })
   }
 
   const endpoint = `${url}/validate_document`


### PR DESCRIPTION
# Problem

Throwing errors in a place, where we assume to get errors via a callback. This leads to errors in the console, that cannot be handled by the frontend. Actually found by web tests.

# Solution

Change from throw to error callback

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [n/a] Has the README been updated?
- [n/a] Has the CONTRIBUTING doc been updated?
- [n/a] Has the RELEASE_GUIDELINES been updated?
- [n/a] Has the TESTING_GUIDELINES been updated?
- [n/a] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [n/a] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [n/a] Have any new automated tests been implemented or the existing ones changed?
- [n/a] Have any new manual tests been written down or the existing ones changed?
- [n/a] Have any new strings been translated or the existing ones changed?