### PR TITLE
when taking percy screenshot set link text transparent to not have a …

### DIFF
--- a/test/webtest/src/test/java/com/onfido/qa/websdk/test/CrossDeviceIT.java
+++ b/test/webtest/src/test/java/com/onfido/qa/websdk/test/CrossDeviceIT.java
@@ -21,6 +21,7 @@ public class CrossDeviceIT extends WebSdkIT {
 
     public static final String PRODUCT_NAME = "for a [COMPANY/PRODUCT NAME] loan";
     public static final String LOGO_URL = "https://assets.onfido.com/web-sdk-releases/6.16.0/images/sample-logo_2hXI-.svg";
+    public static final String HIDE_LINK_TEXT = ".onfido-sdk-ui-crossDevice-CrossDeviceLink-linkText {color: transparent}";
 
 
     @Test(description = "should verify UI elements on the cross device intro screen", groups = {"percy"})
@@ -88,7 +89,7 @@ public class CrossDeviceIT extends WebSdkIT {
 
         verifyCopy(crossDeviceLink.copyLinkText(), "get_link.button_copy");
 
-        takePercySnapshot("CrossDeviceIntro-Link");
+        takePercySnapshot("CrossDeviceIntro-Link", HIDE_LINK_TEXT);
         crossDeviceLink.clickCopyLink();
 
         verifyCopy(crossDeviceLink.copyLinkText(), "get_link.button_copied");


### PR DESCRIPTION
# Problem

Percy screenshots show sometimes a diff on the link text for cross device. 

# Solution

Make the link text transparent for the percy screen shot.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
