### PR TITLE
hide qr code for percy snapshot

### DIFF
--- a/test/webtest/src/test/java/com/onfido/qa/websdk/test/CrossDeviceIT.java
+++ b/test/webtest/src/test/java/com/onfido/qa/websdk/test/CrossDeviceIT.java
@@ -39,7 +39,7 @@ public class CrossDeviceIT extends WebSdkIT {
     public void testShouldVerifyUiElementsOnTheCrossDeviceIntroScreen() {
         gotoCrossDeviceScreen();
 
-        takePercySnapshot("CrossDeviceIntro");
+        takePercySnapshotWithoutQRCode("CrossDeviceIntro");
     }
 
     @Test(description = "should navigate to cross device when forceCrossDevice is enabled")
@@ -77,7 +77,7 @@ public class CrossDeviceIT extends WebSdkIT {
 
         assertThat(crossDeviceLink.isQrHelpListDisplayed()).isTrue();
 
-        takePercySnapshot("CrossDeviceIntro-QR");
+        takePercySnapshotWithoutQRCode("CrossDeviceIntro-QR");
     }
 
     @Test(description = "should verify UI elements on the cross device link screen SMS view")

--- a/test/webtest/src/test/java/com/onfido/qa/websdk/test/WebSdkIT.java
+++ b/test/webtest/src/test/java/com/onfido/qa/websdk/test/WebSdkIT.java
@@ -32,7 +32,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Browser(acceptInsureCertificates = true)
 public abstract class WebSdkIT extends WebTest {
 
-    public static final String WITHOUT_VIDEO_CSS = "video.onfido-sdk-ui-Camera-video { display: none; }";
+    private static final String WITHOUT_VIDEO_CSS = "video.onfido-sdk-ui-Camera-video { display: none; }";
+    private static final String HIDE_QR_CODE = ".onfido-sdk-ui-crossDevice-CrossDeviceLink-qrCodeContainer {visibility: hidden}";
 
     private static final int MIN = 500;
     private static final int SLEEP_BEFORE_SNAPSHOT = 250;
@@ -162,6 +163,10 @@ public abstract class WebSdkIT extends WebTest {
 
     protected void takePercySnapshot(String name) {
         takePercySnapshot(name, null);
+    }
+
+    protected void takePercySnapshotWithoutQRCode(String name) {
+        takePercySnapshot(name, HIDE_QR_CODE);
     }
 
     protected void takePercySnapshot(String name, String css) {


### PR DESCRIPTION
# Problem

Percy always trigger changes, as the QR code is different between the tests.

# Solution

Hide QR Code from percy snapshots.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
