### PR TITLE
Fix error for mobilePhrases without phrases usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Internal: Add support for `.env` file
 - Public: Update Proof of Address flow to present Country Select
 - Public: Determine Proof of Address document options from endpoint
+- Public: Fix error when `mobilePhrases` is supplied but `phrases` are not
 
 ### Fixed
 

--- a/src/locales/polyglot.tsx
+++ b/src/locales/polyglot.tsx
@@ -125,7 +125,7 @@ const verifyKeysPresence = (
   // Only return the warning for missing keys if mobilePhrases are not present in phrases or as a separate object.
   const customMobilePhrases = Object.assign(
     {},
-    phrases.mobilePhrases,
+    phrases?.mobilePhrases,
     mobilePhrases
   )
   const customKeys = polyglotFormatKeys({


### PR DESCRIPTION
# Problem
`Polyglot` throws error when `mobilePhrases` is supplied but `phrases` are not

# Solution
Allow for empty `phrases`

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
