### PR TITLE
Fix camera permission requests for IOS 14.3 WKWebView-based browsers

### DIFF
--- a/src/demo/demoUtils.ts
+++ b/src/demo/demoUtils.ts
@@ -18,6 +18,23 @@ import testDarkCobrandLogo from './assets/onfido-logo.svg'
 import testLightCobrandLogo from './assets/onfido-logo-light.svg'
 import sampleCompanyLogo from './assets/sample-logo.svg'
 
+navigator.mediaDevices.getUserMedia({video: { width: 640 }}).then(() => {
+  alert('success')
+  navigator.mediaDevices.enumerateDevices().then(devices => {
+    const labels = []
+    devices.forEach(device => {
+      labels.push(device.labels)
+    })
+  
+    alert(labels.join(', '))
+  })
+  
+}).catch((e) => console.log('error', e))
+
+
+
+
+
 export type QueryParams = {
   countryCode?: StringifiedBoolean
   createCheck?: StringifiedBoolean


### PR DESCRIPTION
# Problem
WebKit WebView based browsers don't handle blocked camera permissions, resulting in opening the camera app on a black screeen.

# Solution
Implement proper permission handling for IOS >= 14.3 webkit webview based browsers (chrome, etc) 

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
