### PR TITLE
♻️ Remove `isFullScreen` prop from `NavigationBar`

### DIFF
--- a/src/components/NavigationBar/index.tsx
+++ b/src/components/NavigationBar/index.tsx
@@ -8,7 +8,7 @@ import {
 import { useDispatch, useSelector } from 'react-redux'
 import classNames from 'classnames'
 import { setNavigationDisabled } from '../ReduxAppWrapper/store/actions/globals'
-import { withFullScreenState } from '../FullScreen'
+import { withFullScreenState, WithFullScreenStateProps } from '../FullScreen'
 import { isDesktop } from '~utils'
 import { localised } from '~locales'
 import style from './style.scss'
@@ -61,11 +61,10 @@ type NavProps = {
   id?: string
   back?: () => void
   disabled?: boolean
-  isFullScreen?: boolean
   className?: string
 }
 
-type Props = NavProps & WithLocalisedProps
+type Props = NavProps & WithLocalisedProps & WithFullScreenStateProps
 
 class NavigationBar extends Component<Props> {
   private backBtn = createRef<HTMLButtonElement>()


### PR DESCRIPTION
# Problem

It's already exported using `withFullScreenState()`.

# Solution

Remove it. It won't change the exported type.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
