### PR TITLE
Add acceptSslCerts for Edge browserStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Internal: Fixed behavior for analytics event `CUSTOM_API_REQUEST_COMPLETED` & added `CUSTOM_API_REQUEST_COMPLETED`
 - Internal: Updated `integratorTrackedEvents` with multiple triggers for `UPLOAD` to reflect analytics upload events changes
 - Internal: Upgrade `minimist` to v1.2.6
+- Internal: Set `acceptSslCerts` to `true` for browserstack CI test to avoid "This connection is not private" screens
 
 ### Fixed
 

--- a/test/webtest/src/test/java/com/onfido/qa/websdk/sdk/WebSdk.java
+++ b/test/webtest/src/test/java/com/onfido/qa/websdk/sdk/WebSdk.java
@@ -177,7 +177,6 @@ public class WebSdk {
     }
 
     private String getToken() {
-
         return (String) driver.executeScript("return window.getToken()");
     }
 

--- a/test/webtest/src/test/java/com/onfido/qa/websdk/test/WebSdkIT.java
+++ b/test/webtest/src/test/java/com/onfido/qa/websdk/test/WebSdkIT.java
@@ -93,6 +93,7 @@ public abstract class WebSdkIT extends WebTest {
         capabilities.setCapability("browserstack.console", "warnings");
         capabilities.setCapability("browserstack.networkLogs", properties().getProperty("networkLogs", "true"));
         capabilities.setCapability("browserstack.wsLocalSupport", "true");
+        capabilities.setCapability("acceptSslCerts", "true");
 
         capabilities.setCapability("project", "web-sdk");
         capabilities.setCapability("build", System.getenv("BUILD"));


### PR DESCRIPTION
# Problem
In browserStack test on Edge throws the error ` org.openqa.selenium.JavascriptException: javascript error: window.getToken is not a function` from time to time.

# Solution
This is caused by the "This connection is not private" screen in Edge. Add a flag to allow for insecure SSL certs while testing.

https://www.browserstack.com/docs/automate/selenium/accept-insecure-certificates#java

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
