### PR TITLE
Bump react-webcam-onfido to 0.1.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -132,7 +132,7 @@
         "react-phone-number-input": "^3.1.38",
         "react-redux": "^7.2.2",
         "react-router-dom": "^5.2.0",
-        "react-webcam-onfido": "^0.1.27",
+        "react-webcam-onfido": "^0.1.28",
         "redux-mock-store": "^1.5.4",
         "regenerator-runtime": "^0.12.1",
         "rimraf": "^2.5.4",
@@ -12180,34 +12180,30 @@
     },
     "node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -12215,17 +12211,15 @@
     },
     "node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -12233,75 +12227,66 @@
     },
     "node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/debug": {
       "version": "3.2.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -12311,27 +12296,24 @@
     },
     "node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.7",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minipass": "^2.6.0"
       }
     },
     "node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -12345,10 +12327,9 @@
     },
     "node_modules/fsevents/node_modules/glob": {
       "version": "7.1.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -12366,17 +12347,15 @@
     },
     "node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -12386,20 +12365,18 @@
     },
     "node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
       }
     },
     "node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -12407,27 +12384,24 @@
     },
     "node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -12437,17 +12411,15 @@
     },
     "node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -12457,17 +12429,15 @@
     },
     "node_modules/fsevents/node_modules/minimist": {
       "version": "0.0.8",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/minipass": {
       "version": "2.9.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -12475,20 +12445,18 @@
     },
     "node_modules/fsevents/node_modules/minizlib": {
       "version": "1.3.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "minipass": "^2.9.0"
       }
     },
     "node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "minimist": "0.0.8"
       },
@@ -12498,17 +12466,15 @@
     },
     "node_modules/fsevents/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/needle": {
       "version": "2.4.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -12523,10 +12489,9 @@
     },
     "node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.14.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -12545,10 +12510,9 @@
     },
     "node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -12559,27 +12523,24 @@
     },
     "node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "node_modules/fsevents/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.7",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1"
@@ -12587,10 +12548,9 @@
     },
     "node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -12600,60 +12560,54 @@
     },
     "node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -12661,27 +12615,24 @@
     },
     "node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -12694,17 +12645,15 @@
     },
     "node_modules/fsevents/node_modules/rc/node_modules/minimist": {
       "version": "1.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -12717,10 +12666,9 @@
     },
     "node_modules/fsevents/node_modules/rimraf": {
       "version": "2.7.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -12730,65 +12678,57 @@
     },
     "node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/semver": {
       "version": "5.7.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -12800,10 +12740,9 @@
     },
     "node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -12813,20 +12752,18 @@
     },
     "node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/tar": {
       "version": "4.4.13",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -12842,34 +12779,30 @@
     },
     "node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/yallist": {
       "version": "3.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsu": {
       "version": "1.1.1",
@@ -13793,13 +13726,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
-      "dev": true,
-      "peer": true
     },
     "node_modules/import-cwd": {
       "version": "2.1.0",
@@ -17440,19 +17366,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/jszip": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
-      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "set-immediate-shim": "~1.0.1"
-      }
-    },
     "node_modules/keypather": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/keypather/-/keypather-1.10.2.tgz",
@@ -17691,16 +17604,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "node_modules/lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "immediate": "~3.0.5"
-      }
     },
     "node_modules/liftup": {
       "version": "3.0.1",
@@ -21960,9 +21863,9 @@
       "dev": true
     },
     "node_modules/react-webcam-onfido": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/react-webcam-onfido/-/react-webcam-onfido-0.1.27.tgz",
-      "integrity": "sha512-/jVLpFQt3b9e6vhay3QWCWEtCe3kMe2xR5kkTa8LAokbPayRWiJVa2MHbvKO20htNg7dgC6xVug9lsOB4t7qnA==",
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/react-webcam-onfido/-/react-webcam-onfido-0.1.28.tgz",
+      "integrity": "sha512-r3MnaYyBnV5P9O6xFAaSxWyecxmpOQTnA/383Kv3XE3VP2CZGw/od6aiN0Ldvr3MgyvxTd6nF8282Pwfy7XzVg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.4.3",
@@ -22845,73 +22748,6 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
       "dev": true
     },
