### PR TITLE
Scope castor to root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Internal: Remove `trackComponentMode()` & `trackComponentAndMode()`
 - Internal: Added test case configs to our demo app with queryString `testCase`
 - Public: Fix error when `mobilePhrases` is supplied but `phrases` are not
+- Internal: Add a css root scope to our SDK
+- Public: Scope our customization of castor components to our SDK css root
+- Public: Strip away `color-scheme` to prevent interference with customer styles
 
 ## [8.0.0] - 2022-04-21
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,6 +128,7 @@
         "sass": "^1.43.4",
         "sass-loader": "^12.6.0",
         "speed-measure-webpack-plugin": "^1.5.0",
+        "string-replace-loader": "^3.1.0",
         "style-loader": "^3.3.1",
         "stylelint": "^14.0.1",
         "stylelint-config-sass-guidelines": "^9.0.1",
@@ -17370,6 +17371,51 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-replace-loader": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-replace-loader/-/string-replace-loader-3.1.0.tgz",
+      "integrity": "sha512-5AOMUZeX5HE/ylKDnEa/KKBqvlnFmRZudSOjVJHxhoJg9QYTwl1rECx7SLR8BBH7tfxb4Rp7EM2XVfQFxIhsbQ==",
+      "dev": true,
+      "dependencies": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5"
+      }
+    },
+    "node_modules/string-replace-loader/node_modules/loader-utils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "dev": true,
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/string-replace-loader/node_modules/schema-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -32609,6 +32655,40 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
+    "string-replace-loader": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-replace-loader/-/string-replace-loader-3.1.0.tgz",
+      "integrity": "sha512-5AOMUZeX5HE/ylKDnEa/KKBqvlnFmRZudSOjVJHxhoJg9QYTwl1rECx7SLR8BBH7tfxb4Rp7EM2XVfQFxIhsbQ==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
     "sass": "^1.43.4",
     "sass-loader": "^12.6.0",
     "speed-measure-webpack-plugin": "^1.5.0",
+    "string-replace-loader": "^3.1.0",
     "style-loader": "^3.3.1",
     "stylelint": "^14.0.1",
     "stylelint-config-sass-guidelines": "^9.0.1",

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -47,7 +47,7 @@ const Modal = ({
         beforeClose: theme['modalOverlay--before-close'],
       }}
       bodyOpenClassName={theme.modalBody}
-      className={classNames(theme.modalInner, style.inner)}
+      className={classNames(theme.root, theme.modalInner, style.inner)}
       role={'dialog'}
       shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
       closeTimeoutMS={MODAL_ANIMATION_DURATION}
