### PR TITLE
✨ Improve the demo app

### DIFF
--- a/src/contexts/useSdkConfigurationService.tsx
+++ b/src/contexts/useSdkConfigurationService.tsx
@@ -36,13 +36,11 @@ export const SdkConfigurationServiceProvider = ({
   url,
   token,
   fallback,
-  overrideConfiguration = {},
+  overrideConfiguration,
 }: SdkConfigurationServiceProviderProps) => {
   const [configuration, setConfiguration] = useState<
     SdkConfiguration | undefined
   >(undefined)
-
-  const [overrideConfigurationState] = useState(overrideConfiguration)
 
   useEffect(() => {
     if (!url || !token) {
@@ -54,14 +52,14 @@ export const SdkConfigurationServiceProvider = ({
           deepmerge(
             deepmerge(defaultConfiguration, apiConfiguration),
             // TODO: Cleanup the overrideConfigurationState and add it to the mock server
-            process.env.NODE_ENV === 'production'
+            process.env.NODE_ENV === 'production' || !overrideConfiguration
               ? {}
-              : overrideConfigurationState
+              : overrideConfiguration
           )
         )
       )
       .catch(() => setConfiguration(defaultConfiguration))
-  }, [url, token, overrideConfigurationState])
+  }, [url, token, overrideConfiguration])
 
   if (!configuration) {
     return <Fragment>{fallback}</Fragment>

--- a/src/demo/SdkDemo.tsx
+++ b/src/demo/SdkDemo.tsx
@@ -74,7 +74,7 @@ const SdkDemo: FunctionComponent<Props> = ({
 
     if (queryParamToValueString.token) {
       setToken(queryParamToValueString.token)
-    } else {
+    } else if (!token) {
       getToken(
         hasPreview,
         url,

--- a/src/demo/SidebarSections.tsx
+++ b/src/demo/SidebarSections.tsx
@@ -186,7 +186,7 @@ export const SdkOptionsView: FunctionComponent<{
           !!sdkOptions.overrideSdkConfiguration?.experimental_features
             ?.motion_experiment?.enabled
         }
-        title="enable_liveness_experiment"
+        title="motion_experiment"
         onChange={(e) =>
           updateSdkOptions({
             overrideSdkConfiguration: {
@@ -201,7 +201,7 @@ export const SdkOptionsView: FunctionComponent<{
           })
         }
       />
-      &nbsp;enableLivenessExperiment
+      &nbsp;Motion Experiment
     </div>
   </div>
 )

--- a/src/demo/demoUtils.ts
+++ b/src/demo/demoUtils.ts
@@ -29,6 +29,7 @@ export type QueryParams = {
   language?: 'customTranslations' | SupportedLanguages
   customWelcomeScreenCopy?: StringifiedBoolean
   link_id?: string
+  motionExperiment?: StringifiedBoolean
   docVideo?: StringifiedBoolean
   faceVideo?: StringifiedBoolean
   multiDocWithInvalidPresetCountry?: StringifiedBoolean
@@ -246,6 +247,18 @@ export const getInitSdkOptions = (): SdkOptions => {
     }
 
     sdkOptions.steps = steps
+  }
+
+  if (queryParamToValueString.motionExperiment === 'true') {
+    sdkOptions.overrideSdkConfiguration = {
+      ...sdkOptions.overrideSdkConfiguration,
+      experimental_features: {
+        ...sdkOptions.overrideSdkConfiguration?.experimental_features,
+        motion_experiment: {
+          enabled: true,
+        },
+      },
+    }
   }
 
   if (queryParamToValueString.countryCode) {

--- a/src/demo/previewer.ejs
+++ b/src/demo/previewer.ejs
@@ -12,7 +12,7 @@
       http-equiv="Content-Security-Policy"
       content="
         default-src 'self';
-        script-src 'self' https://www.woopra.com https://sentry.io;
+        script-src 'self' https://assets.onfido.com https://www.woopra.com https://sentry.io;
         style-src 'self' 'unsafe-inline' https://assets.onfido.com;
         connect-src 'self' data: blob: <%= process.env.NODE_ENV === 'test' ? 'https://localhost:8080' : '' %> *.onfido.com wss://*.onfido.com *.pre-prod.onfido.xyz  *.dev.onfido.xyz wss://*.dev.onfido.xyz https://www.woopra.com https://sentry.io;
         img-src 'self' data: blob: https://lipis.github.io/flag-icon-css/;

--- a/src/demo/previewer.tsx
+++ b/src/demo/previewer.tsx
@@ -140,7 +140,7 @@ const SdkPreviewer = () => {
         className={`iframe-wrapper${viewOptions.darkBackground ? ' dark' : ''}`}
       >
         <iframe
-          src={`/index.html${window.location.search}`}
+          src={`/${window.location.search}`}
           ref={iframe}
           style={{
             width: viewOptions.iframeWidth,


### PR DESCRIPTION
# Problem

In the demo app, I would like to add a button to turn on/off a feature that is normally provided by the SDK configuration service. Using the `overrideConfiguration` option, I can set the new value at initialisation time, but no change will be taking into account later.

# Solution

Remove the local state in `useSdkConfigurationService` and rely on props instead.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
