### PR TITLE
Load locale files dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ## [next-version]
 
+## Changed
+
+- Internal: Add dynamically loaded files (except en_US)
+
 ## [8.1.0] - 2022-06-13
 
 ### Changed
@@ -33,7 +37,6 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Internal: Update FaceTec SDK on Auth step from 9.4.5 to 9.4.11
 - Internal: Upgrade `typescript` to 4.6.2
 - Public: Add UI customization option for `colorBackgroundQRCode`
-- Public: Fix for http 204 request errors due to parsing
 
 ### Fixed
 

--- a/src/components/App/ModalApp.tsx
+++ b/src/components/App/ModalApp.tsx
@@ -3,7 +3,7 @@ import { EventEmitter2 } from 'eventemitter2'
 import { v4 as uuidv4 } from 'uuid'
 
 import { SdkOptionsProvider } from '~contexts/useSdkOptions'
-import { LocaleProvider } from '~locales'
+import { LocaleLoader, LocaleProvider } from '~locales'
 import {
   parseJwt,
   getUrlsFromJWT,
@@ -398,7 +398,11 @@ class ModalApp extends Component<Props> {
             containerEl={containerEl}
             shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
           >
-            <Router {...otherProps} />
+            <LocaleLoader
+              shouldAutoFocus={options.autoFocusOnInitialScreenTitle}
+            >
+              <Router {...otherProps} />
+            </LocaleLoader>
           </Modal>
         </SdkOptionsProvider>
       </LocaleProvider>

--- a/src/components/Router/CrossDeviceMobileRouter.tsx
+++ b/src/components/Router/CrossDeviceMobileRouter.tsx
@@ -12,7 +12,6 @@ import withTheme from '../Theme'
 import { setUICustomizations, setCobrandingLogos } from '../Theme/utils'
 import Spinner from '../Spinner'
 import GenericError from '../GenericError'
-
 import {
   setupAnalyticsCookie,
   setWoopraCookie,
@@ -20,9 +19,8 @@ import {
   uninstallAnalyticsCookie,
   uninstallWoopra,
 } from '../../Tracker'
-import { LocaleProvider } from '~locales'
+import { LocaleLoader, LocaleProvider } from '~locales'
 import { HistoryRouterWrapper } from './HistoryRouter'
-
 import type { ErrorNames, MobileConfig } from '~types/commons'
 import type { SupportedLanguages, LocaleConfig } from '~types/locales'
 import type { CaptureKeys } from '~types/redux'
@@ -367,12 +365,8 @@ export default class CrossDeviceMobileRouter extends Component<
   }
 
   renderContent = (): h.JSX.Element => {
-    const { hasCamera, token, options, urls } = this.props
-    const { crossDeviceError, loading, steps } = this.state
-
-    if (loading) {
-      return <WrappedSpinner disableNavigation />
-    }
+    const { hasCamera, options, urls } = this.props
+    const { crossDeviceError, steps } = this.state
 
     if (crossDeviceError) {
       return <WrappedError disableNavigation={true} error={crossDeviceError} />
@@ -437,11 +431,18 @@ export default class CrossDeviceMobileRouter extends Component<
   }
 
   render(): h.JSX.Element {
-    const { language } = this.state
+    const { language, loading } = this.state
+    const { autoFocusOnInitialScreenTitle } = this.props.options
+
+    if (loading) {
+      return <WrappedSpinner disableNavigation={true} />
+    }
 
     return (
       <LocaleProvider language={language}>
-        {this.renderContent()}
+        <LocaleLoader shouldAutoFocus={autoFocusOnInitialScreenTitle}>
+          {this.renderContent()}
+        </LocaleLoader>
       </LocaleProvider>
     )
   }

--- a/src/components/Spinner/index.tsx
+++ b/src/components/Spinner/index.tsx
@@ -16,19 +16,20 @@ const Spinner = ({ shouldAutoFocus }: SpinnerProps) => {
   }, [shouldAutoFocus])
 
   return (
-    <div
-      className={style.loader}
-      aria-live="assertive"
-      tabIndex={-1}
-      // role="progressbar" fixes issues on iOS where the aria-live="assertive" is not announced
-      role="progressbar"
-      ref={containerRef}
-      aria-label={translate('generic.loading')}
-    >
-      <div className={style.inner}>
-        <div />
-        <div />
-        <div />
+    <div>
+      <div
+        className={style.loader}
+        aria-live="assertive"
+        tabIndex={-1}
+        role="progressbar" // fixes issues on iOS where the aria-live="assertive" is not announced
+        ref={containerRef}
+        aria-label={translate('generic.loading')}
+      >
+        <div className={style.inner}>
+          <div />
+          <div />
+          <div />
+        </div>
       </div>
     </div>
   )

--- a/src/types/hocs.ts
+++ b/src/types/hocs.ts
@@ -16,6 +16,7 @@ export type WithLocalisedProps = {
   language?: SupportedLanguages
   parseTranslatedTags: TranslatedTagParser
   translate: TranslateCallback
+  loading?: boolean
 }
 
 export type WithCameraDetectionProps = {


### PR DESCRIPTION
# Problem
Locale files are bundled inside our `onfido.min.js` bundle, increasing its size. 

# Solution
Dynamically load locale files (except `en_US`). Saves around 25kb according to bundlewatch.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
