### PR TITLE
Add info about base branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ Please speak to a member of the Onfido SDK team to obtain them. To use these var
 
 When creating a new branch, contributors should use the following convention `{task-type}/{task-description}-{ticket-number}`.
 The most used task types are `feature`, `fix` or `improvement`. The ticket number is an optional reference to our internal ticketing system.
+This project follows the Gitflow workflow, therefore you should point your pull requests at the `development` branch.
 If your pull request is related to a GitHub issue, please reference the issue in your PR description.
 
 For more details, check out the [pull request checklist](./.github/PULL_REQUEST_TEMPLATE.md).


### PR DESCRIPTION
# Problem
New contributors tend to create PRs against `master`. We follow the gitflow workflow, therefore new PRs should point at `development`

# Solution

Add a note in `CONTRIBUTING.md` to inform contributors that the `development` branch should be used as a base when creating pull requests. This will also be automatically enforced by the repo going forward

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
