### PR TITLE
Use steps from createOptionsStepsHook in CrossDevice

### DIFF
--- a/src/components/Router/HistoryRouter.tsx
+++ b/src/components/Router/HistoryRouter.tsx
@@ -158,17 +158,11 @@ export const HistoryRouter = (props: HistoryRouterProps) => {
     const previousUserStep = getComponentsList(steps)[previousUserStepIndex]
 
     onFlowChange &&
-      onFlowChange(
-        newFlow,
-        newStep,
-        previousFlow,
-        {
-          userStepIndex: previousUserStepIndex,
-          clientStepIndex: previousUserStep.stepIndex,
-          clientStep: previousUserStep,
-        },
-        steps
-      )
+      onFlowChange(newFlow, newStep, previousFlow, {
+        userStepIndex: previousUserStepIndex,
+        clientStepIndex: previousUserStep.stepIndex,
+        clientSteps: steps,
+      })
     setStepIndex(newStep, newFlow, excludeStepFromHistory)
   }
 

--- a/src/components/Router/MainRouter.tsx
+++ b/src/components/Router/MainRouter.tsx
@@ -35,7 +35,7 @@ const WrappedError = withTheme(GenericError)
 type State = {
   crossDeviceInitialClientStep?: number
   crossDeviceInitialStep?: number
-  workflowSteps?: StepConfig[]
+  crossDeviceSteps: StepConfig[]
 }
 
 export default class MainRouter extends Component<InternalRouterProps, State> {
@@ -72,7 +72,7 @@ export default class MainRouter extends Component<InternalRouterProps, State> {
     const {
       crossDeviceInitialClientStep,
       crossDeviceInitialStep,
-      workflowSteps,
+      crossDeviceSteps,
     } = this.state
 
     return {
@@ -89,7 +89,7 @@ export default class MainRouter extends Component<InternalRouterProps, State> {
       language,
       poaDocumentType,
       step: crossDeviceInitialStep,
-      steps: workflowSteps ? workflowSteps : steps,
+      steps: crossDeviceSteps ? crossDeviceSteps : steps,
       token,
       urls,
       woopraCookie,
@@ -102,19 +102,14 @@ export default class MainRouter extends Component<InternalRouterProps, State> {
     newFlow,
     _newStep,
     _previousFlow,
-    { userStepIndex, clientStepIndex },
-    workflowSteps
+    { userStepIndex, clientStepIndex, clientSteps }
   ) => {
     if (newFlow === 'crossDeviceSteps') {
       this.setState({
         crossDeviceInitialStep: userStepIndex,
         crossDeviceInitialClientStep: clientStepIndex,
+        crossDeviceSteps: clientSteps,
       })
-      if (this.useWorkflowRun()) {
-        this.setState({
-          workflowSteps: workflowSteps,
-        })
-      }
     }
   }
 

--- a/src/types/routers.ts
+++ b/src/types/routers.ts
@@ -44,9 +44,8 @@ export type FlowChangeCallback = (
   payload: {
     userStepIndex: number
     clientStepIndex: number
-    clientStep: ComponentStep
-  },
-  workflowSteps: StepConfig[]
+    clientSteps: StepConfig[]
+  }
 ) => void
 
 export type ChangeFlowProp = (

--- a/test/webtest/src/test/java/com/onfido/qa/websdk/test/UserConsentIT.java
+++ b/test/webtest/src/test/java/com/onfido/qa/websdk/test/UserConsentIT.java
@@ -90,4 +90,26 @@ public class UserConsentIT extends WebSdkIT {
 
         verifyCopy(welcome.title(), "welcome.title");
     }
+
+    @Test(description = "Is not displayed on cross device", groups = {"percy", "tabs"})
+    public void testIsNotDisplayedOnCrossDevice() {
+        var link = init(Welcome.class, "welcome", "document")
+                .continueToNextStep(UserConsent.class)
+                .acceptUserConsent(RestrictedDocumentSelection.class)
+                .selectCountry(RestrictedDocumentSelection.SUPPORTED_COUNTRY)
+                .selectDocument(PASSPORT, DocumentUpload.class)
+                .switchToCrossDevice().getSecureLink().copyLink();
+
+        openMobileScreen(link);
+
+        var intro = verifyPage(CrossDeviceClientIntro.class);
+        switchToMainScreen();
+
+        verifyPage(CrossDeviceMobileConnected.class);
+        switchToMobileScreen();
+
+        var documentUpload = intro.clickContinue(DocumentUpload.class);
+
+        verifyCopy(documentUpload.title(), "doc_submit.title_passport");
+    }
 }


### PR DESCRIPTION
Steps from options may not contains some steps added by the useSteps hook.

# Problem

When switching to cross device, the mobile app would start with the steps provided by the init options. But UserConsent step is added dynamically in the `useSteps` hook in HistoryRouter.
When the mobile app is loaded, we miss the UserConsent step and we land on the wrong step index.
This is why we see the Face Upload instead of the Document Upload when User Consent is displayed.

# Solution

Send the steps provided by useSteps in the mobile configuration, so we ensure that we have the same steps in the browser and in the mobile.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [X] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
