### PR TITLE
run percy on master always when a push occurred

### DIFF
--- a/.github/workflows/percy_on_master.yml
+++ b/.github/workflows/percy_on_master.yml
@@ -1,8 +1,9 @@
 name: Percy Visual Regression Tests - Master
 
 on:
-  schedule:
-    - cron: '30 20 * * 0'
+  push:
+    branches:
+      - master
 
 env:
   BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
@@ -46,6 +47,14 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '11'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: it-ony/webtest
+          path: webtest
+
+      - name: Build webtest
+        run: cd webtest && mvn --no-transfer-progress clean install && cd ..
 
       - name: Setup Chromedriver
         uses: nanasess/setup-chromedriver@v1


### PR DESCRIPTION
# Problem

Percy on master branch runs per schedule. Therefore, percy comparison might be wrong until the next run.

# Solution

Run percy always, if a push on master happend.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
