### PR TITLE
📝 Make default values explicit in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ onfidoOut.tearDown()
 
 - **`useModal {Boolean} optional`**
 
-  Turns the SDK into a modal, which fades the background and puts the SDK into a contained box.
+  Turns the SDK into a modal, which fades the background and puts the SDK into a contained box. The default value is `false`.
 
   ```javascript
   <script>
@@ -393,11 +393,11 @@ onfidoOut.tearDown()
 
 - **`shouldCloseOnOverlayClick {Boolean} optional`**
 
-  If `useModal` is set to `true`, by default the user can close the SDK by clicking on the close button or on the background overlay. You can disable the user's ability to close the SDK by clicking the background overlay through setting `shouldCloseOnOverlayClick` to `false`.
+  If `useModal` is set to `true`, by default the user can close the SDK by clicking on the close button or on the background overlay. You can disable the user's ability to close the SDK by clicking the background overlay through setting `shouldCloseOnOverlayClick` to `false`. The default value is `true`.
 
-- **`autoFocusOnInitialScreenTitle {Boolean} optional (default: true)`**
+- **`autoFocusOnInitialScreenTitle {Boolean} optional`**
 
-  Sets the SDK to auto focus on the initial screen's title. By default the SDK will auto focus on every screen's title. When disabled, auto focus will not be applied for the initial screen's title. The SDK will still auto focus to all subsequent screens' titles as the user goes through the steps.
+  Sets the SDK to auto focus on the initial screen's title. By default the SDK will auto focus on every screen's title. When disabled, auto focus will not be applied for the initial screen's title. The SDK will still auto focus to all subsequent screens' titles as the user goes through the steps. The default value is `true`.
 
 - **`containerId {String} optional`**
 


### PR DESCRIPTION
# Problem

Default values are documented differently for each option.

# Solution

Make it explicit in the description.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
