### PR TITLE
feat: change certain field labels (and helper text) based on a country

### DIFF
--- a/src/components/Capture/ProfileData.tsx
+++ b/src/components/Capture/ProfileData.tsx
@@ -9,6 +9,7 @@ import classNames from 'classnames'
 import {
   Field,
   FieldLabel,
+  HelperText,
   Validation,
   Input,
   InputProps,
@@ -26,6 +27,7 @@ import style from './style.scss'
 import type { StepComponentDataProps, CompleteStepValue } from '~types/routers'
 import type { FlatStepOptionData } from '~types/steps'
 import type { WithLocalisedProps } from '~types/hocs'
+import { TranslateCallback } from '~types/locales'
 
 const validationContext = createContext({} as ValidationState)
 const ValidationProvider = validationContext.Provider
@@ -183,15 +185,16 @@ const FieldComponent = ({
     <Field>
       <FieldLabel>
         <span>
-          {translate(`profile_data.${type}`)}
+          {getTranslatedFieldLabel(translate, type, selectedCountry)}
           {isRequired ? (
             <Asterisk aria-label="required" />
           ) : (
             <span className={style['optional']}>
-              {` ${translate('profile_data.optional')}`}
+              {` ${translate('profile_data.field_optional')}`}
             </span>
           )}
         </span>
+        {getTranslatedFieldHelperText(translate, type, selectedCountry)}
         {getFieldComponent(type, {
           value,
           invalid: formSubmitted && invalid,
@@ -225,6 +228,45 @@ const getFieldComponent = (
     default:
       return <Input type="text" {...props} />
   }
+}
+
+const getTranslatedFieldLabel = (
+  translate: TranslateCallback,
+  type: fieldType,
+  country?: string
+) => {
+  let specificCountry = ''
+
+  if (country) {
+    switch (type) {
+      case 'town':
+        if (country === 'GBR') specificCountry = 'gbr_specific.'
+        break
+      case 'state':
+        if (country === 'USA') specificCountry = 'usa_specific.'
+        break
+      case 'postcode':
+        if (['GBR', 'USA'].includes(country))
+          specificCountry = `${country.toLowerCase()}_specific.`
+        break
+    }
+  }
+
+  return translate(`profile_data.field_labels.${specificCountry}${type}`)
+}
+
+const getTranslatedFieldHelperText = (
+  translate: TranslateCallback,
+  type: fieldType,
+  country?: string
+) => {
+  if (country !== 'USA' || !['line1', 'line2'].includes(type)) return null
+
+  return (
+    <HelperText>
+      {translate(`profile_data.field_labels.usa_specific.${type}_helper_text`)}
+    </HelperText>
+  )
 }
 
 const isFieldRequired = (type: fieldType, country?: string) => {

--- a/src/components/Theme/style.scss
+++ b/src/components/Theme/style.scss
@@ -5,9 +5,10 @@
 :global {
   @include castor.Field();
   @include castor.FieldLabel();
-  @include castor.Button();
+  @include castor.HelperText();
   @include castor.Validation();
   @include castor.Asterisk();
+  @include castor.Button();
   @include castor.Input();
   @include castor.Icon();
 

--- a/src/locales/en_US/en_US.json
+++ b/src/locales/en_US/en_US.json
@@ -20,18 +20,29 @@
     "profile_data": {
         "personal_details_title": "Add your personal information",
         "address_detials_title": "Add your address",
-        "first_name": "First name",
-        "last_name": "Last name",
-        "dob": "Date of birth",
-        "country": "Country",
-        "line1": "Address line 1",
-        "line2": "Address line 2",
-        "line3": "Address line 3",
-        "town": "Town",
-        "state": "State",
-        "postcode": "Postcode",
+        "field_labels": {
+            "first_name": "First name",
+            "last_name": "Last name",
+            "dob": "Date of birth",
+            "country": "Country",
+            "line1": "Address line 1",
+            "line2": "Address line 2",
+            "line3": "Address line 3",
+            "town": "Town",
+            "postcode": "Postal code",
+            "gbr_specific": {
+                "town": "City/Town",
+                "postcode": "Postcode"
+            },
+            "usa_specific": {
+                "line1_helper_text": "Street address, for example: 200 Albert Street",
+                "line2_helper_text": "Apartment, suite, unit, etc.",
+                "state": "State",
+                "postcode": "Zip code"
+            }
+        },
+        "field_optional": "(optional)",
         "button_submit": "Continue",
-        "optional": "(optional)",
         "required_error": "This field is required",
         "prompt": {
             "header_timeout": "Looks like you took too long",


### PR DESCRIPTION
# Problem

Follow up on https://github.com/onfido/onfido-sdk-ui/pull/1825, to change certain field labels (and add helper text) when a specific country is being selected.

# Solution

Add helper functions, that track selected country and change labels accordingly, also adds helper text when needed.
