### PR TITLE
Add variant to CAPTURE_DATA_WHITELIST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Internal: Migrate `ModalApp` to typescript
 - Internal: Add support for `.env` file
 
+### Fixed
+
+- Public: Fix useLiveDocumentCapture onComplete not working (cross device capture `variant` missing)
+
 ## [6.20.0] - 2022-04-12
 
 ### Changed

--- a/src/components/Router/CrossDeviceMobileRouter.tsx
+++ b/src/components/Router/CrossDeviceMobileRouter.tsx
@@ -42,6 +42,7 @@ const CAPTURE_DATA_WHITELIST = [
   'idDocumentIssuingCountry',
   'poaDocumentType',
   'id',
+  'variant',
   'metadata',
   'method',
   'side',


### PR DESCRIPTION
# Problem
The `onComplete` is not firing when the mobile flow is completed with `useLiveDocumentCapture: true` 
The actual problem turned out to be a missing key `variant` on the capture data that is send to the desktop (from crossdevice/mobile). 

# Solution
Add the `variant` key and send it to desktop

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
