### PR TITLE
fix(orc-1166/1137): fix mobile layout for profile capture data and add SSN input validations

### DIFF
--- a/src/components/Capture/ProfileData.tsx
+++ b/src/components/Capture/ProfileData.tsx
@@ -236,7 +236,7 @@ const FieldComponent = ({
   }
 
   return (
-    <Field>
+    <Field className={style['field']}>
       <FieldLabel>
         <span>
           {getTranslatedFieldLabel(translate, type, selectedCountry)}
@@ -283,6 +283,17 @@ const getFieldComponent = (
       return <DateOfBirthInput {...props} />
     case 'postcode':
       return <Input {...props} type="text" style={{ width: space(22) }} />
+    case 'ssn':
+      return (
+        <Input
+          {...props}
+          placeholder={'999-99-9999'}
+          pattern={'d{3}-d{2}-d{4}'}
+          maxLength={11}
+          type="text"
+          style={{ width: space(22) }}
+        />
+      )
     default:
       return <Input {...props} type="text" />
   }

--- a/src/components/Capture/style.scss
+++ b/src/components/Capture/style.scss
@@ -24,3 +24,9 @@
 .submit-button {
   margin-top: castor.space(4);
 }
+
+@media (--small-viewport) {
+  .field {
+    min-width: 0;
+  }
+}


### PR DESCRIPTION
add ssn max length and pattern

# Problem

Mobile view is broken for Profile capture data
SSN input lets you anything

# Solution

display placeholder 999-99-9999 on the SSN input and add a patterns to validate it
add mobile breakpoint to remove the `min-width` for the profile capture inputs
