### PR TITLE
setOptions keeps the values from init

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -172,7 +172,7 @@ export const init = (opts: SdkOptions): SdkHandle => {
   return {
     options,
     setOptions(changedOptions) {
-      this.options = { ...this.options, ...formatOptions(changedOptions) }
+      this.options = formatOptions({ ...opts, ...changedOptions })
       if (
         this.options.containerEl !== changedOptions.containerEl &&
         changedOptions.containerEl


### PR DESCRIPTION
# Problem

setOptions was setting unspecified values to their default value. 

# Solution

Calling `formatOptions` with the options from `init` merged with the `changedOptions`.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
