### PR TITLE
change: Switch order Country Selector screen and DocumentType Selection Screen

### DIFF
--- a/src/components/CountrySelector/DocumentCountrySelector.tsx
+++ b/src/components/CountrySelector/DocumentCountrySelector.tsx
@@ -52,10 +52,8 @@ class CountrySelection extends CountrySelectionBase {
     this.props.actions.resetIdDocumentIssuingCountry()
   }
 
-  getSupportedCountries = (
-    documentType: Optional<PoaTypes | DocumentTypes>
-  ): CountryData[] => {
-    return getSupportedCountriesForDocument(documentType as DocumentTypes)
+  getSupportedCountries = (): CountryData[] => {
+    return getSupportedCountriesForDocument()
   }
 
   renderNoResultsMessage = (): h.JSX.Element => {

--- a/src/components/CountrySelector/index.tsx
+++ b/src/components/CountrySelector/index.tsx
@@ -60,9 +60,7 @@ export abstract class CountrySelectionBase extends Component<Props, State> {
   abstract renderNoResultsMessage: () => h.JSX.Element
   protected trackScreen?: () => void
 
-  abstract getSupportedCountries: (
-    documentType: Optional<PoaTypes | DocumentTypes>
-  ) => CountryData[]
+  abstract getSupportedCountries: () => CountryData[]
 
   abstract hasChanges: (prevProps: Props) => boolean | undefined
 
@@ -91,7 +89,7 @@ export abstract class CountrySelectionBase extends Component<Props, State> {
       this.resetCountry()
     }
 
-    const countries = this.getSupportedCountries(documentType)
+    const countries = this.getSupportedCountries()
 
     const filteredResults = countries.filter((country) =>
       country.name.toLowerCase().includes(query.trim().toLowerCase())

--- a/src/components/Router/StepComponentMap.tsx
+++ b/src/components/Router/StepComponentMap.tsx
@@ -303,7 +303,7 @@ const buildNonPassportPreCaptureComponents = (
     : []
   // @ts-ignore
   // TODO: convert DocumentSelector to TS
-  return [...prependDocumentSelector, ...prependCountrySelector]
+  return [...prependCountrySelector, ...prependDocumentSelector]
 }
 
 const buildDocumentComponents = (

--- a/src/supported-documents/__tests__/supported-documents.test.ts
+++ b/src/supported-documents/__tests__/supported-documents.test.ts
@@ -3,9 +3,7 @@ import { getSupportedCountriesForDocument } from '../index'
 
 describe('getSupportedCountriesForDocument', () => {
   it('should not contain any duplicate countries', () => {
-    const supportedCountries = getSupportedCountriesForDocument(
-      'driving_licence'
-    )
+    const supportedCountries = getSupportedCountriesForDocument()
     const countryCount = supportedCountries.filter(
       (country) => country.name === 'Singapore'
     ).length
@@ -13,11 +11,14 @@ describe('getSupportedCountriesForDocument', () => {
   })
 
   it('should return countries sorted alphabetically', () => {
-    const supportedCountries = getSupportedCountriesForDocument(
-      'national_identity_card'
-    )
+    const supportedCountries = getSupportedCountriesForDocument()
     const firstFourCountries = supportedCountries.slice(0, 4)
     const expectedResult = [
+      {
+        country_alpha2: 'AX',
+        country_alpha3: 'ALA',
+        name: 'Åland Islands',
+      },
       {
         country_alpha2: 'AL',
         country_alpha3: 'ALB',
@@ -29,27 +30,11 @@ describe('getSupportedCountriesForDocument', () => {
         name: 'Algeria | الجزائر',
       },
       {
-        country_alpha2: 'AO',
-        country_alpha3: 'AGO',
-        name: 'Angola | Ngola',
-      },
-      {
-        country_alpha2: 'AR',
-        country_alpha3: 'ARG',
-        name: 'Argentina',
+        country_alpha2: 'AS',
+        country_alpha3: 'ASM',
+        name: 'American Samoa',
       },
     ]
     expect(firstFourCountries).toEqual(expectedResult)
-  })
-
-  it('should show a console error and return an empty array if given unsupported document type', () => {
-    const consoleError = jest
-      .spyOn(console, 'error')
-      .mockImplementation(() => {})
-    const supportedCountries = getSupportedCountriesForDocument(
-      'unknown_document' as DocumentTypes
-    )
-    expect(consoleError).toHaveBeenCalled()
-    expect(supportedCountries).toEqual([])
   })
 })

--- a/src/supported-documents/index.ts
+++ b/src/supported-documents/index.ts
@@ -33,9 +33,7 @@ export const getCountryDataForDocumentType = (
 ): Optional<CountryData> => {
   // Consistent with API, which accepts a 3-letter ISO country code for issuing_country param value
   if (countryCode && countryCode.length === 3) {
-    const supportedCountriesList = getSupportedCountriesForDocument(
-      documentType
-    )
+    const supportedCountriesList = getSupportedCountriesForDocument()
     const country = supportedCountriesList.find(
       (countryData) => countryData.country_alpha3 === countryCode
     )
@@ -44,20 +42,12 @@ export const getCountryDataForDocumentType = (
   return null
 }
 
-export const getSupportedCountriesForDocument = (
-  documentType: Optional<DocumentTypes>
-): CountryData[] => {
-  switch (documentType) {
-    case 'driving_licence':
-      return getCountriesList(supportedDrivingLicences)
-    case 'national_identity_card':
-      return getCountriesList(supportedNationalIDCards)
-    case 'residence_permit':
-      return getCountriesList(supportedResidencePermit)
-    default:
-      console.error('Unsupported documentType:', documentType)
-      return []
-  }
+export const getSupportedCountriesForDocument = (): CountryData[] => {
+  const allSupportedSocumentTypes = supportedDrivingLicences
+    .concat(supportedNationalIDCards)
+    .concat(supportedResidencePermit)
+  console.log('::::', getCountriesList(allSupportedSocumentTypes))
+  return getCountriesList(allSupportedSocumentTypes)
 }
 
 const getCountriesList = (supportedDocsData: { sourceData: SourceData }[]) => {

--- a/test/webtest/src/test/java/com/onfido/qa/websdk/test/CountrySelectorIT.java
+++ b/test/webtest/src/test/java/com/onfido/qa/websdk/test/CountrySelectorIT.java
@@ -37,29 +37,14 @@ public class CountrySelectorIT extends WebSdkIT {
     }
 
     @Test(
-            dataProvider = "documentTypesWithoutCountrySelection",
-            description = "should not display country selection screen for certain document type selected"
-    )
-    public void testCountryNotSelectionShown(DocumentType documentType) {
-
-        var upload = onfido().init(Welcome.class)
-                             .continueToNextStep(IdDocumentSelector.class)
-                             .select(documentType, DocumentUpload.class);
-
-        verifyCopy(upload.title(), "doc_submit.title_passport");
-
-    }
-
-    @Test(
             dataProvider = "documentTypesWithCountrySelection",
-            description = "should display country selection screen for certain document type selected"
+            description = "should display country selection screen"
     )
     public void testCountrySelectionShown(DocumentType documentType) {
 
 
         var countrySelector = onfido().init(Welcome.class)
-                                      .continueToNextStep(IdDocumentSelector.class)
-                                      .select(documentType, CountrySelector.class);
+                                      .continueToNextStep(CountrySelector.class)
 
         verifyCopy(countrySelector.title(), "country_select.title");
         verifyCopy(countrySelector.selectorLabel(), "country_select.search.label");
@@ -69,23 +54,6 @@ public class CountrySelectorIT extends WebSdkIT {
 
     }
 
-    @Test(
-            description = "should skip country selection screen and successfully upload a document when only residence permit document type preselected"
-    )
-    public void testSkipCountryScreenForResidencePermit() {
-        var welcome = onfido().withSteps("welcome", new DocumentStep().withDocumentType(RESIDENT_PERMIT)).init(Welcome.class);
-        var documentUpload = welcome.continueToNextStep(DocumentUpload.class);
-
-        verifyCopy(documentUpload.title(), "doc_submit.title_permit_front");
-
-        var confirm = documentUpload.upload(UploadDocument.UK_DRIVING_LICENCE_PNG);
-        verifyCopy(confirm.title(), "doc_confirmation.title");
-        verifyCopy(confirm.message(), "doc_confirmation.body_permit");
-
-        var documentUploadBack = confirm.clickConfirmButton(DocumentUpload.class);
-        verifyCopy(documentUploadBack.title(), "doc_submit.title_permit_back");
-
-    }
 
     @Test(
             description = "should skip country selection screen and successfully upload a document when multiple document types have country preset"
@@ -126,20 +94,6 @@ public class CountrySelectorIT extends WebSdkIT {
 
     }
 
-    @Test(description = "should show country selection screen for driver's license and national ID given invalid country code")
-    public void testShowCountrySelectionWithInvalidCountryCode() {
-
-        onfido()
-                .withSteps("welcome", new DocumentStep().withDocumentType(DRIVING_LICENCE, new Option("ES"))
-                                                        .withDocumentType(IDENTITY_CARD, new Option("XYZ")))
-                .init(Welcome.class)
-                .continueToNextStep(IdDocumentSelector.class).select(DRIVING_LICENCE, CountrySelector.class)
-                .back(IdDocumentSelector.class)
-                .select(IDENTITY_CARD, CountrySelector.class).select(CountrySelector.SUPPORTED_COUNTRY, DocumentUpload.class)
-                .upload(NATIONAL_IDENTITY_CARD_JPG)
-                .clickConfirmButton(DocumentUpload.class);
-    }
-
     @Test(description = "should skip country selection screen and successfully upload document when only driver's license preselected with a valid country code")
     public void testSkipCountrySelection() {
 
@@ -150,40 +104,18 @@ public class CountrySelectorIT extends WebSdkIT {
                 .clickConfirmButton(DocumentUpload.class);
     }
 
-
-    @Test(description = "should show country selection screen with only driver's license preselected and showCountrySelection enabled")
-    public void testShowCountrySelectionWithShowCountrySelectionEnabled() {
-        var countrySelector = onfido()
-                .withSteps(new DocumentStep().withDocumentType(DRIVING_LICENCE, true).withShowCountrySelection(true))
-                .init(CountrySelector.class);
-
-        assertThat(countrySelector.isSubmitBtnEnabled()).isFalse();
-    }
-
-    @Test(description = "should show country selection screen when multiple documents enabled with boolean values (legacy config)")
-    public void testShowCountrySelectionWithMultipleDocsEnabled() {
-        onfido()
-                .withSteps(new DocumentStep().withDocumentType(DRIVING_LICENCE, true).withDocumentType(IDENTITY_CARD, true))
-                .init(IdDocumentSelector.class)
-                .select(IDENTITY_CARD, CountrySelector.class)
-                .select(CountrySelector.SUPPORTED_COUNTRY, DocumentUpload.class)
-                .upload(NATIONAL_IDENTITY_CARD_JPG)
-                .clickConfirmButton(DocumentUpload.class);
-    }
-
-    @Test(description = "should go to document upload screen when a supported country is selected")
+    @Test(description = "should go to document type Selection screen when a supported country is selected")
     public void testGoToUploadScreenWhenASupportedCountryIsSelected() {
         onfido().withSteps("document")
-                .init(IdDocumentSelector.class)
-                .select(IDENTITY_CARD, CountrySelector.class)
-                .select(CountrySelector.SUPPORTED_COUNTRY, DocumentUpload.class);
+                .init(CountrySelector.class)
+                .select(CountrySelector.SUPPORTED_COUNTRY, IdDocumentSelector.class)
+                .select(IDENTITY_CARD, DocumentUpload.class);
     }
 
     @Test(description = "should be able to select \"Hong Kong\" as a supported country option when searching with \"香\"")
     public void testSelectHongKong() {
         var countrySelector = onfido().withSteps("document")
-                                      .init(IdDocumentSelector.class)
-                                      .select(IDENTITY_CARD, CountrySelector.class)
+                                      .init(CountrySelector.class)
                                       .searchFor("香 ")
                                       .selectFirstOptionInDropdownMenu();
 
@@ -195,8 +127,7 @@ public class CountrySelectorIT extends WebSdkIT {
     @Test(description = "should display \"Country not found\" message and error variant of help icon when searching for \"xyz\"", enabled = false)
     public void testCountryNotFoundMessage() {
         var countrySelector = onfido().withSteps("document")
-                                      .init(IdDocumentSelector.class)
-                                      .select(IDENTITY_CARD, CountrySelector.class)
+                                      .init(CountrySelector.class)
                                       .select("xyz");
 
         assertThat(countrySelector.countryNotFoundMessageIdDisabled()).isTrue();


### PR DESCRIPTION
# Problem
As part a of a new design improvement, we are filtering DocumentType per country see below design,
https://www.figma.com/file/63ctqWgFALSE3salCca0fA/Restricted-docs-on-Orchestrated-SDK-IX-2194?node-id=1926%3A33
This requires the end user to select country first ( before selecting document type) 
Also orchestration will supply these list dynamically. 
# Solution
Step 1 of this implementation is to switch the order the order of the screens.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [X ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
