### PR TITLE
Remove unnecessary config from analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 - Internal: Set ideal photo width for selfie step to ensure consistency across mobile devices
 - Internal: Prevent Face step (variant: video) from falling back to selfie upon camera error when `uploadFallback: false` is provided
+- Internal: Remove duplicated config and strip out custom locales from analytics events
 
 ## [6.19.0] - 2022-03-14
 

--- a/src/Tracker/onfidoTracker.tsx
+++ b/src/Tracker/onfidoTracker.tsx
@@ -8,6 +8,7 @@ import type { AnalyticsPayload, LegacyTrackedEventNames } from '~types/tracker'
 import { reduxStore } from 'components/ReduxAppWrapper'
 import { analyticsEventsMapping } from './trackerData'
 import { trackException } from './'
+import { pick } from '~utils/object'
 
 let currentStepType: ExtendedStepTypes | undefined
 let analyticsSessionUuid: string | undefined
@@ -40,7 +41,7 @@ const listener = () => {
   applicant_uuid = globalsInStore.applicantUuid
   anonymous_uuid = globalsInStore.anonymousUuid
   isCrossDeviceClient = globalsInStore.isCrossDeviceClient
-  steps = globalsInStore.stepsConfig
+  steps = cleanStepsForConfig(globalsInStore.stepsConfig)
 }
 
 reduxStore.subscribe(listener)
@@ -52,6 +53,40 @@ const source_metadata = {
 }
 
 const stepsArrToString = () => steps?.map((step) => step['type']).join()
+
+const keys = [
+  'documentTypes',
+  'showCountrySelection',
+  'forceCrossDevice',
+  'useLiveDocumentCapture',
+  'uploadFallback',
+  'country',
+  'requestedVariant',
+  'useMultipleSelfieCapture',
+  'photoCaptureFallback',
+  'retries',
+  'useUploader',
+  'useWebcam',
+]
+
+const cleanStepsForConfig = (steps: StepConfig[]): StepConfig[] =>
+  steps.map(
+    (step): StepConfig => {
+      const options = pick(
+        { ...step.options } as Partial<Record<string, unknown>>,
+        keys
+      )
+      const newStep: StepConfig = { ...step }
+
+      if (Object.keys(options).length) {
+        newStep.options = options
+      } else {
+        delete newStep.options
+      }
+
+      return newStep
+    }
+  )
 
 export const sendAnalyticsEvent = (
   event: LegacyTrackedEventNames,

--- a/src/Tracker/onfidoTracker.tsx
+++ b/src/Tracker/onfidoTracker.tsx
@@ -8,7 +8,7 @@ import type { AnalyticsPayload, LegacyTrackedEventNames } from '~types/tracker'
 import { reduxStore } from 'components/ReduxAppWrapper'
 import { analyticsEventsMapping } from './trackerData'
 import { trackException } from './'
-import { pick } from '~utils/object'
+import { cleanStepsForConfig } from './steps'
 
 let currentStepType: ExtendedStepTypes | undefined
 let analyticsSessionUuid: string | undefined
@@ -53,40 +53,6 @@ const source_metadata = {
 }
 
 const stepsArrToString = () => steps?.map((step) => step['type']).join()
-
-const keys = [
-  'documentTypes',
-  'showCountrySelection',
-  'forceCrossDevice',
-  'useLiveDocumentCapture',
-  'uploadFallback',
-  'country',
-  'requestedVariant',
-  'useMultipleSelfieCapture',
-  'photoCaptureFallback',
-  'retries',
-  'useUploader',
-  'useWebcam',
-]
-
-const cleanStepsForConfig = (steps: StepConfig[]): StepConfig[] =>
-  steps.map(
-    (step): StepConfig => {
-      const options = pick(
-        { ...step.options } as Partial<Record<string, unknown>>,
-        keys
-      )
-      const newStep: StepConfig = { ...step }
-
-      if (Object.keys(options).length) {
-        newStep.options = options
-      } else {
-        delete newStep.options
-      }
-
-      return newStep
-    }
-  )
 
 export const sendAnalyticsEvent = (
   event: LegacyTrackedEventNames,

--- a/src/Tracker/steps.tsx
+++ b/src/Tracker/steps.tsx
@@ -1,0 +1,46 @@
+import { StepConfig } from '~types/steps'
+import { pick } from '~utils/object'
+
+// Only accept these keys in step.options
+const keys = [
+  'documentTypes',
+  'showCountrySelection',
+  'forceCrossDevice',
+  'useLiveDocumentCapture',
+  'uploadFallback',
+  'country',
+  'requestedVariant',
+  'useMultipleSelfieCapture',
+  'photoCaptureFallback',
+  'retries',
+  'useUploader',
+  'useWebcam',
+]
+
+export const cleanStepsForConfig = (steps: StepConfig[]): StepConfig[] =>
+  steps.map(
+    (step): StepConfig => {
+      const options = pick(
+        { ...step.options } as Partial<Record<string, unknown>>,
+        keys
+      )
+      const newStep: StepConfig = { ...step }
+
+      if (Object.keys(options).length) {
+        newStep.options = convertKeysToSnakeCase(options)
+      } else {
+        delete newStep.options
+      }
+
+      return newStep
+    }
+  )
+
+const convertKeysToSnakeCase = (obj: Record<string, unknown>) => {
+  const newObj: Record<string, unknown> = {}
+  Object.entries(obj).forEach(([key, value]: [string, unknown]) => {
+    const k = key.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`)
+    newObj[k] = value
+  })
+  return newObj
+}

--- a/src/components/Router/StepsRouter.tsx
+++ b/src/components/Router/StepsRouter.tsx
@@ -24,7 +24,6 @@ class StepsRouter extends Component<StepsRouterProps> {
       ],
       {
         ...properties,
-        ...step.options,
       }
     )
   }


### PR DESCRIPTION
# Problem
We're sending unnecessary config data with our analytics 

# Solution
Remove the unnecessary config and strip the locales from the config 

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
