### PR TITLE
feat: reposition "submit" button for profile data screen

### DIFF
--- a/src/components/Capture/ProfileData.tsx
+++ b/src/components/Capture/ProfileData.tsx
@@ -76,17 +76,8 @@ const ProfileData = ({
     nextStep()
   }
 
-  const actions = (
-    <Button
-      onClick={handleSubmit}
-      className={classNames(theme['button-centered'], theme['button-lg'])}
-    >
-      {translate('profile_data.button_submit')}
-    </Button>
-  )
-
   return (
-    <ScreenLayout actions={actions}>
+    <ScreenLayout>
       <PageTitle title={translate(`profile_data.${title}`)} />
       {Object.entries(formData).map(([type, value]) => (
         <FieldComponent
@@ -99,6 +90,16 @@ const ProfileData = ({
           onChange={handleChange}
         />
       ))}
+      <Button
+        onClick={handleSubmit}
+        className={classNames(
+          theme['button-centered'],
+          theme['button-lg'],
+          style['submit-button']
+        )}
+      >
+        {translate('profile_data.button_submit')}
+      </Button>
     </ScreenLayout>
   )
 }

--- a/src/components/Capture/style.scss
+++ b/src/components/Capture/style.scss
@@ -13,3 +13,7 @@
 .optional {
   color: castor.color('content-secondary');
 }
+
+.submit-button {
+  margin-top: castor.space(4);
+}


### PR DESCRIPTION
# Problem

Reposition "submit" button for profile data screen so that it always at the bottom of the form, and seen only when screen scrolled down.

# Solution

Place button for form submission directly after form, rather than in "actions" section of a screen.
