### PR TITLE
feat: do not display asterisk on required field, highlight only required

### DIFF
--- a/src/components/Capture/ProfileData.tsx
+++ b/src/components/Capture/ProfileData.tsx
@@ -9,7 +9,6 @@ import {
   Validation,
   Input,
   Button,
-  Asterisk,
 } from '@onfido/castor-react'
 import { useLocales } from '~locales'
 import ScreenLayout from '../Theme/ScreenLayout'
@@ -206,9 +205,7 @@ const FieldComponent = ({
       <FieldLabel>
         <span>
           {getTranslatedFieldLabel(translate, type, selectedCountry)}
-          {isRequired ? (
-            <Asterisk aria-label="required" />
-          ) : (
+          {!isRequired && (
             <span className={style['optional']}>
               {` ${translate('profile_data.field_optional')}`}
             </span>


### PR DESCRIPTION
# Problem

From design review, no need to highlight "required" fields, only "optional".

# Solution

Remove displaying asterisk on required fields.
