### PR TITLE
POC: Analytics Stacktraces

### DIFF
--- a/build/morph/AnalyticsStacktrace.injection.ts
+++ b/build/morph/AnalyticsStacktrace.injection.ts
@@ -1,0 +1,169 @@
+// @ts-nocheck
+/*
+  Inject origin location data into Logger methods at build time
+    - filePath: string
+    - method: string
+    - lineNumber: string
+*/
+import { Node, Project, SyntaxKind } from 'ts-morph'
+import { fromBasePath } from './project'
+import { abstractOriginInfo, appendArgumentsToCallExpression } from './util'
+
+export default (project: Project) => {
+  let count = 0
+
+  const sourceFile = project.getSourceFile(
+    fromBasePath('/src/Tracker/index.tsx')
+  )
+
+  if (!sourceFile) {
+    throw new Error('Can not find the source file for ExceptionHandler')
+  }
+
+  const sendEvent = sourceFile.getVariableDeclaration('sendEvent')
+  const sendScreen = sourceFile.getVariableDeclaration('sendScreen')
+  const appendToTracking = sourceFile.getVariableDeclaration('appendToTracking')
+  const trackComponent = sourceFile.getVariableDeclaration('trackComponent')
+
+  const stepsRouterSourceFile = project.getSourceFile(
+    fromBasePath('/src/components/Router/StepsRouter.tsx')
+  )
+  
+  const StepsRouter = stepsRouterSourceFile.getClass('StepsRouter')
+
+  const trackScreenMethod = StepsRouter?.getProperties().find(
+    (i) => i.getName() === 'trackScreen'
+  )
+  const trackScreenParams = trackScreenMethod
+    ?.getFirstDescendant(Node.isArrowFunction)
+    ?.getParameters()
+
+    console.log('trackScreenParams', trackScreenParams?.length)
+
+  const render = StepsRouter?.getProperty('render')
+
+  const l = render?.getDescendantsOfKind(SyntaxKind.PropertyAssignment)
+  const trackScreen = l.find((i) => i.getName() === 'trackScreen')
+
+
+
+  const addOriginInfo = (node) => {
+    if(!node){ return }
+
+    const { filePath, methodName, lineNumber } = abstractOriginInfo(
+      node
+    )
+
+    if (
+      filePath === '/src/Tracker/index.tsx' ||
+      filePath === 'src/components/Router/StepsRouter.tsx'
+    ) {
+      return false
+    }
+
+    console.log('filePath', node.getText())
+
+    // count++
+    appendArgumentsToCallExpression(node, {
+      max: 3, //trackScreenParams.length,
+      data: [
+        `{ filePath: '${filePath}', methodName: '${methodName}', lineNumber: '${lineNumber}', analyticsMethod: 'trackScreen'}`,
+      ],
+    })
+  }
+
+  trackScreen?.findReferencesAsNodes().forEach((node) => {
+    const callExpression = node.getFirstAncestor(Node.isCallExpression)
+
+    if (!callExpression) {
+      node.findReferencesAsNodes().forEach(n => {
+        const s = n.getFirstAncestor(Node.isCallExpression)
+
+        if(s){
+          // console.log('name', s.getKindName())
+          addOriginInfo(s)
+        }
+      })
+      return
+    }
+    addOriginInfo(callExpression)
+  })
+
+
+  // console.log(trackScreen.findReferencesAsNodes().length)
+
+  /*
+
+  TODO:
+    - add ancestorScreenNameHierarchy to see the contruct of the legacy name
+*/
+
+  // console.log(sendEvent?.findReferencesAsNodes().length)
+  ;[
+    { name: 'sendEvent', method: sendEvent },
+    { name: 'sendScreen', method: sendScreen },
+    { name: 'appendToTracking', method: appendToTracking },
+    { name: 'trackComponent', method: trackComponent },
+  ].forEach(({ method, name }) => {
+    let count = 0
+    const params = method
+      ?.getFirstDescendant(Node.isArrowFunction)
+      ?.getParameters()
+
+    const references = method?.findReferencesAsNodes()
+
+    references.forEach((node) => {
+      const callExpression = node.getFirstAncestor(Node.isCallExpression)
+
+      if (!callExpression?.getText().match(new RegExp(`^${name}.*`))) {
+        return
+      }
+
+      const { filePath, methodName, lineNumber } = abstractOriginInfo(
+        callExpression
+      )
+
+      if (
+        filePath === '/src/Tracker/index.tsx' ||
+        filePath === 'src/components/Router/StepsRouter.tsx'
+      ) {
+        return false
+      }
+
+      console.log('filePath', callExpression.getText())
+
+      count++
+      appendArgumentsToCallExpression(callExpression, {
+        max: params.length,
+        data: [
+          `{ filePath: '${filePath}', methodName: '${methodName}', lineNumber: '${lineNumber}', analyticsMethod: '${name}'}`,
+        ],
+      })
+    })
+
+    console.log(`Added to ${count} references`)
+  })
+
+  project.save()
+  // trackException?.findReferencesAsNodes().forEach((node) => {
+  //   const callExpression = node.getFirstAncestor(Node.isCallExpression)
+  //   if (!callExpression) {
+  //     return
+  //   }
+
+  //   const { filePath, methodName, lineNumber } = abstractOriginInfo(
+  //     callExpression
+  //   )
+
+  //   count++
+
+  //   appendArgumentsToCallExpression(callExpression, {
+  //     max: trackExceptionParameters.length,
+  //     data: [`'${filePath}'`, `'${methodName}'`, `'${lineNumber}'`],
+  //   })
+  // })
+
+  // console.log(
+  //   `Extended ${count} ExceptionHandler.captureException references with origin info`
+  // )
+}

