### PR TITLE
Support DocumentTypes option

### DIFF
--- a/src/components/RestrictedDocumentSelection/__tests__/useDocumentTypesAdapter.test.ts
+++ b/src/components/RestrictedDocumentSelection/__tests__/useDocumentTypesAdapter.test.ts
@@ -1,0 +1,115 @@
+import { renderHook } from '@testing-library/preact-hooks'
+import { useDocumentTypesAdapter } from '../useDocumentTypesAdapter'
+import { DocumentTypeConfig, DocumentTypes, StepConfig } from '~types/steps'
+import * as assert from 'assert'
+import { buildStepFinder } from '~utils/steps'
+import { getSupportedCountriesForDocument } from '~supported-documents'
+
+const createSteps = (
+  documentTypes: Partial<Record<DocumentTypes, DocumentTypeConfig>>
+): StepConfig[] => {
+  return [
+    { type: 'welcome' },
+    { type: 'document', options: { documentTypes } },
+    { type: 'complete' },
+  ]
+}
+
+const getDocumentStepOption = (steps: StepConfig[]) => {
+  const findStep = buildStepFinder(steps)
+  const options = findStep('document')?.options
+  assert(options)
+  return options
+}
+
+const renderUseDocumentTypesAdapter = () => {
+  const { result } = renderHook(() => useDocumentTypesAdapter())
+  assert(result.current)
+  return result.current
+}
+
+describe('useDocumentTypes', () => {
+  it('ignores "null" country value', () => {
+    const { documentTypesAdapter } = renderUseDocumentTypesAdapter()
+
+    const steps = documentTypesAdapter(
+      createSteps({
+        residence_permit: {
+          country: null,
+        },
+      })
+    )
+
+    // @ts-ignore
+    const { documentSelection, countryFilter } = getDocumentStepOption(steps)
+
+    expect(documentSelection).toBeUndefined()
+    expect(countryFilter).toBeUndefined()
+  })
+
+  it('create a filter for a single country when country is not "null"', () => {
+    const { documentTypesAdapter } = renderUseDocumentTypesAdapter()
+
+    const steps = documentTypesAdapter(
+      createSteps({
+        residence_permit: {
+          country: 'ESP',
+        },
+        driving_licence: {
+          country: 'ESP',
+        },
+      })
+    )
+
+    // @ts-ignore
+    const { documentSelection, countryFilter } = getDocumentStepOption(steps)
+
+    expect(documentSelection).toEqual([
+      {
+        id: '',
+        config: {},
+        document_type: 'residence_permit',
+        issuing_country: 'ESP',
+      },
+      {
+        id: '',
+        config: {},
+        document_type: 'driving_licence',
+        issuing_country: 'ESP',
+      },
+    ])
+    expect(countryFilter).toEqual([
+      {
+        id: '',
+        config: {},
+        document_type: 'residence_permit',
+        issuing_country: 'ESP',
+      },
+    ])
+  })
+
+  it('create a filter for all supported country when value is true', () => {
+    const { documentTypesAdapter } = renderUseDocumentTypesAdapter()
+    const steps = documentTypesAdapter(
+      createSteps({
+        residence_permit: {
+          country: 'ESP',
+        },
+        driving_licence: true,
+      })
+    )
+
+    // @ts-ignore
+    const { documentSelection, countryFilter } = getDocumentStepOption(steps)
+
+    expect(documentSelection.length).toEqual(
+      // All countries for driving_license + one country for resident_permit
+      getSupportedCountriesForDocument('driving_licence').length + 1
+    )
+
+    // All countries for driving_license + resident_permit
+    expect(countryFilter.length).toEqual(
+      getSupportedCountriesForDocument('driving_licence').length
+    )
+  })
+})

--- a/src/components/RestrictedDocumentSelection/index.tsx
+++ b/src/components/RestrictedDocumentSelection/index.tsx
@@ -1,1 +1,2 @@
 export * from './RestrictedDocumentSelection'
+export * from './useDocumentTypesAdapter'

