### PR TITLE
Upgrade @sentry/browser and fix artifacts upload for release

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -87,15 +87,18 @@ jobs:
           body: ${{ steps.extract-release-notes.outputs.release_notes }}
           draft: true
 
-      # FIXME: Temporarily disabled to allow release build to pass. To be fixed in CX-6470
-      # - name: Send artifacts to Sentry
-      #   run: |
-      #     curl -sL https://sentry.io/get-cli/ | bash
-      #     sentry-cli --auth-token $SENTRY_AUTH_TOKEN
-      #     sentry-cli releases new $LATEST_TAG --log-level=DEBUG
-      #     sentry-cli releases files $LATEST_TAG upload-sourcemaps ./dist/
-      #   env:
-      #     SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      - name: Send artifacts to Sentry
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          curl -sL https://sentry.io/get-cli/ | bash
+          sentry-cli releases new $VERSION --log-level=DEBUG
+          sentry-cli releases files $VERSION upload-sourcemaps ./dist/
+          sentry-cli releases files $VERSION upload-sourcemaps ./lib/
+          sentry-cli releases finalize $VERSION
+          sentry-cli --version
 
       - name: Run build for Surge
         # Legacy: Surge uses the NODE_ENV=test + TEST_ENV=deployment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Internal: Remove `trackComponentMode()` & `trackComponentAndMode()`
 - Internal: Added test case configs to our demo app with queryString `testCase`
 - Public: Fix error when `mobilePhrases` is supplied but `phrases` are not
+- Internal: Upgrade `@sentry/browser@6.19.7`
+- Internal: Fix Sentry artifacts CI upload
 
 ## [8.0.0] - 2022-04-21
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.0.0",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
-        "@sentry/browser": "^5.14.2",
+        "@sentry/browser": "^6.19.7",
         "blueimp-load-image": "~2.29.0",
         "classnames": "~2.2.5",
         "core-js": "^3.21.1",
