### PR TITLE
Feature/add missing percy groups

### DIFF
--- a/.github/workflows/percy_on_master.yml
+++ b/.github/workflows/percy_on_master.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  build:
+  percy:
     runs-on: ubuntu-latest
 
     steps:

--- a/test/webtest/src/test/java/com/onfido/qa/websdk/test/CrossDeviceIT.java
+++ b/test/webtest/src/test/java/com/onfido/qa/websdk/test/CrossDeviceIT.java
@@ -80,7 +80,7 @@ public class CrossDeviceIT extends WebSdkIT {
         takePercySnapshot("CrossDeviceIntro-QR");
     }
 
-    @Test(description = "should verify UI elements on the cross device link screen SMS view")
+    @Test(description = "should verify UI elements on the cross device link screen SMS view", groups = {"percy"})
     public void testShouldVerifyUiElementsOnTheCrossDeviceLinkScreenSmsView() {
 
         var crossDeviceLink = gotoCrossDeviceScreen();
@@ -89,7 +89,7 @@ public class CrossDeviceIT extends WebSdkIT {
         takePercySnapshot("CrossDeviceIntro-Sms");
     }
 
-    @Test(description = "should change the state of the copy to clipboard button after clicking")
+    @Test(description = "should change the state of the copy to clipboard button after clicking", groups = {"percy"})
     public void testShouldVerifyUiElementsOnTheCrossDeviceLinkScreenCopyLinkView() {
         var crossDeviceLink = gotoCrossDeviceScreen().clickLinkOption();
 

--- a/test/webtest/src/test/java/com/onfido/qa/websdk/test/DocumentIT.java
+++ b/test/webtest/src/test/java/com/onfido/qa/websdk/test/DocumentIT.java
@@ -170,7 +170,7 @@ public class DocumentIT extends WebSdkIT {
 
     }
 
-    @Test(description = "should return file size too large message for PDF document upload")
+    @Test(description = "should return file size too large message for PDF document upload", groups = {"percy"})
     public void testShouldReturnFileSizeTooLargeMessageForPdfDocumentUpload() {
         var imageQualityGuide = gotoPassportUpload().upload(SAMPLE_10MB_PDF, ImageQualityGuide.class);
 


### PR DESCRIPTION
# Problem

Only 57 test groups where flagged as percy test, but we have 60 screenshots.

# Solution

Flag all tests taking percy screenshots with `percy` group.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