--- a/build/morph/build.morph.ts
+++ b/build/morph/build.morph.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /*
   Mofidy source files by using AST (Abtract Syntax Tree) modifications
 
@@ -8,9 +9,12 @@ import { getProject } from './project'
 export { getSourceFileAsString } from './project'
 
 import exceptionHandlerInjection from './ExceptionHandler.injection'
+import analyticsStracktraceInjection from './AnalyticsStacktrace.injection'
 
-export default () => {
+// export default () => {
   const project = getProject()
 
-  exceptionHandlerInjection(project)
-}
+  analyticsStracktraceInjection(project)
+  // exceptionHandlerInjection(project)
+// }
+

--- a/build/morph/callGraph.ts
+++ b/build/morph/callGraph.ts
@@ -1,0 +1,65 @@
+// @ts-nocheck
+// const { VariableDeclaration } = require('abstract-syntax-tree')
+const { Project, ScriptTarget, Node, PropertyAssignment } = require('ts-morph')
+const { SyntaxKind } = require('typescript')
+import { getProject, fromBasePath } from "./project"
+
+// const project = new Project({
+//   tsConfigFilePath: '../tsconfig.json'
+// })
+
+const project = getProject()
+
+const sourceFile = project.getSourceFile(
+  fromBasePath('/src/Tracker/onfidoTracker.tsx')
+)
+
+// const sourceFile = project.getSourceFile('./source/onfidoTracker.tsx')
+const origin = sourceFile.getVariableDeclaration('sendAnalyticsEvent')
+
+const trees = []
+
+const reverseUp = (originNode, tree = []) => {
+  if(!originNode.findReferencesAsNodes){
+    console.log(originNode.getKindName(), originNode?.getStartLineNumber(), originNode?.getSourceFile().getFilePath())
+    return
+  }
+
+  originNode.findReferencesAsNodes().forEach(node => {
+    const parent = node.getFirstAncestorByKind(SyntaxKind.FunctionDeclaration)
+    
+    let parent2 = node.getFirstAncestorByKind(SyntaxKind.ArrowFunction)
+    if(parent2){
+      parent2 = parent2.getFirstAncestorByKind(SyntaxKind.Variabl)
+    }
+
+    const funcNode = parent || parent2
+    console.log('funcNode', !!funcNode)
+    if(funcNode){
+      reverseUp(funcNode, [...tree, funcNode])
+    } 
+    // else {
+    // //   trees.push([...tree, node])
+    // // }
+  })
+}
+
+reverseUp(origin, [origin])
+
+const logTrees = (trees) => {
+  trees.forEach((tree, index) => {
+    console.group(index)
+
+    tree.forEach(node => {
+      console.log(
+        node.getSymbol().getName(), 
+        `${node.getSourceFile().getFilePath()}:${node.getStartLineNumber()}`, 
+        node.getStartLinePos())
+    })
+
+    console.groupEnd()
+  })
+}
+
+
+// logTrees(trees)

--- a/build/morph/project.ts
+++ b/build/morph/project.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { Project } from 'ts-morph'
 import { join } from 'path'
 

--- a/build/morph/util.ts
+++ b/build/morph/util.ts
@@ -36,17 +36,28 @@ export const appendArgumentsToCallExpression = (
   callExpression: CallExpression,
   { max, data }: { max: number; data: string[] }
 ) => {
-  const originArguments = callExpression.getArguments()
+  const originArguments = callExpression?.getArguments() || []
   const originArgumentsLength = originArguments.length
   const expectedArgumentLength = max - data.length
 
+  console.log(
+    callExpression.getText(),
+    originArgumentsLength,
+    expectedArgumentLength
+  )
+
   if (originArgumentsLength < expectedArgumentLength) {
     // Too few arguments, add a couple
+    // console.log('--> to few')
     callExpression.addArguments(
       new Array(expectedArgumentLength - originArgumentsLength).fill('null')
     )
   } else if (originArgumentsLength > expectedArgumentLength) {
     // Too many arguments, remove a couple
+    // console.log(
+    //   '--> to many',
+    //   originArguments.slice(-(originArgumentsLength - expectedArgumentLength))
+    // )
     originArguments
       .slice(-(originArgumentsLength - expectedArgumentLength))
       .forEach((i) => callExpression.removeArgument(i))

--- a/src/Tracker/onfidoTracker.tsx
+++ b/src/Tracker/onfidoTracker.tsx
@@ -120,6 +120,31 @@ export const sendAnalyticsEvent = (
   const payload = JSON.stringify(analyticsPayload)
 
   const url = urls.onfido_api_url
+  // console.log('[Analytics]', event, eventData?.eventName, eventProperties)
 
-  sendAnalytics(url, payload)
+  const createStacktrace = (stacktrace) => {
+    const text = []
+
+    return stacktrace
+      .map((i) =>
+        [
+          `[${i.namePartial || '.'}]`,
+          i.filePath && `   src: ${i.filePath}:${i.lineNumber}`,
+          i.methodName && `   method: ${i.methodName}`,
+          i.analyticsMethod && `   analyticsMethod: ${i.analyticsMethod}`,
+        ]
+          .filter(Boolean)
+          .join('\n')
+      )
+      .join('\n\n')
+  }
+
+  console.log(
+    `[Analytics] ${event} ${eventData.eventName} \n`,
+    { properties: eventProperties },
+    '\n',
+    createStacktrace(eventProperties.originStacktrace)
+  )
+
+  // sendAnalytics(url, payload)
 }

--- a/src/components/Router/StepsRouter.tsx
+++ b/src/components/Router/StepsRouter.tsx
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact'
 import classNames from 'classnames'
-import { sendScreen } from '../../Tracker'
+import { sendScreen, withOriginStacktrace } from '../../Tracker'
 import { wrapArray } from '~utils/array'
 import NavigationBar from '../NavigationBar'
 import theme from '../Theme/style.scss'
@@ -15,16 +15,16 @@ class StepsRouter extends Component<StepsRouterProps> {
 
   resetSdkFocus = () => this.container?.focus()
 
-  trackScreen: TrackScreenCallback = (screenNameHierarchy, properties = {}) => {
+  trackScreen: TrackScreenCallback = (screenNameHierarchy, properties = {}, originInfo) => {
     const { step } = this.currentComponent()
+
     sendScreen(
       [
         step.type,
         ...(screenNameHierarchy ? wrapArray(screenNameHierarchy) : []),
       ],
-      {
-        ...properties,
-      }
+      withOriginStacktrace('StepsRouter.trackScreen', {...properties}, {filePath: 'src/Router/StepsRouter.tsx', lineNumber: 28, methodName: 'trackScreen'}, step.type),
+      originInfo
     )
   }
 


### PR DESCRIPTION
# Problem
Our analytics api dynamically generates  event names. This makes it hard to find all the pieces and follow the code path of what a single event went through.

# Solution
Use AST to inject origin info and use the analytics api to construct useful stracktraces for analytics events

- [x] Get it working
- [ ] Clean up
- [ ] Make decent api 
- [ ] Add docs

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