@@ -3093,12 +3093,13 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "5.14.2",
-      "integrity": "sha512-Vuuy2E5mt2VQKeHpFqtowZdKUe1Ui7J2KmgZQCduVilM7dFmprdXfv/mQ3Uv+73VIiCd22PpxojR3peDksb/Gg==",
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.19.7.tgz",
+      "integrity": "sha512-oDbklp4O3MtAM4mtuwyZLrgO1qDVYIujzNJQzXmi9YzymJCuzMLSRDvhY83NNDCRxf0pds4DShgYeZdbSyKraA==",
       "dependencies": {
-        "@sentry/core": "5.14.2",
-        "@sentry/types": "5.14.2",
-        "@sentry/utils": "5.14.2",
+        "@sentry/core": "6.19.7",
+        "@sentry/types": "6.19.7",
+        "@sentry/utils": "6.19.7",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -3106,13 +3107,14 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "5.14.2",
-      "integrity": "sha512-B2XjUMCmVu4H3s5hapgynhb28MSc+irt9wRI9j0Lbjx2cxsCUr/YFGL8GuEuYwf4zXNKnh2ke6t+I37OlSaGOg==",
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.7.tgz",
+      "integrity": "sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==",
       "dependencies": {
-        "@sentry/hub": "5.14.2",
-        "@sentry/minimal": "5.14.2",
-        "@sentry/types": "5.14.2",
-        "@sentry/utils": "5.14.2",
+        "@sentry/hub": "6.19.7",
+        "@sentry/minimal": "6.19.7",
+        "@sentry/types": "6.19.7",
+        "@sentry/utils": "6.19.7",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -3120,11 +3122,12 @@
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "5.14.2",
-      "integrity": "sha512-0ckTDnhCANkuY+VepMPz5vl/dkFQnWmzlJiCIxgM5fCgAF8dfNd9VhGn0qVQXnzKPGoW9zxs/uAmH3/XFqqmNA==",
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.7.tgz",
+      "integrity": "sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==",
       "dependencies": {
-        "@sentry/types": "5.14.2",
-        "@sentry/utils": "5.14.2",
+        "@sentry/types": "6.19.7",
+        "@sentry/utils": "6.19.7",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -3132,11 +3135,12 @@
       }
     },
     "node_modules/@sentry/minimal": {
-      "version": "5.14.2",
-      "integrity": "sha512-uih9a8KwFCQrWaGb3UxkrSntxMRT4EIlud158ZKlrsLaCOE6i08unOR4xWqlrXlKPySq16H4wjbBFQ56ogOWdQ==",
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.7.tgz",
+      "integrity": "sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==",
       "dependencies": {
-        "@sentry/hub": "5.14.2",
-        "@sentry/types": "5.14.2",
+        "@sentry/hub": "6.19.7",
+        "@sentry/types": "6.19.7",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -3144,17 +3148,19 @@
       }
     },
     "node_modules/@sentry/types": {
-      "version": "5.14.2",
-      "integrity": "sha512-NtB/o+/whR/mJJf67Nvdab7E2+/THgAUY114FWFqDLHMaoiIVWy9J/yLKtQWymwuQslh7zpPxjA1AhqTJerVCg==",
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
+      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "5.14.2",
-      "integrity": "sha512-DV9/kw/O8o5xqvQYwITm0lBaBqS4RKicjguWYJQ/+F94P/SKxuXor7EE0iMDYvUGslvPz8TlgB7r+nb/YRl+Fg==",
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.7.tgz",
+      "integrity": "sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==",
       "dependencies": {
-        "@sentry/types": "5.14.2",
+        "@sentry/types": "6.19.7",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -21697,53 +21703,59 @@
       "requires": {}
     },
     "@sentry/browser": {
-      "version": "5.14.2",
-      "integrity": "sha512-Vuuy2E5mt2VQKeHpFqtowZdKUe1Ui7J2KmgZQCduVilM7dFmprdXfv/mQ3Uv+73VIiCd22PpxojR3peDksb/Gg==",
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.19.7.tgz",
+      "integrity": "sha512-oDbklp4O3MtAM4mtuwyZLrgO1qDVYIujzNJQzXmi9YzymJCuzMLSRDvhY83NNDCRxf0pds4DShgYeZdbSyKraA==",
       "requires": {
-        "@sentry/core": "5.14.2",
-        "@sentry/types": "5.14.2",
-        "@sentry/utils": "5.14.2",
+        "@sentry/core": "6.19.7",
+        "@sentry/types": "6.19.7",
+        "@sentry/utils": "6.19.7",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "5.14.2",
-      "integrity": "sha512-B2XjUMCmVu4H3s5hapgynhb28MSc+irt9wRI9j0Lbjx2cxsCUr/YFGL8GuEuYwf4zXNKnh2ke6t+I37OlSaGOg==",
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.7.tgz",
+      "integrity": "sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==",
       "requires": {
-        "@sentry/hub": "5.14.2",
-        "@sentry/minimal": "5.14.2",
-        "@sentry/types": "5.14.2",
-        "@sentry/utils": "5.14.2",
+        "@sentry/hub": "6.19.7",
+        "@sentry/minimal": "6.19.7",
+        "@sentry/types": "6.19.7",
+        "@sentry/utils": "6.19.7",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "5.14.2",
-      "integrity": "sha512-0ckTDnhCANkuY+VepMPz5vl/dkFQnWmzlJiCIxgM5fCgAF8dfNd9VhGn0qVQXnzKPGoW9zxs/uAmH3/XFqqmNA==",
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.7.tgz",
+      "integrity": "sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==",
       "requires": {
-        "@sentry/types": "5.14.2",
-        "@sentry/utils": "5.14.2",
+        "@sentry/types": "6.19.7",
+        "@sentry/utils": "6.19.7",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "5.14.2",
-      "integrity": "sha512-uih9a8KwFCQrWaGb3UxkrSntxMRT4EIlud158ZKlrsLaCOE6i08unOR4xWqlrXlKPySq16H4wjbBFQ56ogOWdQ==",
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.7.tgz",
+      "integrity": "sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==",
       "requires": {
-        "@sentry/hub": "5.14.2",
-        "@sentry/types": "5.14.2",
+        "@sentry/hub": "6.19.7",
+        "@sentry/types": "6.19.7",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "5.14.2",
-      "integrity": "sha512-NtB/o+/whR/mJJf67Nvdab7E2+/THgAUY114FWFqDLHMaoiIVWy9J/yLKtQWymwuQslh7zpPxjA1AhqTJerVCg=="
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
+      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg=="
     },
     "@sentry/utils": {
-      "version": "5.14.2",
-      "integrity": "sha512-DV9/kw/O8o5xqvQYwITm0lBaBqS4RKicjguWYJQ/+F94P/SKxuXor7EE0iMDYvUGslvPz8TlgB7r+nb/YRl+Fg==",
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.7.tgz",
+      "integrity": "sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==",
       "requires": {
-        "@sentry/types": "5.14.2",
+        "@sentry/types": "6.19.7",
         "tslib": "^1.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "files": [
       {
         "path": "./dist/onfido.min.js",
-        "maxSize": "320 kB"
+        "maxSize": "330 kB"
       },
       {
         "path": "./dist/onfido.crossDevice.min.js",
@@ -233,7 +233,7 @@
     "yn": "^3.0.0"
   },
   "dependencies": {
-    "@sentry/browser": "^5.14.2",
+    "@sentry/browser": "^6.19.7",
     "blueimp-load-image": "~2.29.0",
     "classnames": "~2.2.5",
     "core-js": "^3.21.1",


### PR DESCRIPTION
# Problem
Sentry complaining about outdated `@sentry/browser` and we're not uploading source maps for each release anymore.
Disabled in: https://github.com/onfido/onfido-sdk-ui/pull/1620

# Solution
Upgrade package and fix CI uploads to sentry

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