--- a/src/components/RestrictedDocumentSelection/useDocumentTypesAdapter.ts
+++ b/src/components/RestrictedDocumentSelection/useDocumentTypesAdapter.ts
@@ -1,0 +1,90 @@
+import {
+  getCountryDataForDocumentType,
+  getSupportedCountriesForDocument,
+} from '~supported-documents'
+import {
+  CountryConfig,
+  DocumentTypes,
+  StepConfig,
+  StepConfigDocument,
+} from '~types/steps'
+import { documentSelectionType } from '~types/commons'
+import { useCallback } from 'preact/hooks'
+
+const getCountryFilter = (
+  config: Array<documentSelectionType>
+): Array<documentSelectionType> =>
+  config &&
+  config.filter((value, index, self) => {
+    return (
+      self.findIndex((v) => v.issuing_country === value.issuing_country) ===
+      index
+    )
+  })
+
+export const useDocumentTypesAdapter = () => {
+  const documentTypesAdapter = useCallback(
+    (steps: StepConfig[]): StepConfig[] => {
+      // Adapt current `documentTypes` options for Restricted Document
+      const documentStepIndex = steps.findIndex(
+        ({ type }) => type === 'document'
+      )
+      const documentStep = steps[documentStepIndex] as StepConfigDocument
+      const documentTypes = documentStep?.options?.documentTypes
+
+      if (!documentTypes) {
+        return steps
+      }
+
+      const documentTypesKeys = Object.keys(documentTypes) as DocumentTypes[]
+      const documentSelection: documentSelectionType[] = []
+
+      documentTypesKeys.forEach((type) => {
+        if (typeof documentTypes[type] === 'boolean') {
+          // Display this document type for all supported countries
+          getSupportedCountriesForDocument(type).map((countryData) =>
+            documentSelection.push({
+              document_type: type,
+              issuing_country: countryData.country_alpha3,
+              config: {},
+              id: '',
+            })
+          )
+        }
+
+        // Display this document type for a single country
+        const country = (documentTypes[type] as CountryConfig).country
+        const countryData = getCountryDataForDocumentType(country, type)
+        if (countryData) {
+          documentSelection.push({
+            document_type: type,
+            issuing_country: countryData.country_alpha3,
+            config: {},
+            id: '',
+          })
+        }
+      })
+
+      if (documentSelection.length === 0) {
+        return steps
+      }
+
+      const countryFilter = getCountryFilter(documentSelection)
+
+      return [
+        ...steps.slice(0, documentStepIndex),
+        {
+          ...documentStep,
+          options: {
+            ...documentStep.options,
+            documentSelection,
+            countryFilter,
+          },
+        },
+        ...steps.slice(documentStepIndex + 1),
+      ]
+    },
+    []
+  )
+  return { documentTypesAdapter }
+}

--- a/src/components/Router/StepComponentMap.tsx
+++ b/src/components/Router/StepComponentMap.tsx
@@ -51,6 +51,7 @@ import Guidance from '../ProofOfAddress/Guidance'
 import PoADocumentSelector from '../DocumentSelector/PoADocumentSelector'
 import PoACountrySelector from '../CountrySelector/PoACountrySelector'
 import { RestrictedDocumentSelection } from '../RestrictedDocumentSelection'
+import { getCountryDataForDocumentType } from '~supported-documents'
 
 let LazyAuth: ComponentType<StepComponentProps>
 
@@ -292,13 +293,14 @@ const buildRequiredSelfieComponents = (
 }
 
 const buildNonPassportPreCaptureComponents = (
-  hasOnePreselectedDocument: boolean
+  hasOnePreselectedDocument: boolean,
+  showCountrySelection: boolean
 ): ComponentType<StepComponentProps>[] => {
-  const prependDocumentSelector = hasOnePreselectedDocument
-    ? []
-    : [RestrictedDocumentSelection]
+  const prependDocumentSelector =
+    hasOnePreselectedDocument && !showCountrySelection
+      ? []
+      : [RestrictedDocumentSelection]
   // @ts-ignore
-  // TODO: convert DocumentSelector to TS
   return [...prependDocumentSelector]
 }
 
