### PR TITLE
Test on firefox

### DIFF
--- a/.github/workflows/CI-PR.yml
+++ b/.github/workflows/CI-PR.yml
@@ -202,6 +202,77 @@ jobs:
             exit 1
           fi
 
+  test-ui-firefox:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: it-ony/webtest
+          path: webtest
+
+      - name: Build webtest
+        run: cd webtest && mvn --no-transfer-progress clean install && cd ..
+
+      - name: Setup Geckodriver
+        uses: browser-actions/setup-geckodriver@latest
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: build-${{ github.run_id }}
+          path: dist
+
+      - name: build test server
+        id: testserver
+        run: rm -rf ./test/mock-server/frontend && cp -r dist test/mock-server/frontend && docker-compose up --build --no-start
+
+      - name: Run UI tests in Firefox
+        working-directory: ./test/webtest
+        id: firefox
+        if: ${{ steps.testserver.outcome == 'success' }}
+        run: ./run-ui-tests.sh "-Dbrowser=firefox -Dit.test=!MultipleBrowsersDocumentUploadIT -DexcludedGroups=mobile,percy -DthreadCount=10 -Denvironment=headless"
+        shell: bash
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD: ${{ github.ref }}-${{ github.run_id }}
+
+      - name: Upload screenshot reports
+        uses: actions/upload-artifact@v2
+        if: ${{ steps.firefox.outcome == 'failure' }}
+        with:
+          name: firefox-testrun-report
+          path: test/webtest/target/screenShot
+          retention-days: 5
+
+      - name: Publish Selenium Test Results - Firefox
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
+        with:
+          files: test/webtest/target/surefire-reports/junitreports/*.xml
+          check_name: "UI Test results - Firefox"
+
+      - name: Verify test results
+        if: ${{ steps.testserver.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -x
+
+          FIREFOX=${{ steps.firefox.outputs.exit_code }}
+
+          if [[ "$FIREFOX" != "0" ]]
+          then
+            exit 1
+          fi
+
   test-ui-browserstack:
     runs-on: ubuntu-latest
     needs:
@@ -230,26 +301,6 @@ jobs:
       - name: build test server
         id: testserver
         run: rm -rf ./test/mock-server/frontend && cp -r dist test/mock-server/frontend && docker-compose up --build --no-start
-
-      - name: Run UI tests in Firefox
-        id: firefox
-        if: ${{ steps.testserver.outcome == 'success' }}
-        working-directory: ./test/webtest
-        continue-on-error: true
-        run: ./run-ui-tests.sh "-Dit.test=MultipleBrowsersDocumentUploadIT -DthreadCount=1 -Denvironment=browserstack -Dbrowser=firefox -DscreenshotListener.enabled=false"
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
-          BUILD: ${{ github.ref }}-${{ github.run_id }}
-
-      - name: Publish Selenium Test Results - Firefox
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        if: ${{ steps.firefox.outcome == 'success' || steps.firefox.outcome == 'failure' }}
-        with:
-          files: test/webtest/target/surefire-reports/junitreports/*.xml
-          check_name: "UI Test results - Firefox"
 
       - name: Run UI tests in Edge
         working-directory: ./test/webtest
@@ -318,12 +369,11 @@ jobs:
         run: |
           set -x
 
-          FIREFOX=${{ steps.firefox.outputs.exit_code }}
           EDGE=${{ steps.edge.outputs.exit_code }}
           SAFARI=${{ steps.safari.outputs.exit_code }}
           IE=${{ steps.ie.outputs.exit_code }}
 
-          if [[ "$FIREFOX" != "0" || "$EDGE" != "0" || "$SAFARI" != "0" ]]
+          if [[ "$EDGE" != "0" || "$SAFARI" != "0" ]]
           then
             exit 1
           fi

--- a/test/webtest/src/test/java/com/onfido/qa/websdk/test/DocumentIT.java
+++ b/test/webtest/src/test/java/com/onfido/qa/websdk/test/DocumentIT.java
@@ -57,7 +57,7 @@ public class DocumentIT extends WebSdkIT {
                        .clickUploadButton(ImageQualityGuide.class);
     }
 
-    @Test(groups = {"percy"})
+    @Test(groups = {"percy", "mobile"})
     @Mobile
     public void testPermissionDialogIsShown() {
         var permission = onfido().withSteps(new DocumentStep().withUseLiveDocumentCapture(true))
@@ -69,7 +69,7 @@ public class DocumentIT extends WebSdkIT {
     }
 
 
-    @Test(groups = {"percy"}, description = "should display document upload screen on desktop browsers when useLiveDocumentCapture is enabled")
+    @Test(groups = {"percy", "mobile"}, description = "should display document upload screen on desktop browsers when useLiveDocumentCapture is enabled")
     @Mobile
     @Browser(enableMicrophoneCameraAccess = true)
     public void testPassportLiveCapture() {
@@ -87,7 +87,7 @@ public class DocumentIT extends WebSdkIT {
 
     }
 
-    @Test(description = "should upload a passport and verify UI elements", groups = {"percy"})
+    @Test(description = "should upload a passport and verify UI elements", groups = {"percy", "mobile"})
     @Mobile
     public void testPassportUploadScreen() {
 

--- a/test/webtest/src/test/java/com/onfido/qa/websdk/test/FaceIT.java
+++ b/test/webtest/src/test/java/com/onfido/qa/websdk/test/FaceIT.java
@@ -58,7 +58,7 @@ public class FaceIT extends WebSdkIT {
                 .init(CrossDeviceIntro.class);
     }
 
-    @Test(description = "should be taken to the selfie screen if browser does not have MediaRecorder API and faceVideo variant requested")
+    @Test(description = "should be taken to the selfie screen if browser does not have MediaRecorder API and faceVideo variant requested", groups = {"mobile"})
     @Browser(enableMicrophoneCameraAccess = true)
     @Mobile
     public void testFallbackToSelfieScreenWithoutMediaRecorderSupport() {
@@ -121,7 +121,7 @@ public class FaceIT extends WebSdkIT {
                 .clickConfirmButton(Complete.class);
     }
 
-    @Test(description = "should be taken to the selfie screen if browser does not have MediaRecorder API and faceVideo variant requested")
+    @Test(description = "should be taken to the selfie screen if browser does not have MediaRecorder API and faceVideo variant requested", groups = {"mobile"})
     @Mobile
     public void testSelfieScreenIfNoMediaRecorderAvailableAndFaceVideoVariantRequested() {
 
@@ -250,7 +250,7 @@ public class FaceIT extends WebSdkIT {
     @Browser(enableMicrophoneCameraAccess = true)
     public void testShouldRecordAVideoWithLivenessChallengePlayItAndSubmitIt() {
         var video = onfido().withSteps(new FaceStep().withRequestedVariant(VIDEO), "complete").init(FaceVideoIntro.class)
-                                .recordVideo(FaceVideo.class);
+                            .recordVideo(FaceVideo.class);
 
         takePercySnapshotWithoutVideo("face liveness");
 


### PR DESCRIPTION
# Problem

Tests are queuing up against browserstack and we want to execute more tests in less time.

# Solution

Run headless against firefox

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
