### PR TITLE
capture percy without video in testPassportLiveCapture

### DIFF
--- a/test/webtest/src/test/java/com/onfido/qa/websdk/test/DocumentIT.java
+++ b/test/webtest/src/test/java/com/onfido/qa/websdk/test/DocumentIT.java
@@ -78,10 +78,10 @@ public class DocumentIT extends WebSdkIT {
                               .init(IdDocumentSelector.class)
                               .select(PASSPORT, DocumentLiveCapture.class);
 
-        takePercySnapshot("document-submit-passport useLiveDocumentCapture=true");
+        takePercySnapshotWithoutVideo("document-submit-passport useLiveDocumentCapture=true");
 
         var confirm = capture.takePhoto();
-        takePercySnapshot("document-confirm-passport useLiveDocumentCapture=true");
+        takePercySnapshotWithoutVideo("document-confirm-passport useLiveDocumentCapture=true");
 
         confirm.clickConfirmButton(null);
 


### PR DESCRIPTION
# Problem

Video element has always a percy diff and needs to be excluded.

# Solution

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
