### PR TITLE
fix: correct spacing for profile data form

### DIFF
--- a/src/components/Capture/DateOfBirthInput/styles.scss
+++ b/src/components/Capture/DateOfBirthInput/styles.scss
@@ -1,5 +1,9 @@
 @use '~@onfido/castor';
 
+:global(.ods-field-label) > .componentContainer {
+  margin: castor.space(0.5) 0 castor.space(-0.5);
+}
+
 .componentContainer {
   display: flex;
   flex-direction: row;

--- a/src/components/Capture/ProfileData.tsx
+++ b/src/components/Capture/ProfileData.tsx
@@ -80,27 +80,29 @@ const ProfileData = ({
   return (
     <ScreenLayout>
       <PageTitle title={translate(`profile_data.${title}`)} />
-      {Object.entries(formData).map(([type, value]) => (
-        <FieldComponent
-          key={type}
-          type={type as FieldComponentProps['type']}
-          value={value as FieldComponentProps['value']}
-          selectedCountry={formData.country}
-          setToucher={setToucher}
-          removeToucher={removeToucher}
-          onChange={handleChange}
-        />
-      ))}
-      <Button
-        onClick={handleSubmit}
-        className={classNames(
-          theme['button-centered'],
-          theme['button-lg'],
-          style['submit-button']
-        )}
-      >
-        {translate('profile_data.button_submit')}
-      </Button>
+      <div className={style['form']}>
+        {Object.entries(formData).map(([type, value]) => (
+          <FieldComponent
+            key={type}
+            type={type as FieldComponentProps['type']}
+            value={value as FieldComponentProps['value']}
+            selectedCountry={formData.country}
+            setToucher={setToucher}
+            removeToucher={removeToucher}
+            onChange={handleChange}
+          />
+        ))}
+        <Button
+          onClick={handleSubmit}
+          className={classNames(
+            theme['button-centered'],
+            theme['button-lg'],
+            style['submit-button']
+          )}
+        >
+          {translate('profile_data.button_submit')}
+        </Button>
+      </div>
     </ScreenLayout>
   )
 }

--- a/src/components/Capture/style.scss
+++ b/src/components/Capture/style.scss
@@ -10,6 +10,13 @@
   position: static;
 }
 
+.form {
+  display: grid;
+  gap: castor.space(2);
+  grid: auto-flow / 1fr;
+  width: 100%;
+}
+
 .optional {
   color: castor.color('content-secondary');
 }


### PR DESCRIPTION
# Problem

Correct spacing for profile data form.

# Solution

Add spacing to form elements, adjust how margins are placed for a date of birth field when following a label.

Before:

<img width="537" alt="Screenshot 2022-05-05 at 14 03 21" src="https://user-images.githubusercontent.com/20243687/166928593-48b49ccc-3047-4597-a2c2-dceeb08f3315.png">

After:

<img width="531" alt="Screenshot 2022-05-05 at 14 00 11" src="https://user-images.githubusercontent.com/20243687/166928640-f27bda3a-8d04-4f28-bd5f-9c3c198541c5.png">

