### PR TITLE
Convert polyglot to typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Internal: Migrated `Pannable` to typescript
 - Internal: Migrated `QRCode` to typescript
 - Internal: Migrated `PhoneNumberInput` to typescript
+- Internal: Migrated `locales/polyglot` to typescript
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@types/history": "^4.7.8",
         "@types/html-webpack-plugin": "^3.2.6",
         "@types/jest": "^27.4.0",
+        "@types/node-polyglot": "^2.4.2",
         "@types/pdfobject": "^2.0.6",
         "@types/qrcode.react": "^1.0.2",
         "@types/react-dom": "^17.0.11",
@@ -3744,6 +3745,12 @@
       "version": "14.14.14",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node-polyglot": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/node-polyglot/-/node-polyglot-2.4.2.tgz",
+      "integrity": "sha512-Tfx3TU/PBK8vW/BG1TK793EHlVpGnoHUj+DGxOwNOYwZiueLeu7FgksvDdpEyFSw4+AKKiEuiMm8EGUHUR4o6g==",
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -20803,6 +20810,12 @@
     },
     "@types/node": {
       "version": "14.14.14",
+      "dev": true
+    },
+    "@types/node-polyglot": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/node-polyglot/-/node-polyglot-2.4.2.tgz",
+      "integrity": "sha512-Tfx3TU/PBK8vW/BG1TK793EHlVpGnoHUj+DGxOwNOYwZiueLeu7FgksvDdpEyFSw4+AKKiEuiMm8EGUHUR4o6g==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     },
     "transform": {
       "^.+\\.(js|jsx)$": "babel-jest",
-      "^.+\\.(ts|tsx)$": "ts-jest"
+      "^.+\\.(ts|tsx|json)$": "ts-jest"
     },
     "testEnvironment": "jsdom",
     "testMatch": [
@@ -140,6 +140,7 @@
     "@types/history": "^4.7.8",
     "@types/html-webpack-plugin": "^3.2.6",
     "@types/jest": "^27.4.0",
+    "@types/node-polyglot": "^2.4.2",
     "@types/pdfobject": "^2.0.6",
     "@types/qrcode.react": "^1.0.2",
     "@types/react-dom": "^17.0.11",

--- a/src/components/utils/func.ts
+++ b/src/components/utils/func.ts
@@ -7,7 +7,8 @@ type ComposeFunction<T> = (param: T) => T
 export const compose = <T>(...fns: ComposeFunction<T>[]): ComposeFunction<T> =>
   fns.reduceRight((prev, next) => (...args) => next(prev(...args)), identity)
 
-type MemoizeFunction<T> = (...params: unknown[]) => T
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MemoizeFunction<T> = (...params: any[]) => T
 
 export const memoize = <T>(fn: MemoizeFunction<T>): MemoizeFunction<T> => {
   const cache: Record<string, T> = {}

--- a/src/demo/demoUtils.ts
+++ b/src/demo/demoUtils.ts
@@ -458,6 +458,7 @@ export const commonLanguages: Record<
   fr: 'fr',
   nl: 'nl',
   custom: {
+    locale: 'en',
     phrases: { 'welcome.title': 'My custom title' },
     mobilePhrases: {
       'capture.driving_licence.back.instructions': 'Custom instructions',

--- a/src/demo/demoUtils.ts
+++ b/src/demo/demoUtils.ts
@@ -458,7 +458,6 @@ export const commonLanguages: Record<
   fr: 'fr',
   nl: 'nl',
   custom: {
-    locale: 'en',
     phrases: { 'welcome.title': 'My custom title' },
     mobilePhrases: {
       'capture.driving_licence.back.instructions': 'Custom instructions',

--- a/src/locales/index.tsx
+++ b/src/locales/index.tsx
@@ -50,7 +50,7 @@ export const useLocales = (): WithLocalisedProps => {
   return context
 }
 
-export const localised = <P extends unknown>(
+export const localised = <P,>(
   WrappedComponent: ComponentType<P & WithLocalisedProps>
 ): ComponentType<P> => {
   const LocalisedComponent: FunctionComponent<P> = (props) => (

--- a/src/locales/polyglot.tsx
+++ b/src/locales/polyglot.tsx
@@ -64,18 +64,18 @@ const mobileTranslations = mobilePhrases()
 const defaultLanguage = () => {
   const polyglot = new Polyglot({ onMissingKey: undefined }) as PolyglotExtended
   return extendPolyglot(
-    defaultLocaleTag,
     polyglot,
     availableTranslations[defaultLocaleTag],
-    mobileTranslations[defaultLocaleTag]
+    mobileTranslations[defaultLocaleTag],
+    defaultLocaleTag
   )
 }
 
 const extendPolyglot = (
-  locale: SupportedLanguages,
   polyglot: PolyglotExtended,
   phrases: LocaleConfig['phrases'],
-  mobilePhrases: LocaleConfig['mobilePhrases']
+  mobilePhrases: LocaleConfig['mobilePhrases'],
+  locale?: SupportedLanguages
 ): PolyglotExtended => {
   polyglot.locale(locale)
   polyglot.extend(phrases)
@@ -128,15 +128,15 @@ const verifyKeysPresence = (
 }
 
 const trySupportedLanguage = (
-  language: SupportedLanguages,
-  polyglot: PolyglotExtended
+  polyglot: PolyglotExtended,
+  language?: SupportedLanguages
 ): PolyglotExtended | undefined => {
-  if (availableTranslations[language]) {
+  if (language && availableTranslations[language]) {
     return extendPolyglot(
-      language,
       polyglot,
       availableTranslations[language],
-      mobileTranslations[language]
+      mobileTranslations[language],
+      language
     )
   }
   console.warn('Locale not supported')
@@ -148,8 +148,8 @@ const withCustomLanguage = (
 ): PolyglotExtended => {
   const { locale, phrases, mobilePhrases } = customLanguageConfig
   verifyKeysPresence(customLanguageConfig, polyglot)
-  const newPolyglot = trySupportedLanguage(locale, polyglot) || polyglot
-  return extendPolyglot(locale, newPolyglot, phrases, mobilePhrases)
+  const newPolyglot = trySupportedLanguage(polyglot, locale) || polyglot
+  return extendPolyglot(newPolyglot, phrases, mobilePhrases, locale)
 }
 
 const overrideTranslations = (
@@ -157,7 +157,7 @@ const overrideTranslations = (
   polyglot: PolyglotExtended
 ): PolyglotExtended | undefined => {
   if (typeof language === 'string') {
-    return trySupportedLanguage(language, polyglot)
+    return trySupportedLanguage(polyglot, language)
   }
   return withCustomLanguage(language, polyglot)
 }

--- a/src/types/hocs.ts
+++ b/src/types/hocs.ts
@@ -13,7 +13,7 @@ export type WithChallengesProps = {
 }
 
 export type WithLocalisedProps = {
-  language: SupportedLanguages
+  language?: SupportedLanguages
   parseTranslatedTags: TranslatedTagParser
   translate: TranslateCallback
 }

--- a/src/types/locales.ts
+++ b/src/types/locales.ts
@@ -17,7 +17,7 @@ export type SupportedLanguages =
   | 'nl'
 
 export type LocaleConfig = {
-  locale: SupportedLanguages
+  locale?: SupportedLanguages
   phrases: Record<string, unknown>
   mobilePhrases?: Record<string, unknown>
 }

--- a/src/types/locales.ts
+++ b/src/types/locales.ts
@@ -17,7 +17,7 @@ export type SupportedLanguages =
   | 'nl'
 
 export type LocaleConfig = {
-  locale?: SupportedLanguages
+  locale: SupportedLanguages
   phrases: Record<string, unknown>
   mobilePhrases?: Record<string, unknown>
 }


### PR DESCRIPTION
# Solution
Make sure `locales & polyglot` are in typescript

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