-    "node_modules/selenium-webdriver": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-beta.3.tgz",
-      "integrity": "sha512-R0mGHpQkSKgIWiPgcKDcckh4A6aaK0KTyWxs5ieuiI7zsXQ+Kb6neph+dNoeqq3jSBGyv3ONo2w3oohoL4D/Rg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "jszip": "^3.5.0",
-        "rimraf": "^2.7.1",
-        "tmp": "^0.2.1",
-        "ws": "^7.3.1"
-      },
-      "engines": {
-        "node": ">= 10.15.0"
-      }
-    },
-    "node_modules/selenium-webdriver/node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.17.0"
-      }
-    },
-    "node_modules/selenium-webdriver/node_modules/tmp/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/selenium-webdriver/node_modules/ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/selfsigned": {
       "version": "1.10.8",
       "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
@@ -23146,16 +22982,6 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
-    },
-    "node_modules/set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/set-value": {
       "version": "2.0.1",
@@ -29459,15 +29285,13 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/@onfido/castor-icons/-/castor-icons-2.8.1.tgz",
       "integrity": "sha512-OjSqTw1UDeKdPjdYsu4QpAskmZfltxHfASFfa4yJPFN56PnEMjJGMqXAaT46sdci6Yzf/mZ+MqjHOcnEptpBfw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@onfido/castor-react": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@onfido/castor-react/-/castor-react-2.0.3.tgz",
       "integrity": "sha512-KMZVfRGhg9i1hRvtV0BSVgEi+w6DHYcpCd4E288NGoXweyvmaeK8kqbK2TyWlbgX8FkJSRCHUowxvshCWMtEdg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@onfido/castor-tokens": {
       "version": "1.0.0-beta.5",
@@ -29767,8 +29591,7 @@
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
           "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -30191,8 +30014,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@testing-library/preact-hooks/-/preact-hooks-1.1.0.tgz",
       "integrity": "sha512-+JIor+NsOHkK3oIrwMDGKGHXTN0JJi462dBJlj4FNbGaDPTlctE6eu2ranWQirh7/FJMkWfzQCP+tk7jmY8ZrQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@testing-library/user-event": {
       "version": "13.5.0",
@@ -31871,8 +31693,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -31912,15 +31733,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "amdefine": {
       "version": "1.0.1",
@@ -35066,8 +34885,7 @@
         "ws": {
           "version": "7.4.6",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-          "requires": {}
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
         }
       }
     },
@@ -35775,8 +35593,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
       "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -36748,26 +36565,22 @@
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "aproba": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -36776,14 +36589,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -36792,38 +36603,32 @@
         "chownr": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "debug": {
           "version": "3.2.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -36831,26 +36636,22 @@
         "deep-extend": {
           "version": "0.6.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "detect-libc": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "fs-minipass": {
           "version": "1.2.7",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "minipass": "^2.6.0"
           }
@@ -36858,14 +36659,12 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -36880,8 +36679,7 @@
         "glob": {
           "version": "7.1.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -36894,14 +36692,12 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "iconv-lite": {
           "version": "0.4.24",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -36909,8 +36705,7 @@
         "ignore-walk": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
@@ -36918,8 +36713,7 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -36928,20 +36722,17 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "ini": {
           "version": "1.3.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -36949,14 +36740,12 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -36964,14 +36753,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -36980,8 +36767,7 @@
         "minizlib": {
           "version": "1.3.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "minipass": "^2.9.0"
           }
@@ -36989,8 +36775,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -36998,14 +36783,12 @@
         "ms": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "needle": {
           "version": "2.4.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
@@ -37015,8 +36798,7 @@
         "node-pre-gyp": {
           "version": "0.14.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -37033,8 +36815,7 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -37043,8 +36824,7 @@
         "npm-bundled": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
@@ -37052,14 +36832,12 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "npm-packlist": {
           "version": "1.4.7",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1"
@@ -37068,8 +36846,7 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -37080,20 +36857,17 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "wrappy": "1"
           }
@@ -37101,20 +36875,17 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -37123,20 +36894,17 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -37147,16 +36915,14 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "extraneous": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -37170,8 +36936,7 @@
         "rimraf": {
           "version": "2.7.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -37179,44 +36944,37 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "sax": {
           "version": "1.2.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "semver": {
           "version": "5.7.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -37224,8 +36982,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -37235,8 +36992,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -37244,14 +37000,12 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "tar": {
           "version": "4.4.13",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -37265,14 +37019,12 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
@@ -37280,14 +37032,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         }
       }
     },
@@ -38018,13 +37768,6 @@
       "requires": {
         "queue": "6.0.2"
       }
-    },
-    "immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
-      "dev": true,
-      "peer": true
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -39759,8 +39502,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -40612,8 +40354,7 @@
           "version": "7.4.6",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -40755,19 +40496,6 @@
       "requires": {
         "array-includes": "^3.1.1",
         "object.assign": "^4.1.0"
-      }
-    },
-    "jszip": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
-      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "set-immediate-shim": "~1.0.1"
       }
     },
     "keypather": {
@@ -40946,16 +40674,6 @@
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
         }
-      }
-    },
-    "lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "immediate": "~3.0.5"
       }
     },
     "liftup": {
@@ -43757,15 +43475,13 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
       "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-scss": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.2.tgz",
       "integrity": "sha512-xfdkU128CkKKKVAwkyt0M8OdnelJ3MRcIRAPPQkRpoPeuzWY3RIeg7piRCpZ79MK7Q16diLXMMAD9dN5mauPlQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-selector-parser": {
       "version": "6.0.6",
@@ -43781,8 +43497,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-7.0.1.tgz",
       "integrity": "sha512-iLBFYz6VRYyLJEJsBJ8M3TCqNcckVzz4wFounSc5Oez35ogE/X+aoC5fFu103Ot7NyvjU3/xqIXn93Gp3kJk4g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-url": {
       "version": "8.0.0",
@@ -44357,9 +44072,9 @@
       }
     },
     "react-webcam-onfido": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/react-webcam-onfido/-/react-webcam-onfido-0.1.27.tgz",
-      "integrity": "sha512-/jVLpFQt3b9e6vhay3QWCWEtCe3kMe2xR5kkTa8LAokbPayRWiJVa2MHbvKO20htNg7dgC6xVug9lsOB4t7qnA==",
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/react-webcam-onfido/-/react-webcam-onfido-0.1.28.tgz",
+      "integrity": "sha512-r3MnaYyBnV5P9O6xFAaSxWyecxmpOQTnA/383Kv3XE3VP2CZGw/od6aiN0Ldvr3MgyvxTd6nF8282Pwfy7XzVg==",
       "dev": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.4.3",
@@ -45042,51 +44757,6 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
       "dev": true
     },
