### PR TITLE
🧑‍💻 Add a demo option to skip the document step

### DIFF
--- a/src/demo/demoUtils.ts
+++ b/src/demo/demoUtils.ts
@@ -34,6 +34,7 @@ export type QueryParams = {
   multiDocWithPresetCountry?: StringifiedBoolean
   multiDocWithBooleanValues?: StringifiedBoolean
   noCompleteStep?: StringifiedBoolean
+  noDocumentStep?: StringifiedBoolean
   oneDoc?: DocumentTypes
   oneDocWithCountrySelection?: StringifiedBoolean
   oneDocWithPresetCountry?: StringifiedBoolean
@@ -199,21 +200,23 @@ export const getInitSdkOptions = (): SdkOptions => {
     steps.push({ type: 'poa' })
   }
 
-  steps.push({
-    type: 'document',
-    options: {
-      useLiveDocumentCapture:
-        queryParamToValueString.useLiveDocumentCapture === 'true',
-      uploadFallback: queryParamToValueString.uploadFallback !== 'false',
-      useWebcam: queryParamToValueString.useWebcam === 'true',
-      documentTypes: getPreselectedDocumentTypes(),
-      showCountrySelection:
-        queryParamToValueString.oneDocWithCountrySelection === 'true',
-      forceCrossDevice: queryParamToValueString.forceCrossDevice === 'true',
-      requestedVariant:
-        queryParamToValueString.docVideo === 'true' ? 'video' : 'standard',
-    },
-  })
+  if (queryParamToValueString.noDocumentStep !== 'true') {
+    steps.push({
+      type: 'document',
+      options: {
+        useLiveDocumentCapture:
+          queryParamToValueString.useLiveDocumentCapture === 'true',
+        uploadFallback: queryParamToValueString.uploadFallback !== 'false',
+        useWebcam: queryParamToValueString.useWebcam === 'true',
+        documentTypes: getPreselectedDocumentTypes(),
+        showCountrySelection:
+          queryParamToValueString.oneDocWithCountrySelection === 'true',
+        forceCrossDevice: queryParamToValueString.forceCrossDevice === 'true',
+        requestedVariant:
+          queryParamToValueString.docVideo === 'true' ? 'video' : 'standard',
+      },
+    })
+  }
 
   steps.push({
     type: 'face',


### PR DESCRIPTION
# Problem

To test a later step, I have to go through the document step every time.

# Solution

Provide a demo query parameter that just skips the document step.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
