### PR TITLE
Temporary fix the infinite loop

### DIFF
--- a/src/components/Capture/ProfileData.tsx
+++ b/src/components/Capture/ProfileData.tsx
@@ -205,7 +205,8 @@ const FieldComponent = ({
     return () => {
       removeToucher(type)
     }
-  }, [type, isInvalid, setToucher, removeToucher, setIsTouched])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [type, isInvalid])
 
   useEffect(() => {
     setValidationError(


### PR DESCRIPTION
# Problem
An infinite call loop occurs with the country dropdown

During debugging I found that the `setToucher` & `removeToucher` from `ProfileData` don't keep their references when passed a prop to the `<FieldComponent/>`. The `useEffect` that has it as dependencies keep firing causing an infinite loop.

Could not replicate in clean preact project.

# Solution
Temporary remove the functions from the dependencies for the useEffect.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
