### PR TITLE
Host PR build files & demo apps on AWS

### DIFF
--- a/.github/workflows/CI-PR.yml
+++ b/.github/workflows/CI-PR.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
 
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: 'eu-west-1'
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -99,30 +104,21 @@ jobs:
       - name: Build artifact
         run: NODE_ENV=test TEST_ENV=deployment npm run build
 
-      - name: Publish to Surge
-        uses: dswistowski/surge-sh-action@v1.0.1
-        with:
-          domain: "https://${{ github.event.pull_request.number }}-pr-onfido-sdk-ui-onfido.surge.sh"
-          project: './dist'
-          login: ${{ secrets.SURGE_LOGIN }}
-          token: ${{ secrets.SURGE_TOKEN }}
+      - name: Upload to AWS (pr)
+        run: aws s3 cp ./dist s3://${{ secrets.AWS_S3_BUCKET }}/web-sdk-pr/${{ github.event.pull_request.number }}/ --recursive --acl public-read
 
       - name: Build artifact
         run: NODE_ENV=staging npm run build
 
-      - name: Publish to Surge
-        uses: dswistowski/surge-sh-action@v1.0.1
-        with:
-          domain: "https://staging-${{ github.event.pull_request.number }}-pr-onfido-sdk-ui-onfido.surge.sh"
-          project: './dist'
-          login: ${{ secrets.SURGE_LOGIN }}
-          token: ${{ secrets.SURGE_TOKEN }}
+      - name: Upload to AWS (pr)
+        run: aws s3 cp ./dist s3://${{ secrets.AWS_S3_BUCKET }}/web-sdk-pr/${{ github.event.pull_request.number }}/staging/ --recursive --acl public-read
 
-      - name: Add comment with Surge link to PR
+      - name: Add comment with demo links to PR
         uses: mshick/add-pr-comment@v1
         with:
-          message: "https://${{ github.event.pull_request.number }}-pr-onfido-sdk-ui-onfido.surge.sh 🚀\nhttps://staging-${{ github.event.pull_request.number }}-pr-onfido-sdk-ui-onfido.surge.sh 🚀"
+          message: "https://assets.onfido.com/web-sdk-pr/${{ github.event.pull_request.number }}/index.html 🚀\nhttps://assets.onfido.com/web-sdk-pr/${{ github.event.pull_request.number }}/staging/index.html 🚀"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
   test-ui-chrome:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload Release to S3
         run: |
-          aws s3 cp ./dist s3://${{ secrets.AWS_S3_BUCKET }}/web-sdk-releases/$VERSION/ --exclude "*.html" --recursive --acl public-read
+          aws s3 cp ./dist s3://${{ secrets.AWS_S3_BUCKET }}/web-sdk-releases/$VERSION/ --recursive --acl public-read
 
       - name: Publish to NPM
         run: |
@@ -97,19 +97,14 @@ jobs:
       #   env:
       #     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
-      - name: Run build for Surge
-        # Legacy: Surge uses the NODE_ENV=test + TEST_ENV=deployment
+      - name: Run build
+        # Legacy: Demo app uses the NODE_ENV=test + TEST_ENV=deployment
         run: |
           if [ "$VERSION" == "$LATEST_TAG" ]
           then
             TEST_ENV=deployment npm run build:test
           fi
 
-      - name: Publish latest version to Surge
+      - name: Publish latest version to AWS
         if: ${{ env.VERSION == env.LATEST_TAG }}
-        uses: dswistowski/surge-sh-action@v1.0.1
-        with:
-          domain: 'https://latest-onfido-sdk-ui-onfido.surge.sh'
-          project: './dist/'
-          login: ${{ secrets.SURGE_LOGIN }}
-          token: ${{ secrets.SURGE_TOKEN }}
+        run: aws s3 cp ./dist s3://${{ secrets.AWS_S3_BUCKET }}/web-sdk-releases/latest/ --recursive --acl public-read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Public: Determine Proof of Address document options from endpoint
 - Internal: Added test case configs to our demo app with queryString `testCase`
 - Public: Fix error when `mobilePhrases` is supplied but `phrases` are not
+- Internal: Host our PR build files & demo app on AWS
 
 ## [6.20.1] - 2022-04-28
 


### PR DESCRIPTION
# Problem
Surge is poorly maintained and having issue with SSL, preventing decent usage of our generate test links for PRs.

# Solution
Host our PR build files & demo app on AWS.

- [x] PR: [assets.onfido.com/web-sdk-pr/1840](https://assets.onfido.com/web-sdk-pr/1840)
- [x] PR (staging): [assets.onfido.com/web-sdk-pr/1840/staging](https://assets.onfido.com/web-sdk-pr/1840/staging)
- [x] Release (latest): [assets.onfido.com/web-sdk-releases/latest](https://assets.onfido.com/web-sdk-releases/latest)
- [x] Release (version): [assets.onfido.com/web-sdk-releases/6.20.0](https://assets.onfido.com/web-sdk-releases/6.20.0)

### Waiting for Devops Ticket: PLAT-7446

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
