### PR TITLE
install node modules first

### DIFF
--- a/.github/workflows/percy_on_master.yml
+++ b/.github/workflows/percy_on_master.yml
@@ -36,6 +36,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
+      - name: Install Dependencies
+        run: npm install
+
       - name: Build test server
         run: npm run build:test
         id: testserver


### PR DESCRIPTION
# Problem

Percy tests on master fail to run, as npm install was forgotten. Pipelines cannot be easily tested before.

# Solution

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