-    "selenium-webdriver": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-beta.3.tgz",
-      "integrity": "sha512-R0mGHpQkSKgIWiPgcKDcckh4A6aaK0KTyWxs5ieuiI7zsXQ+Kb6neph+dNoeqq3jSBGyv3ONo2w3oohoL4D/Rg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "jszip": "^3.5.0",
-        "rimraf": "^2.7.1",
-        "tmp": "^0.2.1",
-        "ws": "^7.3.1"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "rimraf": "^3.0.0"
-          },
-          "dependencies": {
-            "rimraf": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-              "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-              "dev": true,
-              "peer": true,
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            }
-          }
-        },
-        "ws": {
-          "version": "7.4.6",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-          "dev": true,
-          "peer": true,
-          "requires": {}
-        }
-      }
-    },
     "selfsigned": {
       "version": "1.10.8",
       "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
@@ -45293,13 +44963,6 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
-    },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true,
-      "peer": true
     },
     "set-value": {
       "version": "2.0.1",
@@ -47666,8 +47329,7 @@
           "version": "7.5.5",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
           "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -48179,8 +47841,7 @@
           "version": "0.14.9",
           "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.9.tgz",
           "integrity": "sha1-BQZKPc8PsYgKOyv8nVjFXY2fYpM=",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "whatwg-fetch": {
           "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "react-phone-number-input": "^3.1.38",
     "react-redux": "^7.2.2",
     "react-router-dom": "^5.2.0",
-    "react-webcam-onfido": "^0.1.27",
+    "react-webcam-onfido": "^0.1.28",
     "redux-mock-store": "^1.5.4",
     "regenerator-runtime": "^0.12.1",
     "rimraf": "^2.5.4",


### PR DESCRIPTION
# Problem

On Safari we always fallback on lowest camera definition after asking access to the user

# Solution

Update react-webcam-onfido which contains the fix.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
