### PR TITLE
pass isUploadFallbackDisabled prop to Camera component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ### Fixed
 
 - Internal: Set ideal photo width for selfie step to ensure consistency across mobile devices
+- Internal: Prevent Face step (variant: video) from falling back to selfie upon camera error when `uploadFallback: false` is provided
 
 ## [6.19.0] - 2022-03-14
 

--- a/src/components/FaceVideo/index.tsx
+++ b/src/components/FaceVideo/index.tsx
@@ -26,6 +26,7 @@ import type {
 export type FaceVideoProps = {
   cameraClassName: string
   inactiveError: ErrorProp
+  isUploadFallbackDisabled?: boolean
   onRedo: () => void
   onVideoCapture: HandleCaptureProp
   renderFallback: RenderFallbackProp
@@ -84,6 +85,7 @@ class FaceVideo extends Component<Props, State> {
       inactiveError,
       onRedo,
       renderFallback,
+      isUploadFallbackDisabled,
       trackScreen,
       translate,
     } = this.props
@@ -99,6 +101,7 @@ class FaceVideo extends Component<Props, State> {
         audio
         cameraClassName={cameraClassName}
         inactiveError={inactiveError}
+        isUploadFallbackDisabled={isUploadFallbackDisabled}
         method="face"
         onRecordingStart={this.onRecordingStart}
         onRedo={onRedo}

--- a/src/components/VideoCapture/index.tsx
+++ b/src/components/VideoCapture/index.tsx
@@ -46,6 +46,7 @@ export type VideoCaptureProps = {
   title?: string
   webcamRef?: Ref<Webcam>
   pageId?: string
+  isUploadFallbackDisabled?: boolean
 } & WithTrackingProps
 
 type State = {
@@ -240,6 +241,7 @@ export default class VideoCapture extends Component<VideoCaptureProps, State> {
         facing={facing}
         fallbackToDefaultWidth
         isButtonDisabled={disableRecording}
+        isUploadFallbackDisabled={this.props.isUploadFallbackDisabled}
         onButtonClick={this.handleRecordingStart}
         onError={this.handleCameraError}
         onUserMedia={this.handleMediaStream}


### PR DESCRIPTION
# Problem

In some edge cases the Camera component will error out being unable to enable the camera and this was showing a popup that allowed applicants to upload a selfie using the native camera instead, even when video steps configuration explicitly says `uploadFallback: false` and `photoCaptureFallback: false`.

This is because the camera component it self has some logic to display different alert messages depending on if the customer has upload fallback enabled or not, but because the prop wasn't being correctly propagated from the face step to the component it was always assuming the fallback was possible.

# Solution

Propagate `isUploadFallbackDisabled` prop to the Camera component on face step variant video.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
