### PR TITLE
Enable sourcemaps for TypeScript

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -277,7 +277,7 @@ const baseConfig = {
     setImmediate: false,
   },
 
-  devtool: PRODUCTION_BUILD ? 'source-map' : 'eval-cheap-source-map',
+  devtool: PRODUCTION_BUILD ? 'source-map' : 'eval-cheap-module-source-map',
 }
 
 const configDist = () => ({


### PR DESCRIPTION
# Problem

We can't see TypeScript code in source maps

# Solution

Process source maps from loaders with 'eval-cheap-module-source-map'

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
