### PR TITLE
fix: add "format" as helper text for date of birth field

### DIFF
--- a/src/components/Capture/ProfileData.tsx
+++ b/src/components/Capture/ProfileData.tsx
@@ -265,9 +265,20 @@ const getTranslatedFieldHelperText = (
 ) => {
   const specificTranslation = translateSpecific('helper_text', type, country)
 
-  return specificTranslation ? (
-    <HelperText>{translate(`profile_data.${specificTranslation}`)}</HelperText>
-  ) : null
+  if (specificTranslation) {
+    return (
+      <HelperText>
+        {translate(`profile_data.${specificTranslation}`)}
+      </HelperText>
+    )
+  }
+
+  switch (type) {
+    case 'dob':
+      return <HelperText>MM / DD / YYYY</HelperText>
+    default:
+      return null
+  }
 }
 
 const isFieldRequired = (


### PR DESCRIPTION
# Problem

Date of birth field needs to have a format described as helper text.

# Solution

When building helper text for a field, use a custom format one for "dob" case.

Before:

<img width="277" alt="Screenshot 2022-05-05 at 14 20 04" src="https://user-images.githubusercontent.com/20243687/166931638-05d38ff4-7399-4e9d-9622-9a43cc063a83.png">

After:

<img width="271" alt="Screenshot 2022-05-05 at 14 20 38" src="https://user-images.githubusercontent.com/20243687/166931734-fea40a17-7d28-4bfb-a119-3f051b146a80.png">

