### PR TITLE
Send analytics event on capture validation errors

### DIFF
--- a/src/Tracker/trackerData.tsx
+++ b/src/Tracker/trackerData.tsx
@@ -125,6 +125,13 @@ export const analyticsEventsMapping = new Map<
     },
   ],
   [
+    'screen_capture_validation_error',
+    {
+      eventName: 'CAPTURE_VALIDATION_ERROR',
+      properties: { event_type: 'action' },
+    },
+  ],
+  [
     'screen_crossDevice_mobile_notification_sent',
     {
       eventName: 'CROSS_DEVICE_MOBILE_NOTIFICATION_SENT',

--- a/src/components/Confirm/Confirm.js
+++ b/src/components/Confirm/Confirm.js
@@ -89,6 +89,8 @@ class Confirm extends Component {
       return this.props.crossDeviceClientError()
     } else if (status === 422) {
       errorKey = this.onfidoErrorReduce(response.error) || UNEXPECTED_ERROR
+      // TODO: decide event name, properties & if 1 or multiple events (one for each type)
+      sendEvent(`screen_capture_validation_error`, { error: errorKey })
     } else {
       this.props.triggerOnError({ status, response })
       trackException(`${status} - ${response}`)

--- a/src/types/tracker.ts
+++ b/src/types/tracker.ts
@@ -16,6 +16,7 @@ export type LegacyTrackedEventNames =
   | 'copy link selected'
   | 'qr code selected'
   | 'sms selected'
+  | 'screen_capture_validation_error'
   | 'screen_crossDevice_mobile_notification_sent'
   | 'screen_crossDevice_mobile_connected'
   | 'screen_crossDevice_sms_failed'
@@ -143,6 +144,7 @@ export type AnalyticsPayload = {
 }
 
 export type AnalyticsTrackedEventNames =
+  | 'CAPTURE_VALIDATION_ERROR'
   | 'COMPLETE'
   | 'COMPLETE_CROSS_DEVICE_MOBILE_SUCCESS'
   | 'COUNTRY_SELECTION'


### PR DESCRIPTION
# Problem
The SDK is not sending an analytics event when the users get a capture validation message on their screen after uploading a document/selfie/video.

# Solution
Send an event to our analytics api

## Checklist
- [ ] Agree on event name(s) (see slack)

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
