### PR TITLE
feat: make custom field size for "postcode" field type

### DIFF
--- a/src/components/Capture/ProfileData.tsx
+++ b/src/components/Capture/ProfileData.tsx
@@ -1,6 +1,7 @@
 import { h } from 'preact'
 import { useCallback, useEffect, useState } from 'preact/compat'
 import classNames from 'classnames'
+import { space } from '@onfido/castor'
 import {
   Field,
   FieldLabel,
@@ -235,6 +236,8 @@ const getFieldComponent = (
       return <CountrySelector {...props} />
     case 'dob':
       return <DateOfBirthInput {...props} />
+    case 'postcode':
+      return <Input {...props} type="text" style={{ width: space(22) }} />
     default:
       return <Input {...props} type="text" />
   }


### PR DESCRIPTION
# Problem

Make "postcode" field type smaller than other fields.

# Solution

Upon returning a "postcode" field type component, adjust it's width.

<img width="580" alt="Screenshot 2022-04-28 at 11 39 10" src="https://user-images.githubusercontent.com/20243687/165735143-98d8ce16-e428-4463-a4f4-d1a5425f12fa.png">

