### PR TITLE
Hide User Consent when consent already given

### DIFF
--- a/src/components/Capture/__tests__/Document.test.tsx
+++ b/src/components/Capture/__tests__/Document.test.tsx
@@ -10,8 +10,6 @@ import Document from '../Document'
 import withCaptureVariant from '../withCaptureVariant'
 
 import type { StepComponentDocumentProps } from '~types/routers'
-import { createOptionsStepsHook } from '../../Router/createOptionsStepsHook'
-import { NarrowSdkOptions } from '~types/commons'
 
 jest.mock('../withCrossDeviceWhenNoCamera')
 
@@ -21,10 +19,6 @@ const DocumentVideoCapture = withCaptureVariant(Document, {
   side: 'front',
   requestedVariant: 'video',
 })
-
-const defaultOptions: NarrowSdkOptions = {
-  steps: [{ type: 'welcome' }, { type: 'document' }],
-}
 
 const defaultProps: StepComponentDocumentProps = {
   allowCrossDeviceFlow: true,
@@ -40,7 +34,6 @@ const defaultProps: StepComponentDocumentProps = {
   trackScreen: jest.fn(),
   triggerOnError: jest.fn(),
   hasCamera: true,
-  useSteps: createOptionsStepsHook(defaultOptions),
   completeStep: jest.fn(),
   ...mockedReduxProps,
 }

--- a/src/components/Confirm/__tests__/Confirm.test.tsx
+++ b/src/components/Confirm/__tests__/Confirm.test.tsx
@@ -45,7 +45,6 @@ const defaultStepComponentBaseProps: StepComponentBaseProps = {
   trackScreen: jest.fn(),
   completeStep: jest.fn(),
   step: 0,
-  useSteps: jest.fn(),
 }
 
 const defaultLocalisedProps: WithLocalisedProps = {

--- a/src/components/CountrySelector/__tests__/index.test.tsx
+++ b/src/components/CountrySelector/__tests__/index.test.tsx
@@ -3,12 +3,6 @@ import { shallow } from 'enzyme'
 
 import { mockedReduxProps } from '~jest/MockedReduxProvider'
 
-import { createOptionsStepsHook } from '../../Router/createOptionsStepsHook'
-import { NarrowSdkOptions } from '~types/commons'
-
-const defaultOptions: NarrowSdkOptions = {
-  steps: [{ type: 'welcome' }],
-}
 import { Props as CountrySelectorProps } from '../index'
 import IdentityCountrySelector from '../IdentityCountrySelector'
 
@@ -35,7 +29,6 @@ const defaultProps: CountrySelectorProps = {
   triggerOnError: jest.fn(),
   hasCamera: true,
   allowCrossDeviceFlow: true,
-  useSteps: createOptionsStepsHook(defaultOptions),
   completeStep: jest.fn(),
   ...mockedReduxProps,
 }

--- a/src/components/DocumentVideo/Confirm/__tests__/index.test.tsx
+++ b/src/components/DocumentVideo/Confirm/__tests__/index.test.tsx
@@ -17,7 +17,6 @@ import Confirm from '../index'
 
 import type { NarrowSdkOptions } from '~types/commons'
 import type { StepComponentDocumentProps } from '~types/routers'
-import { createOptionsStepsHook } from '../../../Router/createOptionsStepsHook'
 
 jest.mock('~utils/objectUrl')
 jest.mock('~utils/onfidoApi')
@@ -52,7 +51,6 @@ const defaultProps: StepComponentDocumentProps = {
   steps: [{ type: 'document' }],
   trackScreen: jest.fn(),
   triggerOnError: jest.fn(),
-  useSteps: createOptionsStepsHook(defaultOptions),
   completeStep: jest.fn(),
   ...mockedReduxProps,
 }

--- a/src/components/Router/CrossDeviceMobileRouter.tsx
+++ b/src/components/Router/CrossDeviceMobileRouter.tsx
@@ -21,7 +21,7 @@ import {
   uninstallWoopra,
 } from '../../Tracker'
 import { LocaleProvider } from '~locales'
-import { HistoryRouter } from './HistoryRouter'
+import { HistoryRouterWrapper } from './HistoryRouter'
 
 import type { ErrorNames, MobileConfig } from '~types/commons'
 import type { SupportedLanguages, LocaleConfig } from '~types/locales'
@@ -413,7 +413,7 @@ export default class CrossDeviceMobileRouter extends Component<
               />
             }
           >
-            <HistoryRouter
+            <HistoryRouterWrapper
               {...this.props}
               {...this.state}
               crossDeviceClientError={this.setError}

--- a/src/components/Router/MainRouter.tsx
+++ b/src/components/Router/MainRouter.tsx
@@ -6,7 +6,7 @@ import withTheme from '../Theme'
 import GenericError from '../GenericError'
 
 import { getWoopraCookie } from '../../Tracker'
-import { HistoryRouter } from './HistoryRouter'
+import { HistoryRouterWrapper } from './HistoryRouter'
 
 import type { MobileConfig } from '~types/commons'
 import type { StepConfig } from '~types/steps'
@@ -174,7 +174,7 @@ export default class MainRouter extends Component<InternalRouterProps, State> {
               />
             }
           >
-            <HistoryRouter
+            <HistoryRouterWrapper
               {...this.props}
               mobileConfig={this.generateMobileConfig()}
               onFlowChange={this.onFlowChange}
@@ -183,6 +183,11 @@ export default class MainRouter extends Component<InternalRouterProps, State> {
                 this.useWorkflowRun()
                   ? createWorkflowStepsHook(options, urls)
                   : createOptionsStepsHook(options)
+              }
+              fallback={
+                <Spinner
+                  shouldAutoFocus={options.autoFocusOnInitialScreenTitle}
+                />
               }
             />
           </PoASupportedCountriesProvider>

--- a/src/components/Router/createCrossDeviceStepsHook.tsx
+++ b/src/components/Router/createCrossDeviceStepsHook.tsx
@@ -1,21 +1,22 @@
 import { useCallback, useState } from 'preact/hooks'
-import { StepsHook, StepsLoadingStatus } from '~types/routers'
+import { StepsHook } from '~types/routers'
 import { StepConfig } from '~types/steps'
 
 export const createCrossDeviceStepsHook = (
   defaultSteps: StepConfig[],
   onCompleteStep: (docData: unknown[]) => void
 ): StepsHook => () => {
-  const [status, setStatus] = useState<StepsLoadingStatus>('idle')
+  const [hasNextStep, setHasNextStep] = useState<boolean>(true)
   const [steps] = useState(defaultSteps)
 
   return {
-    loadNextStep: useCallback(() => setStatus('finished'), []),
+    loadNextStep: useCallback(() => setHasNextStep(false), []),
     completeStep: useCallback((data) => {
       if (Array.isArray(data)) onCompleteStep(data)
     }, []),
     error: undefined,
-    status,
+    loading: false,
+    hasNextStep,
     steps,
   }
 }

--- a/src/components/Router/createOptionsStepsHook.tsx
+++ b/src/components/Router/createOptionsStepsHook.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'preact/hooks'
-import { StepsHook, StepsLoadingStatus } from '~types/routers'
+import { StepsHook } from '~types/routers'
 import { StepConfig } from '~types/steps'
 import useUserConsent from '~contexts/useUserConsent'
 import { NarrowSdkOptions } from '~types/commons'
@@ -8,18 +8,19 @@ export const createOptionsStepsHook = (
   options: NarrowSdkOptions
 ): StepsHook => () => {
   const { addUserConsentStep } = useUserConsent()
-  const [status, setStatus] = useState<StepsLoadingStatus>('idle')
-  const [steps, setSteps] = useState<StepConfig[]>(options.steps)
+  const [hasNextStep, setHasNextStep] = useState<boolean>(true)
+  const [steps, setSteps] = useState<StepConfig[] | undefined>(undefined)
 
   useEffect(() => {
     setSteps(addUserConsentStep(options.steps))
   }, [addUserConsentStep])
 
   return {
-    loadNextStep: useCallback(() => setStatus('finished'), []),
+    loadNextStep: useCallback(() => setHasNextStep(false), []),
     completeStep: useCallback(() => ({}), []),
     error: undefined,
-    status,
+    loading: false,
+    hasNextStep,
     steps,
   }
 }

--- a/src/components/UserConsent/__tests__/index.test.tsx
+++ b/src/components/UserConsent/__tests__/index.test.tsx
@@ -16,7 +16,6 @@ import { UserConsentContext } from '~contexts/useUserConsent'
 configure({
   testIdAttribute: 'data-onfido-qa',
 })
-import { createOptionsStepsHook } from '../../Router/createOptionsStepsHook'
 
 jest.mock('dompurify')
 
@@ -52,7 +51,6 @@ const defaultProps: StepComponentBaseProps = {
   resetSdkFocus: jest.fn(),
   trackScreen: jest.fn(),
   step: 0,
-  useSteps: createOptionsStepsHook(defaultOptions),
   completeStep: jest.fn(),
 }
 

--- a/src/components/Welcome/__tests__/index.test.tsx
+++ b/src/components/Welcome/__tests__/index.test.tsx
@@ -10,7 +10,6 @@ import Welcome from '../index'
 
 import type { NarrowSdkOptions } from '~types/commons'
 import type { StepComponentBaseProps } from '~types/routers'
-import { createOptionsStepsHook } from '../../Router/createOptionsStepsHook'
 
 const defaultOptions: NarrowSdkOptions = {
   steps: [{ type: 'welcome' }, { type: 'document' }],
@@ -31,7 +30,6 @@ const defaultProps: StepComponentBaseProps = {
   resetSdkFocus: jest.fn(),
   trackScreen: jest.fn(),
   step: 0,
-  useSteps: createOptionsStepsHook(defaultOptions),
   completeStep: jest.fn(),
 }
 

--- a/src/components/utils/steps.ts
+++ b/src/components/utils/steps.ts
@@ -39,3 +39,6 @@ export const findFirstIndex = (
   componentsList: ComponentStep[],
   clientStepIndex: number
 ) => componentsList.findIndex(({ stepIndex }) => stepIndex === clientStepIndex)
+
+export const findFirstEnabled = (componentsList: ComponentStep[]) =>
+  componentsList.findIndex((c) => !c.step.skip)

--- a/src/types/routers.ts
+++ b/src/types/routers.ts
@@ -1,4 +1,4 @@
-import { h, ComponentType } from 'preact'
+import { h, ComponentType, ComponentChildren } from 'preact'
 import { ActionCreatorsMapObject } from 'redux'
 
 import type { ErrorCallback } from './api'
@@ -86,15 +86,26 @@ export type InternalRouterProps = {
   options: NarrowSdkOptions
 } & ExternalRouterProps
 
-export type HistoryRouterProps = {
+type HistoryRouterBaseProps = {
   crossDeviceClientError?: (name?: ErrorNames) => void
   mobileConfig?: MobileConfig
   sendClientSuccess?: () => void
   step?: number
   stepIndexType?: StepIndexType
   workflowRunId?: string
-  useSteps: StepsHook
 } & InternalRouterProps
+
+export type HistoryRouterWrapperProps = HistoryRouterBaseProps & {
+  useSteps: StepsHook
+  fallback?: ComponentChildren
+}
+
+export type HistoryRouterProps = HistoryRouterBaseProps & {
+  loadNextStep: (p: () => void) => void
+  completeStep: (data: CompleteStepValue) => void
+  hasNextStep: boolean
+  steps: StepConfig[]
+}
 
 export type StepsRouterProps = {
   back: () => void
@@ -107,7 +118,7 @@ export type StepsRouterProps = {
   triggerOnError: ErrorCallback
   isLoadingStep?: boolean
   completeStep: (data: CompleteStepValue) => void
-} & HistoryRouterProps
+} & HistoryRouterBaseProps
 
 export type StepComponentBaseProps = {
   resetSdkFocus: () => void
@@ -164,19 +175,13 @@ export type StepperState = {
   docData: unknown[]
 }
 
-export type StepsLoadingStatus =
-  | 'idle'
-  | 'loading'
-  | 'success'
-  | 'finished'
-  | 'error'
-
 export type CompleteStepValue = Array<{ id: string }> | Record<string, unknown>
 
 export type StepsHook = () => {
   loadNextStep: (p: () => void) => void
   completeStep: (data: CompleteStepValue) => void
-  status: StepsLoadingStatus
-  steps: StepConfig[]
+  loading: boolean
+  hasNextStep: boolean
+  steps: StepConfig[] | undefined
   error: string | undefined
 }

--- a/test/webtest/src/test/java/com/onfido/qa/websdk/test/UserConsentIT.java
+++ b/test/webtest/src/test/java/com/onfido/qa/websdk/test/UserConsentIT.java
@@ -106,17 +106,31 @@ public class UserConsentIT extends WebSdkIT {
         verifyCopy(welcome.title(), "welcome.title");
     }
 
-
-    // FIXME: this actually shows a bug with the web sdk
-    @Test(description = "do not show consent screen, if consent is already given", enabled = false)
+    @Test(description = "do not show consent screen, if consent is already given")
     public void testConsentScreenNotShownWhenConsentAlreadyGiven() {
-        onfido()
+        var document = onfido()
                 .withSteps("document")
                 .withMock(mock -> {
                     mock.extend(Code.SDK_CONFIGURATION, new SdkConfiguration().withEnableRequireApplicantConsents(true));
                     mock.set(Code.CONSENTS, Arrays.asList(new Consent("privacy_notices_read_consent_given").withGranted(true)));
                 })
                 .init(RestrictedDocumentSelection.class);
+
+        verifyCopy(document.title(), "doc_select.title");
+    }
+
+    @Test(description = "do not show consent screen, if consent is already given and not first screen")
+    public void testConsentScreenNotShownWhenConsentAlreadyGivenAndNotFirstScreen() {
+        var document = onfido()
+                .withSteps("welcome","document")
+                .withMock(mock -> {
+                    mock.extend(Code.SDK_CONFIGURATION, new SdkConfiguration().withEnableRequireApplicantConsents(true));
+                    mock.set(Code.CONSENTS, Arrays.asList(new Consent("privacy_notices_read_consent_given").withGranted(true)));
+                })
+                .init(Welcome.class)
+                .continueToNextStep(RestrictedDocumentSelection.class);
+
+        verifyCopy(document.title(), "doc_select.title");
     }
 
     @Test(description = "Is not displayed on cross device", groups = {"percy", "tabs"})


### PR DESCRIPTION
# Problem

When User Consent is the first step, it wasn't hide when the consent was
already given. 

This, because we were not waiting for User Consent step to be injected, so the history
router was pointing to the wrong step index.

# Solution

Now, we display the spinner until the user consent is injected, and then
we display history router with the proper list of steps. History Router
will also ensure to skip Steps flagged with `skip: true`.

Also, cleaning types to avoid the dependency between `StepsRouterProps`
and the Step Hook. And, adding a `loading` boolean instead of the
`status` variable.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [X] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