@@ -310,6 +312,13 @@ const buildDocumentComponents = (
   mobileFlow: boolean | undefined,
   isFirstCaptureStepInFlow: boolean | undefined
 ): ComponentType<StepComponentProps>[] => {
+  const options = documentStep?.options
+
+  const configForDocumentType =
+    documentType && options?.documentTypes
+      ? options?.documentTypes[documentType]
+      : undefined
+
   const shouldUseVideo =
     documentStep?.options?.requestedVariant === 'video' &&
     window.MediaRecorder != null
@@ -352,8 +361,25 @@ const buildDocumentComponents = (
       : [...preCaptureComponents, ...standardCaptureComponents]
   }
 
+  const countryCode =
+    typeof configForDocumentType === 'boolean'
+      ? null
+      : configForDocumentType?.country
+  const supportedCountry = getCountryDataForDocumentType(
+    countryCode,
+    documentType
+  )
+  const hasMultipleDocumentsWithUnsupportedCountry =
+    !hasOnePreselectedDocument && !supportedCountry
+  const hasCountryCodeOrDocumentTypeFlag =
+    countryCode !== null || configForDocumentType === true
+  const showCountrySelection =
+    hasMultipleDocumentsWithUnsupportedCountry &&
+    hasCountryCodeOrDocumentTypeFlag
+
   const preCaptureComponents = buildNonPassportPreCaptureComponents(
-    hasOnePreselectedDocument
+    hasOnePreselectedDocument,
+    showCountrySelection
   )
 
   if (shouldUseVideo) {

--- a/src/components/Router/createOptionsStepsHook.tsx
+++ b/src/components/Router/createOptionsStepsHook.tsx
@@ -3,17 +3,20 @@ import { StepsHook } from '~types/routers'
 import { StepConfig } from '~types/steps'
 import useUserConsent from '~contexts/useUserConsent'
 import { NarrowSdkOptions } from '~types/commons'
+import { useDocumentTypesAdapter } from '../RestrictedDocumentSelection'
 
 export const createOptionsStepsHook = (
   options: NarrowSdkOptions
 ): StepsHook => () => {
   const { addUserConsentStep } = useUserConsent()
+  const { documentTypesAdapter } = useDocumentTypesAdapter()
+
   const [hasNextStep, setHasNextStep] = useState<boolean>(true)
   const [steps, setSteps] = useState<StepConfig[] | undefined>(undefined)
 
   useEffect(() => {
-    setSteps(addUserConsentStep(options.steps))
-  }, [addUserConsentStep])
+    setSteps(addUserConsentStep(documentTypesAdapter(options.steps)))
+  }, [addUserConsentStep, documentTypesAdapter])
 
   return {
     loadNextStep: useCallback(() => setHasNextStep(false), []),

--- a/test/webtest/src/test/java/com/onfido/qa/websdk/test/RestrictedDocumentSelectionIT.java
+++ b/test/webtest/src/test/java/com/onfido/qa/websdk/test/RestrictedDocumentSelectionIT.java
@@ -59,7 +59,7 @@ public class RestrictedDocumentSelectionIT extends WebSdkIT {
 
         var countrySelector = onfido().init(Welcome.class)
                                       .continueToNextStep(RestrictedDocumentSelection.class);
-                            
+
 
         verifyCopy(countrySelector.title(), "doc_select.title");
         verifyCopy(countrySelector.selectorLabel(), "doc_select.section.header_country");
@@ -72,7 +72,7 @@ public class RestrictedDocumentSelectionIT extends WebSdkIT {
             description = "should skip Restricted document selection screen and successfully upload a document when only residence permit document type preselected"
     )
     public void testSkipCountryScreenForResidencePermit() {
-        var welcome = onfido().withSteps("welcome", new DocumentStep().withDocumentType(RESIDENT_PERMIT)).init(Welcome.class);
+        var welcome = onfido().withSteps("welcome", new DocumentStep().withDocumentType(RESIDENT_PERMIT, new Option("ESP"))).init(Welcome.class);
         var documentUpload = welcome.continueToNextStep(DocumentUpload.class);
 
         verifyCopy(documentUpload.title(), "doc_submit.title_permit_front");
@@ -87,7 +87,7 @@ public class RestrictedDocumentSelectionIT extends WebSdkIT {
     }
 
     @Test(
-            description = "should successfully upload a document when multiple document types have country preset"
+            description = "should successfully upload a document when multiple document types have country preset, and ignore 'null' country"
     )
     public void testSkippingCountrySelectionIfPreset() {
 
@@ -111,17 +111,12 @@ public class RestrictedDocumentSelectionIT extends WebSdkIT {
         documentUpload = documentSelector.selectDocument(IDENTITY_CARD, DocumentUpload.class);
         verifyCopy(documentUpload.title(), "doc_submit.title_id_front");
 
-        documentSelector = documentUpload.back(RestrictedDocumentSelection.class).selectCountry(RestrictedDocumentSelection.SUPPORTED_COUNTRY);
-        documentUpload = documentSelector.selectDocument(RESIDENT_PERMIT, DocumentUpload.class);
-
-        verifyCopy(documentUpload.title(), "doc_submit.title_permit_front");
-
         var confirm = documentUpload.upload(NATIONAL_IDENTITY_CARD_JPG);
         verifyCopy(confirm.title(), "doc_confirmation.title");
         verifyCopy(confirm.message(), "doc_confirmation.body_permit");
 
         var documentUploadBack = confirm.clickConfirmButton(DocumentUpload.class);
-        verifyCopy(documentUploadBack.title(), "doc_submit.title_permit_back");
+        verifyCopy(documentUploadBack.title(), "doc_submit.title_id_back");
 
     }
 
@@ -135,7 +130,7 @@ public class RestrictedDocumentSelectionIT extends WebSdkIT {
                 .continueToNextStep(RestrictedDocumentSelection.class)
                 .selectCountry(RestrictedDocumentSelection.SUPPORTED_COUNTRY)
                 .selectDocument(DRIVING_LICENCE, DocumentUpload.class)
-               
+
                 .back(RestrictedDocumentSelection.class)
                 .selectCountry(RestrictedDocumentSelection.SUPPORTED_COUNTRY)
                 .selectDocument(IDENTITY_CARD, DocumentUpload.class)
@@ -189,7 +184,7 @@ public class RestrictedDocumentSelectionIT extends WebSdkIT {
         var countrySelector = onfido().withSteps("document")
                                       .init(RestrictedDocumentSelection.class)
                                       .selectCountry("xyz");
-                        
+
         assertThat(countrySelector.countryNotFoundMessageIdDisabled()).isTrue();
     }
 }


### PR DESCRIPTION
# Problem

Restricted Document Selection doesn't support the legacy document/country selection options

# Solution

Added `useDocumentTypesAdapter` which will create `documentSelectionType` filters from the options.

Also, put back code to hide document/country selection when a single document type
with a supported country is selected.

Note: We do not support 'null' country and `howCountrySelection` because in the new design, selecting a country is mandatory.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [X] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