@@ -80,7 +80,7 @@ const WrappedModal = ({
   useModal ? (
     <ModalContainer {...otherProps}>{children}</ModalContainer>
   ) : (
-    <div className={style.inner}>{children}</div>
+    <div className={classNames(theme.root, style.inner)}>{children}</div>
   )
 
 export default WrappedModal

--- a/src/components/Theme/style.scss
+++ b/src/components/Theme/style.scss
@@ -12,68 +12,74 @@
   @include castor.Input();
   @include castor.Select();
   @include castor.Icon();
+}
 
-  .ods-field-label {
+.root {
+  @include castor.day();
+  @include onfidoSdk.tokens();
+
+  /*
+    Note: The WebSDK is used in Onfido's workflow builder, which also uses castor.
+    The prevent interference we scope our adjusted castor classes to our root.
+
+    The :global classes endup like .onfido-sdk-ui-Theme-root .ods-button in the compiled css.
+  */
+  :global(.ods-field-label) {
     text-align: left;
   }
 
-  .ods-popover {
+  :global(.ods-popover) {
     max-width: unset;
   }
 
-  .ods-button {
+  :global(.ods-button) {
     border-radius: var(--osdk-border-radius-button);
+  }
 
-    /* stylelint-disable-next-line selector-class-pattern */
-    &.-action--primary {
-      background-color: var(--osdk-color-background-button-primary);
-      color: var(--osdk-color-content-button-primary-text);
-      border-color: var(--osdk-color-border-button-primary);
+  /* stylelint-disable-next-line selector-class-pattern */
+  :global(.ods-button.-action--primary) {
+    background-color: var(--osdk-color-background-button-primary);
+    color: var(--osdk-color-content-button-primary-text);
+    border-color: var(--osdk-color-border-button-primary);
 
-      &:active {
-        background-color: var(--osdk-color-background-button-primary-active);
-      }
-
-      /* stylelint-disable max-nesting-depth */
-      @media (hover: hover) {
-        &:hover {
-          background-color: var(--osdk-color-background-button-primary-hover);
-        }
-      }
-      /* stylelint-enable max-nesting-depth */
-
-      &:disabled {
-        background-color: rgba(var(--ods-color-neutral-300));
-        border-color: transparent;
-      }
+    &:active {
+      background-color: var(--osdk-color-background-button-primary-active);
     }
 
-    /* stylelint-disable-next-line selector-class-pattern */
-    &.-action--secondary {
-      background-color: var(--osdk-color-background-button-secondary);
-      color: var(--osdk-color-content-button-secondary-text);
-      border-color: var(--osdk-color-border-button-secondary);
-
-      &:active {
-        background-color: var(--osdk-color-background-button-secondary-active);
-        border-color: var(--osdk-color-border-button-secondary);
+    /* stylelint-disable max-nesting-depth */
+    @media (hover: hover) {
+      &:hover {
+        background-color: var(--osdk-color-background-button-primary-hover);
       }
+    }
+    /* stylelint-enable max-nesting-depth */
 
-      /* stylelint-disable max-nesting-depth */
-      @media (hover: hover) {
-        &:hover {
-          background-color: var(--osdk-color-background-button-secondary-hover);
-          border-color: var(--osdk-color-border-button-secondary);
-        }
-      }
-      /* stylelint-enable max-nesting-depth */
+    &:disabled {
+      background-color: rgba(var(--ods-color-neutral-300));
+      border-color: transparent;
     }
   }
-}
 
-:root {
-  @include castor.day();
-  @include onfidoSdk.tokens();
+  /* stylelint-disable-next-line selector-class-pattern */
+  :global(.ods-button.-action--secondary) {
+    background-color: var(--osdk-color-background-button-secondary);
+    color: var(--osdk-color-content-button-secondary-text);
+    border-color: var(--osdk-color-border-button-secondary);
+
+    &:active {
+      background-color: var(--osdk-color-background-button-secondary-active);
+      border-color: var(--osdk-color-border-button-secondary);
+    }
+
+    /* stylelint-disable max-nesting-depth */
+    @media (hover: hover) {
+      &:hover {
+        background-color: var(--osdk-color-background-button-secondary-hover);
+        border-color: var(--osdk-color-border-button-secondary);
+      }
+    }
+    /* stylelint-enable max-nesting-depth */
+  }
 }
 
 .step {

--- a/src/components/Theme/style.scss
+++ b/src/components/Theme/style.scss
@@ -14,14 +14,16 @@
   @include castor.Icon();
 }
 
-.root {
+:root {
+  // Note: color-scheme from castor.day is stripped away by webpack
   @include castor.day();
   @include onfidoSdk.tokens();
+}
 
+.root {
   /*
     Note: The WebSDK is used in Onfido's workflow builder, which also uses castor.
     The prevent interference we scope our adjusted castor classes to our root.
-
     The :global classes endup like .onfido-sdk-ui-Theme-root .ods-button in the compiled css.
   */
   :global(.ods-field-label) {

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -70,6 +70,15 @@ const baseStyleLoaders = (modules, withSourceMap) => [
         : modules,
     },
   },
+  // ref: https://github.com/onfido/onfido-sdk-ui/issues/1804
+  // Note: The css vars polyfill (IE11) seems to only support :root vars
+  {
+    loader: 'string-replace-loader',
+    options: {
+      search: /color-scheme: light;/,
+      replace: '',
+    },
+  },
   ...(modules
     ? [
         {


### PR DESCRIPTION
# Problem
1) Our castor implementation is interfering with css outside of our SDK due to us overwriting the style for the castor button.
2) Castor adds a `color-scheme` in `castor.day()` which overrides our customers `color-scheme`. Since we don't need it for our SDK and due to limitation of IE11  that only allows vars in root we strip it away in build. See https://github.com/onfido/onfido-sdk-ui/issues/1804. 

# Solution
1) Move the custom styling within our sdk css root scope
2) Strip away during build

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
