### PR TITLE
Feature/ filter country dropdown with workflow config

### DIFF
--- a/src/components/CountrySelector/DocumentCountrySelector.tsx
+++ b/src/components/CountrySelector/DocumentCountrySelector.tsx
@@ -52,18 +52,17 @@ class CountrySelection extends CountrySelectionBase {
     this.props.actions.resetIdDocumentIssuingCountry()
   }
 
-  getSupportedCountries = (): CountryData[] => {
-    const { document_selection } = this.props
-    const countryFilter =
-      document_selection &&
-      document_selection.filter((value, index, self) => {
-        return (
-          self.findIndex((v) => v.issuing_country === value.issuing_country) ===
-          index
-        )
-      })
+  countryFilter = (): documentSelectionType[] | undefined =>
+    this.props.document_selection &&
+    this.props.document_selection.filter((value, index, self) => {
+      return (
+        self.findIndex((v) => v.issuing_country === value.issuing_country) ===
+        index
+      )
+    })
 
-    return getSupportedCountriesForDocument(countryFilter)
+  getSupportedCountries = (): CountryData[] => {
+    return getSupportedCountriesForDocument(this.countryFilter())
   }
 
   renderNoResultsMessage = (): h.JSX.Element => {

--- a/src/components/CountrySelector/DocumentCountrySelector.tsx
+++ b/src/components/CountrySelector/DocumentCountrySelector.tsx
@@ -5,11 +5,10 @@ import { appendToTracking } from 'Tracker'
 import theme from 'components/Theme/style.scss'
 import classNames from 'classnames'
 
-import type { CountryData } from '~types/commons'
+import type { CountryData, documentSelectionType } from '~types/commons'
 import type { WithLocalisedProps, WithTrackingProps } from '~types/hocs'
 import type { StepComponentBaseProps } from '~types/routers'
 import { CountrySelectionBase, DocumentProps, Props } from '.'
-import { DocumentTypes, PoaTypes } from '~types/steps'
 
 import style from './style.scss'
 import { parseTags, preventDefaultOnClick } from '~utils'
@@ -17,6 +16,7 @@ import { parseTags, preventDefaultOnClick } from '~utils'
 export type DocProps = {
   documentType: string
   idDocumentIssuingCountry: CountryData
+  document_selection?: documentSelectionType[] | undefined
 } & Props &
   WithLocalisedProps &
   WithTrackingProps &
@@ -53,7 +53,17 @@ class CountrySelection extends CountrySelectionBase {
   }
 
   getSupportedCountries = (): CountryData[] => {
-    return getSupportedCountriesForDocument()
+    const { document_selection } = this.props
+    const countryFilter =
+      document_selection &&
+      document_selection.filter((value, index, self) => {
+        return (
+          self.findIndex((v) => v.issuing_country === value.issuing_country) ===
+          index
+        )
+      })
+
+    return getSupportedCountriesForDocument(countryFilter)
   }
 
   renderNoResultsMessage = (): h.JSX.Element => {

--- a/src/components/CountrySelector/index.tsx
+++ b/src/components/CountrySelector/index.tsx
@@ -159,11 +159,6 @@ export abstract class CountrySelectionBase extends Component<Props, State> {
     const hasNoCountry = !documentCountry || !documentCountry.country_alpha3
     const hasCountrySelectError =
       !this.isDocumentPreselected() && this.state.showNoResultsError
-    console.log('error hasCountrySelectError', hasCountrySelectError)
-    console.log(
-      'error this.state.alwaysShowEmptyMessage',
-      this.state.alwaysShowEmptyMessage
-    )
     return (
       <ScreenLayout
         actions={

--- a/src/components/CountrySelector/index.tsx
+++ b/src/components/CountrySelector/index.tsx
@@ -83,7 +83,7 @@ export abstract class CountrySelectionBase extends Component<Props, State> {
     query = '',
     populateResults: (results: CountryData[]) => string[]
   ) => {
-    const { documentCountry, documentType } = this.getDocumentProps()
+    const { documentCountry } = this.getDocumentProps()
 
     if (documentCountry && query !== documentCountry.name) {
       this.resetCountry()
@@ -159,7 +159,11 @@ export abstract class CountrySelectionBase extends Component<Props, State> {
     const hasNoCountry = !documentCountry || !documentCountry.country_alpha3
     const hasCountrySelectError =
       !this.isDocumentPreselected() && this.state.showNoResultsError
-
+    console.log('error hasCountrySelectError', hasCountrySelectError)
+    console.log(
+      'error this.state.alwaysShowEmptyMessage',
+      this.state.alwaysShowEmptyMessage
+    )
     return (
       <ScreenLayout
         actions={

--- a/src/supported-documents/index.ts
+++ b/src/supported-documents/index.ts
@@ -3,7 +3,7 @@ const supportedDrivingLicences = require('./supported-docs-driving_licence.json'
 const supportedNationalIDCards = require('./supported-docs-national_identity_card.json')
 const supportedResidencePermit = require('./supported-docs-residence_permit.json')
 
-import type { CountryData } from '~types/commons'
+import type { CountryData, documentSelectionType } from '~types/commons'
 import type { DocumentTypes } from '~types/steps'
 
 type SourceData = {
@@ -42,12 +42,20 @@ export const getCountryDataForDocumentType = (
   return null
 }
 
-export const getSupportedCountriesForDocument = (): CountryData[] => {
+export const getSupportedCountriesForDocument = (
+  filterList?: documentSelectionType[]
+): CountryData[] => {
   const allSupportedSocumentTypes = supportedDrivingLicences
     .concat(supportedNationalIDCards)
     .concat(supportedResidencePermit)
-  console.log('::::', getCountriesList(allSupportedSocumentTypes))
-  return getCountriesList(allSupportedSocumentTypes)
+
+  return filterList
+    ? getCountriesList(allSupportedSocumentTypes).filter((el) => {
+        return filterList.some((f) => {
+          return f.issuing_country === el.country_alpha3
+        })
+      })
+    : getCountriesList(allSupportedSocumentTypes)
 }
 
 const getCountriesList = (supportedDocsData: { sourceData: SourceData }[]) => {

--- a/src/types/commons.ts
+++ b/src/types/commons.ts
@@ -123,6 +123,13 @@ export type ErrorNames =
 
 export type ErrorTypes = 'error' | 'warning'
 
+export type documentSelectionType = {
+  config: unknown
+  document_type: string
+  id: string
+  issuing_country: string
+}
+
 export type MobileConfig = {
   clientStepIndex?: number
   deviceHasCameraSupport?: boolean
@@ -144,6 +151,7 @@ export type MobileConfig = {
   crossDeviceClientIntroProductName?: string
   crossDeviceClientIntroProductLogoSrc?: string
   analyticsSessionUuid?: string
+  document_selection?: Array<documentSelectionType>
 }
 
 export type FormattedError = {

--- a/src/types/redux/globals.ts
+++ b/src/types/redux/globals.ts
@@ -1,5 +1,10 @@
 import * as constants from './constants'
-import type { CountryData, UrlsConfig, ExtendedStepTypes } from '~types/commons'
+import type {
+  CountryData,
+  UrlsConfig,
+  ExtendedStepTypes,
+  documentSelectionType,
+} from '~types/commons'
 import type {
   EnterpriseCobranding,
   EnterpriseLogoCobranding,
@@ -95,4 +100,5 @@ export type GlobalState = {
   anonymousUuid?: string
   clientUuid?: string
   stepsConfig: Array<StepConfig>
+  document_selection?: Array<documentSelectionType>
 }


### PR DESCRIPTION
# Problem
 - Filter the config `document_selection` by unique `issuing_country`
 - Pass the result as filter to `getSupportedCountriesForDocument` 
 - Map the supportedCountriesList the this filter
# Solution

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
