### PR TITLE
run percy also on development branch

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - development
 
 jobs:
   percy:


### PR DESCRIPTION
# Problem

Percy snapshots are compared to master, where development should be also available as baseline.

# Solution

Run percy also for development branch
