### PR TITLE
enable integration tests again after api gateway has been fixed

### DIFF
--- a/src/components/utils/__integrations__/onfidoApi/document.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/document.integration.js
@@ -79,7 +79,7 @@ describe('API uploadDocument endpoint', () => {
     )
   })
 
-  test.skip('uploadDocument returns an error if request is made with an expired JWT token', (done) => {
+  test('uploadDocument returns an error if request is made with an expired JWT token', (done) => {
     expect.hasAssertions()
     const testFileName = 'passport.jpg'
     const data = fs.readFileSync(`${PATH_TO_RESOURCE_FILES}${testFileName}`)

--- a/src/components/utils/__integrations__/onfidoApi/selfie.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/selfie.integration.js
@@ -63,7 +63,7 @@ describe('API uploadFacePhoto endpoint', () => {
     )
   })
 
-  test.skip('uploadFacePhoto returns an error if request is made with an expired JWT token', (done) => {
+  test('uploadFacePhoto returns an error if request is made with an expired JWT token', (done) => {
     expect.hasAssertions()
 
     const testFileName = 'one_face.jpg'

--- a/src/components/utils/__integrations__/onfidoApi/video.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/video.integration.js
@@ -83,7 +83,7 @@ describe('API uploadFaceVideo endpoint', () => {
     )
   })
 
-  test.skip('uploadFaceVideo returns an error if request is made with an expired JWT token', (done) => {
+  test('uploadFaceVideo returns an error if request is made with an expired JWT token', (done) => {
     expect.hasAssertions()
     const testFileName = 'test-video.webm'
     const data = fs.readFileSync(`${PATH_TO_RESOURCE_FILES}${testFileName}`)


### PR DESCRIPTION
# Problem

Some integration tests have been disabled because changes in api gateway lead to the fact that they're failing. Now it's time to re-enable them.

# Solution

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
