### PR TITLE
⬆️ Upgrade license-checker-rseidelsohn

### DIFF
--- a/licenses.json
+++ b/licenses.json
@@ -90,7 +90,7 @@
   },
   "@babel/helper-builder-react-jsx@7.8.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-builder-react-jsx",
+    "repository": "https://github.com/babel/babel.git#master",
     "path": "node_modules/@babel/helper-builder-react-jsx",
     "licenseFile": "node_modules/@babel/helper-builder-react-jsx/LICENSE"
   },
@@ -262,7 +262,7 @@
   },
   "@babel/helper-wrap-function@7.8.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/babel/babel/tree/master/packages/babel-helper-wrap-function",
+    "repository": "https://github.com/babel/babel.git#master",
     "path": "node_modules/@babel/helper-wrap-function",
     "licenseFile": "node_modules/@babel/helper-wrap-function/LICENSE"
   },
@@ -320,13 +320,13 @@
   },
   "@babel/plugin-proposal-export-default-from@7.8.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-export-default-from",
+    "repository": "https://github.com/babel/babel.git#master",
     "path": "node_modules/@babel/plugin-proposal-export-default-from",
     "licenseFile": "node_modules/@babel/plugin-proposal-export-default-from/LICENSE"
   },
   "@babel/plugin-proposal-function-sent@7.8.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-function-sent",
+    "repository": "https://github.com/babel/babel.git#master",
     "path": "node_modules/@babel/plugin-proposal-function-sent",
     "licenseFile": "node_modules/@babel/plugin-proposal-function-sent/LICENSE"
   },
@@ -374,7 +374,7 @@
   },
   "@babel/plugin-proposal-throw-expressions@7.8.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-throw-expressions",
+    "repository": "https://github.com/babel/babel.git#master",
     "path": "node_modules/@babel/plugin-proposal-throw-expressions",
     "licenseFile": "node_modules/@babel/plugin-proposal-throw-expressions/LICENSE"
   },
@@ -386,13 +386,13 @@
   },
   "@babel/plugin-syntax-async-generators@7.8.4": {
     "licenses": "MIT",
-    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators",
+    "repository": "https://github.com/babel/babel.git#master",
     "path": "node_modules/@babel/plugin-syntax-async-generators",
     "licenseFile": "node_modules/@babel/plugin-syntax-async-generators/LICENSE"
   },
   "@babel/plugin-syntax-bigint@7.8.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-bigint",
+    "repository": "https://github.com/babel/babel.git#master",
     "path": "node_modules/@babel/plugin-syntax-bigint",
     "licenseFile": "node_modules/@babel/plugin-syntax-bigint/LICENSE"
   },
@@ -412,19 +412,19 @@
   },
   "@babel/plugin-syntax-dynamic-import@7.8.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import",
+    "repository": "https://github.com/babel/babel.git#master",
     "path": "node_modules/@babel/plugin-syntax-dynamic-import",
     "licenseFile": "node_modules/@babel/plugin-syntax-dynamic-import/LICENSE"
   },
   "@babel/plugin-syntax-export-default-from@7.8.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-default-from",
+    "repository": "https://github.com/babel/babel.git#master",
     "path": "node_modules/@babel/plugin-syntax-export-default-from",
     "licenseFile": "node_modules/@babel/plugin-syntax-export-default-from/LICENSE"
   },
   "@babel/plugin-syntax-function-sent@7.8.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-function-sent",
+    "repository": "https://github.com/babel/babel.git#master",
     "path": "node_modules/@babel/plugin-syntax-function-sent",
     "licenseFile": "node_modules/@babel/plugin-syntax-function-sent/LICENSE"
   },
@@ -436,7 +436,7 @@
   },
   "@babel/plugin-syntax-json-strings@7.8.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-json-strings",
+    "repository": "https://github.com/babel/babel.git#master",
     "path": "node_modules/@babel/plugin-syntax-json-strings",
     "licenseFile": "node_modules/@babel/plugin-syntax-json-strings/LICENSE"
   },
@@ -456,7 +456,7 @@
   },
   "@babel/plugin-syntax-nullish-coalescing-operator@7.8.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator",
+    "repository": "https://github.com/babel/babel.git#master",
     "path": "node_modules/@babel/plugin-syntax-nullish-coalescing-operator",
     "licenseFile": "node_modules/@babel/plugin-syntax-nullish-coalescing-operator/LICENSE"
   },
@@ -468,31 +468,31 @@
   },
   "@babel/plugin-syntax-numeric-separator@7.8.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-numeric-separator",
+    "repository": "https://github.com/babel/babel.git#master",
     "path": "node_modules/@babel/plugin-syntax-numeric-separator",
     "licenseFile": "node_modules/@babel/plugin-syntax-numeric-separator/LICENSE"
   },
   "@babel/plugin-syntax-object-rest-spread@7.8.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread",
+    "repository": "https://github.com/babel/babel.git#master",
     "path": "node_modules/@babel/plugin-syntax-object-rest-spread",
     "licenseFile": "node_modules/@babel/plugin-syntax-object-rest-spread/LICENSE"
   },
   "@babel/plugin-syntax-optional-catch-binding@7.8.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-catch-binding",
+    "repository": "https://github.com/babel/babel.git#master",
     "path": "node_modules/@babel/plugin-syntax-optional-catch-binding",
     "licenseFile": "node_modules/@babel/plugin-syntax-optional-catch-binding/LICENSE"
   },
   "@babel/plugin-syntax-optional-chaining@7.8.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-chaining",
+    "repository": "https://github.com/babel/babel.git#master",
     "path": "node_modules/@babel/plugin-syntax-optional-chaining",
     "licenseFile": "node_modules/@babel/plugin-syntax-optional-chaining/LICENSE"
   },
   "@babel/plugin-syntax-throw-expressions@7.8.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-throw-expressions",
+    "repository": "https://github.com/babel/babel.git#master",
     "path": "node_modules/@babel/plugin-syntax-throw-expressions",
     "licenseFile": "node_modules/@babel/plugin-syntax-throw-expressions/LICENSE"
   },
@@ -648,7 +648,7 @@
   },
   "@babel/plugin-transform-react-jsx@7.8.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx",
+    "repository": "https://github.com/babel/babel.git#master",
     "path": "node_modules/@babel/plugin-transform-react-jsx",
     "licenseFile": "node_modules/@babel/plugin-transform-react-jsx/LICENSE"
   },
@@ -964,25 +964,25 @@
   },
   "@nodelib/fs.scandir@2.1.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.scandir",
+    "repository": "https://github.com/nodelib/nodelib.git#master",
     "path": "node_modules/@nodelib/fs.scandir",
     "licenseFile": "node_modules/@nodelib/fs.scandir/LICENSE"
   },
   "@nodelib/fs.stat@2.0.3": {
     "licenses": "MIT",
-    "repository": "https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.stat",
+    "repository": "https://github.com/nodelib/nodelib.git#master",
     "path": "node_modules/@nodelib/fs.scandir/node_modules/@nodelib/fs.stat",
     "licenseFile": "node_modules/@nodelib/fs.scandir/node_modules/@nodelib/fs.stat/LICENSE"
   },
   "@nodelib/fs.stat@2.0.5": {
     "licenses": "MIT",
-    "repository": "https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.stat",
+    "repository": "https://github.com/nodelib/nodelib.git#master",
     "path": "node_modules/@nodelib/fs.stat",
     "licenseFile": "node_modules/@nodelib/fs.stat/LICENSE"
   },
   "@nodelib/fs.walk@1.2.4": {
     "licenses": "MIT",
-    "repository": "https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.walk",
+    "repository": "https://github.com/nodelib/nodelib.git#master",
     "path": "node_modules/@nodelib/fs.walk",
     "licenseFile": "node_modules/@nodelib/fs.walk/LICENSE"
   },
@@ -999,7 +999,7 @@
     "path": "node_modules/@onfido/castor-icons",
     "licenseFile": "node_modules/@onfido/castor-icons/README.md"
   },
-  "@onfido/castor-react@2.0.3": {
+  "@onfido/castor-react@2.2.1": {
     "licenses": "Apache-2.0",
     "repository": "https://github.com/onfido/castor",
     "publisher": "Onfido",
@@ -1013,7 +1013,7 @@
     "path": "node_modules/@onfido/castor-tokens",
     "licenseFile": "node_modules/@onfido/castor-tokens/README.md"
   },
-  "@onfido/castor@2.0.3": {
+  "@onfido/castor@2.2.1": {
     "licenses": "Apache-2.0",
     "repository": "https://github.com/onfido/castor",
     "publisher": "Onfido",
@@ -1685,8 +1685,8 @@
   "@typescript-eslint/utils@5.15.0": {
     "licenses": "MIT",
     "repository": "https://github.com/typescript-eslint/typescript-eslint",
-    "path": "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/utils",
-    "licenseFile": "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/utils/LICENSE"
+    "path": "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils",
+    "licenseFile": "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils/LICENSE"
   },
   "@typescript-eslint/visitor-keys@5.15.0": {
     "licenses": "MIT",
@@ -1918,8 +1918,8 @@
   "acorn@8.7.0": {
     "licenses": "MIT",
     "repository": "https://github.com/acornjs/acorn",
-    "path": "node_modules/webpack/node_modules/acorn",
-    "licenseFile": "node_modules/webpack/node_modules/acorn/LICENSE"
+    "path": "node_modules/jsdom/node_modules/acorn",
+    "licenseFile": "node_modules/jsdom/node_modules/acorn/LICENSE"
   },
   "acorn@8.7.1": {
     "licenses": "MIT",
@@ -2017,8 +2017,8 @@
     "publisher": "Sindre Sorhus",
     "email": "sindresorhus@gmail.com",
     "url": "sindresorhus.com",
-    "path": "node_modules/string-width/node_modules/ansi-regex",
-    "licenseFile": "node_modules/string-width/node_modules/ansi-regex/license"
+    "path": "node_modules/jest-message-util/node_modules/ansi-regex",
+    "licenseFile": "node_modules/jest-message-util/node_modules/ansi-regex/license"
   },
   "ansi-regex@6.0.1": {
     "licenses": "MIT",
@@ -2044,8 +2044,8 @@
     "publisher": "Sindre Sorhus",
     "email": "sindresorhus@gmail.com",
     "url": "sindresorhus.com",
-    "path": "node_modules/wrap-ansi/node_modules/ansi-styles",
-    "licenseFile": "node_modules/wrap-ansi/node_modules/ansi-styles/license"
+    "path": "node_modules/@jest/console/node_modules/ansi-styles",
+    "licenseFile": "node_modules/@jest/console/node_modules/ansi-styles/license"
   },
   "ansi-styles@5.2.0": {
     "licenses": "MIT",
@@ -2583,20 +2583,14 @@
   "chalk@3.0.0": {
     "licenses": "MIT",
     "repository": "https://github.com/chalk/chalk",
-    "path": "node_modules/@testing-library/jest-dom/node_modules/chalk",
-    "licenseFile": "node_modules/@testing-library/jest-dom/node_modules/chalk/license"
+    "path": "node_modules/ora/node_modules/chalk",
+    "licenseFile": "node_modules/ora/node_modules/chalk/license"
   },
   "chalk@4.1.0": {
     "licenses": "MIT",
     "repository": "https://github.com/chalk/chalk",
     "path": "node_modules/@jest/types/node_modules/chalk",
     "licenseFile": "node_modules/@jest/types/node_modules/chalk/license"
-  },
-  "chalk@4.1.1": {
-    "licenses": "MIT",
-    "repository": "https://github.com/chalk/chalk",
-    "path": "node_modules/license-checker-rseidelsohn/node_modules/chalk",
-    "licenseFile": "node_modules/license-checker-rseidelsohn/node_modules/chalk/license"
   },
   "chalk@4.1.2": {
     "licenses": "MIT",
@@ -2791,8 +2785,8 @@
     "repository": "https://github.com/Qix-/color-convert",
     "publisher": "Heather Arthur",
     "email": "fayearthur@gmail.com",
-    "path": "node_modules/wrap-ansi/node_modules/color-convert",
-    "licenseFile": "node_modules/wrap-ansi/node_modules/color-convert/LICENSE"
+    "path": "node_modules/@jest/console/node_modules/color-convert",
+    "licenseFile": "node_modules/@jest/console/node_modules/color-convert/LICENSE"
   },
   "color-name@1.1.3": {
     "licenses": "MIT",
@@ -2807,8 +2801,8 @@
     "repository": "https://github.com/colorjs/color-name",
     "publisher": "DY",
     "email": "dfcreative@gmail.com",
-    "path": "node_modules/wrap-ansi/node_modules/color-name",
-    "licenseFile": "node_modules/wrap-ansi/node_modules/color-name/LICENSE"
+    "path": "node_modules/@jest/console/node_modules/color-name",
+    "licenseFile": "node_modules/@jest/console/node_modules/color-name/LICENSE"
   },
   "colorette@2.0.16": {
     "licenses": "MIT",
@@ -2831,8 +2825,8 @@
     "repository": "https://github.com/tj/commander.js",
     "publisher": "TJ Holowaychuk",
     "email": "tj@vision-media.ca",
-    "path": "node_modules/terser/node_modules/commander",
-    "licenseFile": "node_modules/terser/node_modules/commander/LICENSE"
+    "path": "node_modules/nearley/node_modules/commander",
+    "licenseFile": "node_modules/nearley/node_modules/commander/LICENSE"
   },
   "commander@4.1.1": {
     "licenses": "MIT",
@@ -3101,7 +3095,7 @@
     "path": "node_modules/cssstyle",
     "licenseFile": "node_modules/cssstyle/LICENSE"
   },
-  "csstype@3.0.10": {
+  "csstype@3.1.0": {
     "licenses": "MIT",
     "repository": "https://github.com/frenic/csstype",
     "publisher": "Fredrik Nicol",
@@ -3337,7 +3331,7 @@
     "path": "node_modules/detect-node",
     "licenseFile": "node_modules/detect-node/LICENSE"
   },
-  "dezalgo@1.0.3": {
+  "dezalgo@1.0.4": {
     "licenses": "ISC",
     "repository": "https://github.com/npm/dezalgo",
     "publisher": "Isaac Z. Schlueter",
@@ -3798,8 +3792,8 @@
     "licenses": "MIT",
     "repository": "https://github.com/mysticatea/eslint-utils",
     "publisher": "Toru Nagashima",
-    "path": "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/utils/node_modules/eslint-utils",
-    "licenseFile": "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/utils/node_modules/eslint-utils/LICENSE"
+    "path": "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils/node_modules/eslint-utils",
+    "licenseFile": "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils/node_modules/eslint-utils/LICENSE"
   },
   "eslint-visitor-keys@1.3.0": {
     "licenses": "Apache-2.0",
@@ -4106,8 +4100,8 @@
     "publisher": "Sindre Sorhus",
     "email": "sindresorhus@gmail.com",
     "url": "sindresorhus.com",
-    "path": "node_modules/yargs/node_modules/find-up",
-    "licenseFile": "node_modules/yargs/node_modules/find-up/license"
+    "path": "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up",
+    "licenseFile": "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up/license"
   },
   "find-up@5.0.0": {
     "licenses": "MIT",
@@ -4615,17 +4609,17 @@
     "publisher": "Rebecca Turner",
     "email": "me@re-becca.org",
     "url": "http://re-becca.org",
-    "path": "node_modules/hosted-git-info",
-    "licenseFile": "node_modules/hosted-git-info/LICENSE"
+    "path": "node_modules/meow/node_modules/read-pkg/node_modules/hosted-git-info",
+    "licenseFile": "node_modules/meow/node_modules/read-pkg/node_modules/hosted-git-info/LICENSE"
   },
-  "hosted-git-info@4.0.2": {
+  "hosted-git-info@4.1.0": {
     "licenses": "ISC",
     "repository": "https://github.com/npm/hosted-git-info",
     "publisher": "Rebecca Turner",
     "email": "me@re-becca.org",
     "url": "http://re-becca.org",
-    "path": "node_modules/meow/node_modules/hosted-git-info",
-    "licenseFile": "node_modules/meow/node_modules/hosted-git-info/LICENSE"
+    "path": "node_modules/hosted-git-info",
+    "licenseFile": "node_modules/hosted-git-info/LICENSE"
   },
   "hpack.js@2.1.6": {
     "licenses": "MIT",
@@ -5017,7 +5011,7 @@
     "path": "node_modules/is-callable",
     "licenseFile": "node_modules/is-callable/LICENSE"
   },
-  "is-core-module@2.3.0": {
+  "is-core-module@2.9.0": {
     "licenses": "MIT",
     "repository": "https://github.com/inspect-js/is-core-module",
     "publisher": "Jordan Harband",
@@ -5734,7 +5728,7 @@
     "path": "node_modules/libphonenumber-js",
     "licenseFile": "node_modules/libphonenumber-js/LICENSE"
   },
-  "license-checker-rseidelsohn@1.2.2": {
+  "license-checker-rseidelsohn@3.1.0": {
     "licenses": "BSD-3-Clause",
     "repository": "https://github.com/RSeidelsohn/license-checker-rseidelsohn",
     "publisher": "Roman Seidelsohn",
@@ -5821,8 +5815,8 @@
     "publisher": "Sindre Sorhus",
     "email": "sindresorhus@gmail.com",
     "url": "sindresorhus.com",
-    "path": "node_modules/yargs/node_modules/locate-path",
-    "licenseFile": "node_modules/yargs/node_modules/locate-path/license"
+    "path": "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path",
+    "licenseFile": "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path/license"
   },
   "locate-path@6.0.0": {
     "licenses": "MIT",
@@ -6408,16 +6402,16 @@
     "repository": "https://github.com/npm/normalize-package-data",
     "publisher": "Meryn Stol",
     "email": "merynstol@gmail.com",
-    "path": "node_modules/normalize-package-data",
-    "licenseFile": "node_modules/normalize-package-data/LICENSE"
+    "path": "node_modules/meow/node_modules/read-pkg/node_modules/normalize-package-data",
+    "licenseFile": "node_modules/meow/node_modules/read-pkg/node_modules/normalize-package-data/LICENSE"
   },
-  "normalize-package-data@3.0.2": {
+  "normalize-package-data@3.0.3": {
     "licenses": "BSD-2-Clause",
     "repository": "https://github.com/npm/normalize-package-data",
     "publisher": "Meryn Stol",
     "email": "merynstol@gmail.com",
-    "path": "node_modules/meow/node_modules/normalize-package-data",
-    "licenseFile": "node_modules/meow/node_modules/normalize-package-data/LICENSE"
+    "path": "node_modules/normalize-package-data",
+    "licenseFile": "node_modules/normalize-package-data/LICENSE"
   },
   "normalize-path@3.0.0": {
     "licenses": "MIT",
@@ -6630,13 +6624,13 @@
     "path": "node_modules/onetime",
     "licenseFile": "node_modules/onetime/license"
   },
-  "onfido-sdk-ui@8.1.0": {
+  "onfido-sdk-ui@8.1.1": {
     "licenses": "Custom: https://travis-ci.org/onfido/onfido-sdk-ui.svg",
     "repository": "https://github.com/onfido/onfido-sdk-ui",
     "publisher": "Web SDK Customer Support",
     "email": "web-sdk@onfido.com",
     "url": "https://github.com/onfido",
-    "path": "/Users/danny/Onfido/onfido-sdk-ui",
+    "path": "",
     "licenseFile": "LICENSE"
   },
   "open@8.4.0": {
@@ -6742,8 +6736,8 @@
     "publisher": "Sindre Sorhus",
     "email": "sindresorhus@gmail.com",
     "url": "sindresorhus.com",
-    "path": "node_modules/yargs/node_modules/p-locate",
-    "licenseFile": "node_modules/yargs/node_modules/p-locate/license"
+    "path": "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate",
+    "licenseFile": "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate/license"
   },
   "p-locate@5.0.0": {
     "licenses": "MIT",
@@ -6910,8 +6904,8 @@
     "publisher": "Sindre Sorhus",
     "email": "sindresorhus@gmail.com",
     "url": "sindresorhus.com",
-    "path": "node_modules/yargs/node_modules/path-exists",
-    "licenseFile": "node_modules/yargs/node_modules/path-exists/license"
+    "path": "node_modules/@istanbuljs/load-nyc-config/node_modules/path-exists",
+    "licenseFile": "node_modules/@istanbuljs/load-nyc-config/node_modules/path-exists/license"
   },
   "path-is-absolute@1.0.1": {
     "licenses": "MIT",
@@ -7495,16 +7489,15 @@
     "path": "node_modules/webpack-visualizer-plugin2/node_modules/react",
     "licenseFile": "node_modules/webpack-visualizer-plugin2/node_modules/react/LICENSE"
   },
-  "read-installed@4.0.3": {
+  "read-installed-packages@1.0.0": {
     "licenses": "ISC",
-    "repository": "https://github.com/isaacs/read-installed",
-    "publisher": "Isaac Z. Schlueter",
-    "email": "i@izs.me",
-    "url": "http://blog.izs.me/",
-    "path": "node_modules/read-installed",
-    "licenseFile": "node_modules/read-installed/LICENSE"
+    "repository": "https://github.com/Semigradsky/read-installed",
+    "publisher": "Dmitry Semigradsky",
+    "email": "semigradskyd@gmail.com",
+    "path": "node_modules/read-installed-packages",
+    "licenseFile": "node_modules/read-installed-packages/LICENSE"
   },
-  "read-package-json@2.1.2": {
+  "read-package-json@4.1.2": {
     "licenses": "ISC",
     "repository": "https://github.com/npm/read-package-json",
     "publisher": "Isaac Z. Schlueter",
@@ -7611,7 +7604,7 @@
   },
   "regenerator-runtime@0.12.1": {
     "licenses": "MIT",
-    "repository": "https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime",
+    "repository": "https://github.com/facebook/regenerator.git#master",
     "publisher": "Ben Newman",
     "email": "bn@cs.stanford.edu",
     "path": "node_modules/regenerator-runtime",
@@ -7619,7 +7612,7 @@
   },
   "regenerator-runtime@0.13.5": {
     "licenses": "MIT",
-    "repository": "https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime",
+    "repository": "https://github.com/facebook/regenerator.git#master",
     "publisher": "Ben Newman",
     "email": "bn@cs.stanford.edu",
     "path": "node_modules/@babel/runtime/node_modules/regenerator-runtime",
@@ -7627,7 +7620,7 @@
   },
   "regenerator-transform@0.14.5": {
     "licenses": "MIT",
-    "repository": "https://github.com/facebook/regenerator/tree/master/packages/regenerator-transform",
+    "repository": "https://github.com/facebook/regenerator.git#master",
     "publisher": "Ben Newman",
     "email": "bn@cs.stanford.edu",
     "path": "node_modules/regenerator-transform",
@@ -7854,8 +7847,8 @@
     "publisher": "Isaac Z. Schlueter",
     "email": "i@izs.me",
     "url": "http://blog.izs.me/",
-    "path": "node_modules/flat-cache/node_modules/rimraf",
-    "licenseFile": "node_modules/flat-cache/node_modules/rimraf/LICENSE"
+    "path": "node_modules/@jest/core/node_modules/rimraf",
+    "licenseFile": "node_modules/@jest/core/node_modules/rimraf/LICENSE"
   },
   "rst-selector-parser@2.2.3": {
     "licenses": "BSD-3-Clause",
@@ -7988,8 +7981,8 @@
   "semver@5.7.1": {
     "licenses": "ISC",
     "repository": "https://github.com/npm/node-semver",
-    "path": "node_modules/make-dir/node_modules/semver",
-    "licenseFile": "node_modules/make-dir/node_modules/semver/LICENSE"
+    "path": "node_modules/nearley/node_modules/semver",
+    "licenseFile": "node_modules/nearley/node_modules/semver/LICENSE"
   },
   "semver@6.3.0": {
     "licenses": "ISC",
@@ -8242,8 +8235,8 @@
     "repository": "https://github.com/mozilla/source-map",
     "publisher": "Nick Fitzgerald",
     "email": "nfitzgerald@mozilla.com",
-    "path": "node_modules/terser/node_modules/source-map",
-    "licenseFile": "node_modules/terser/node_modules/source-map/LICENSE"
+    "path": "node_modules/v8-to-istanbul/node_modules/source-map",
+    "licenseFile": "node_modules/v8-to-istanbul/node_modules/source-map/LICENSE"
   },
   "spawn-command@0.0.2-1": {
     "licenses": "MIT",
@@ -8262,7 +8255,7 @@
     "path": "node_modules/spdx-compare",
     "licenseFile": "node_modules/spdx-compare/LICENSE.md"
   },
-  "spdx-correct@3.1.0": {
+  "spdx-correct@3.1.1": {
     "licenses": "Apache-2.0",
     "repository": "https://github.com/jslicense/spdx-correct.js",
     "publisher": "Kyle E. Mitchell",
@@ -8278,12 +8271,12 @@
     "path": "node_modules/spdx-exceptions",
     "licenseFile": "node_modules/spdx-exceptions/README.md"
   },
-  "spdx-expression-parse@3.0.0": {
+  "spdx-expression-parse@3.0.1": {
     "licenses": "MIT",
     "repository": "https://github.com/jslicense/spdx-expression-parse.js",
     "publisher": "Kyle E. Mitchell",
     "email": "kyle@kemitchell.com",
-    "url": "http://kemitchell.com",
+    "url": "https://kemitchell.com",
     "path": "node_modules/spdx-expression-parse",
     "licenseFile": "node_modules/spdx-expression-parse/LICENSE"
   },
@@ -8447,8 +8440,8 @@
     "publisher": "Sindre Sorhus",
     "email": "sindresorhus@gmail.com",
     "url": "sindresorhus.com",
-    "path": "node_modules/string-width/node_modules/strip-ansi",
-    "licenseFile": "node_modules/string-width/node_modules/strip-ansi/license"
+    "path": "node_modules/string-length/node_modules/strip-ansi",
+    "licenseFile": "node_modules/string-length/node_modules/strip-ansi/license"
   },
   "strip-ansi@7.0.1": {
     "licenses": "MIT",
@@ -9021,12 +9014,6 @@
     "url": "http://n8.io/",
     "path": "node_modules/util-deprecate",
     "licenseFile": "node_modules/util-deprecate/LICENSE"
-  },
-  "util-extend@1.0.3": {
-    "licenses": "MIT",
-    "repository": "https://github.com/isaacs/util-extend",
-    "path": "node_modules/util-extend",
-    "licenseFile": "node_modules/util-extend/LICENSE"
   },
   "utila@0.4.0": {
     "licenses": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,7 @@
         "jest-cli": "^27.5.1",
         "jest-environment-jsdom": "^27.5.1",
         "jest-fetch-mock": "^3.0.3",
-        "license-checker-rseidelsohn": "^1.1.2",
+        "license-checker-rseidelsohn": "^3.1.0",
         "mini-css-extract-plugin": "^2.5.3",
         "modify-source-webpack-plugin": "^3.0.0",
         "moment": "^2.29.3",
@@ -5203,7 +5203,8 @@
     },
     "node_modules/asap": {
       "version": "2.0.6",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
     "node_modules/ast-metadata-inferer": {
@@ -6911,7 +6912,8 @@
     },
     "node_modules/debuglog": {
       "version": "1.0.1",
-      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -7108,8 +7110,9 @@
       "dev": true
     },
     "node_modules/dezalgo": {
-      "version": "1.0.3",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
       "dev": true,
       "dependencies": {
         "asap": "^2.0.0",
@@ -9524,9 +9527,16 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/hpack.js": {
       "version": "2.1.6",
@@ -10098,8 +10108,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.3.0",
-      "integrity": "sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -13881,27 +13892,33 @@
       "dev": true
     },
     "node_modules/license-checker-rseidelsohn": {
-      "version": "1.2.2",
-      "integrity": "sha512-EkR46infvGNEEM5agxBLX8BPsN40N/tC+CuYfao80/ZphzusI+gUrXyPA+OzAB8a+2sBrLCfZ9fVxgRLn4aDTA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/license-checker-rseidelsohn/-/license-checker-rseidelsohn-3.1.0.tgz",
+      "integrity": "sha512-rcwDcRacbKlAKfdwuQNw4pa8L9bH3GWHFSg7k9b5kFhWugVD/VPfx92AkZOwRzGqTYAj2iN26bXNP30mmAUKSw==",
       "dev": true,
       "dependencies": {
-        "chalk": "^4.1.0",
-        "debug": "^4.1.1",
-        "mkdirp": "^1.0.3",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.2",
+        "lodash.clonedeep": "^4.5.0",
+        "mkdirp": "^1.0.4",
         "nopt": "^5.0.0",
-        "read-installed": "~4.0.3",
+        "read-installed-packages": "^1.0.0",
         "semver": "^7.3.5",
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-satisfies": "^5.0.0",
+        "spdx-correct": "^3.1.1",
+        "spdx-expression-parse": "^3.0.1",
+        "spdx-satisfies": "^5.0.1",
         "treeify": "^1.1.0"
       },
       "bin": {
         "license-checker-rseidelsohn": "bin/license-checker-rseidelsohn"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/license-checker-rseidelsohn/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "dependencies": {
@@ -13915,8 +13932,9 @@
       }
     },
     "node_modules/license-checker-rseidelsohn/node_modules/chalk": {
-      "version": "4.1.1",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -13931,6 +13949,7 @@
     },
     "node_modules/license-checker-rseidelsohn/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "dependencies": {
@@ -13942,11 +13961,13 @@
     },
     "node_modules/license-checker-rseidelsohn/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
     "node_modules/license-checker-rseidelsohn/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "engines": {
@@ -13980,6 +14001,7 @@
     },
     "node_modules/license-checker-rseidelsohn/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "dependencies": {
@@ -14338,17 +14360,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/meow/node_modules/hosted-git-info": {
-      "version": "4.0.2",
-      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/meow/node_modules/locate-path": {
       "version": "5.0.0",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
@@ -14358,20 +14369,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/meow/node_modules/normalize-package-data": {
-      "version": "3.0.2",
-      "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
-      "dev": true,
-      "dependencies": {
-        "hosted-git-info": "^4.0.1",
-        "resolve": "^1.20.0",
-        "semver": "^7.3.4",
-        "validate-npm-package-license": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/meow/node_modules/p-locate": {
@@ -14976,23 +14973,18 @@
       }
     },
     "node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
       "dev": true,
       "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
         "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/normalize-path": {
@@ -15018,6 +15010,7 @@
     },
     "node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
       "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
       "dev": true
     },
@@ -16473,40 +16466,38 @@
         "preact": ">=9.0.0"
       }
     },
-    "node_modules/read-installed": {
-      "version": "4.0.3",
-      "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
+    "node_modules/read-installed-packages": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-installed-packages/-/read-installed-packages-1.0.0.tgz",
+      "integrity": "sha512-CZdFN0oYn7Iko+X8ynOztXNfbpO7UvAw1qEboRXCASP/psVrdt8LTvmwUYhAUF9q1dnD5R7lW4pmbpO6CQsfOg==",
       "dev": true,
       "dependencies": {
-        "debuglog": "^1.0.1",
-        "read-package-json": "^2.0.0",
+        "debug": "^4.3.1",
+        "read-package-json": "^4.0.0",
         "readdir-scoped-modules": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "slide": "~1.1.3",
-        "util-extend": "^1.0.1"
+        "semver": "2 || 3 || 4 || 5 || 6 || 7",
+        "slide": "~1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.2"
       }
     },
-    "node_modules/read-installed/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/read-package-json": {
-      "version": "2.1.2",
-      "integrity": "sha512-D1KmuLQr6ZSJS0tW8hf3WGpRlwszJOXZ3E8Yd/DNRaM5d+1wVRZdHlpGBLAuovjr28LbWvjpWkBHMxpRGGjzNA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-4.1.2.tgz",
+      "integrity": "sha512-Dqer4pqzamDE2O4M55xp1qZMuLPqi4ldk2ya648FOMHRjwMzFhuxVrG04wd0c38IsvkVdr3vgHI6z+QTPdAjrQ==",
       "dev": true,
       "dependencies": {
         "glob": "^7.1.1",
         "json-parse-even-better-errors": "^2.3.0",
-        "normalize-package-data": "^2.0.0",
+        "normalize-package-data": "^3.0.0",
         "npm-normalize-package-bin": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/readable-stream": {
@@ -16530,6 +16521,7 @@
     },
     "node_modules/readdir-scoped-modules": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
       "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
       "dev": true,
       "dependencies": {
@@ -17330,7 +17322,8 @@
     },
     "node_modules/slide": {
       "version": "1.1.6",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -17434,8 +17427,9 @@
       }
     },
     "node_modules/spdx-correct": {
-      "version": "3.1.0",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
@@ -17448,8 +17442,9 @@
       "dev": true
     },
     "node_modules/spdx-expression-parse": {
-      "version": "3.0.0",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
@@ -18747,11 +18742,6 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
-    "node_modules/util-extend": {
-      "version": "1.0.3",
-      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
       "dev": true
     },
     "node_modules/utila": {
@@ -23806,7 +23796,8 @@
     },
     "asap": {
       "version": "2.0.6",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
     "ast-metadata-inferer": {
@@ -25123,7 +25114,8 @@
     },
     "debuglog": {
       "version": "1.0.1",
-      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
       "dev": true
     },
     "decamelize": {
@@ -25272,8 +25264,9 @@
       "dev": true
     },
     "dezalgo": {
-      "version": "1.0.3",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
       "dev": true,
       "requires": {
         "asap": "^2.0.0",
@@ -27038,9 +27031,13 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.9",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "hpack.js": {
       "version": "2.1.6",
@@ -27465,8 +27462,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.3.0",
-      "integrity": "sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -30325,24 +30323,27 @@
       "dev": true
     },
     "license-checker-rseidelsohn": {
-      "version": "1.2.2",
-      "integrity": "sha512-EkR46infvGNEEM5agxBLX8BPsN40N/tC+CuYfao80/ZphzusI+gUrXyPA+OzAB8a+2sBrLCfZ9fVxgRLn4aDTA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/license-checker-rseidelsohn/-/license-checker-rseidelsohn-3.1.0.tgz",
+      "integrity": "sha512-rcwDcRacbKlAKfdwuQNw4pa8L9bH3GWHFSg7k9b5kFhWugVD/VPfx92AkZOwRzGqTYAj2iN26bXNP30mmAUKSw==",
       "dev": true,
       "requires": {
-        "chalk": "^4.1.0",
-        "debug": "^4.1.1",
-        "mkdirp": "^1.0.3",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.2",
+        "lodash.clonedeep": "^4.5.0",
+        "mkdirp": "^1.0.4",
         "nopt": "^5.0.0",
-        "read-installed": "~4.0.3",
+        "read-installed-packages": "^1.0.0",
         "semver": "^7.3.5",
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-satisfies": "^5.0.0",
+        "spdx-correct": "^3.1.1",
+        "spdx-expression-parse": "^3.0.1",
+        "spdx-satisfies": "^5.0.1",
         "treeify": "^1.1.0"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
@@ -30350,8 +30351,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -30360,6 +30362,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -30368,11 +30371,13 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
@@ -30391,6 +30396,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
@@ -30691,31 +30697,12 @@
             "path-exists": "^4.0.0"
           }
         },
-        "hosted-git-info": {
-          "version": "4.0.2",
-          "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "locate-path": {
           "version": "5.0.0",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
-          }
-        },
-        "normalize-package-data": {
-          "version": "3.0.2",
-          "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "^4.0.1",
-            "resolve": "^1.20.0",
-            "semver": "^7.3.4",
-            "validate-npm-package-license": "^3.0.1"
           }
         },
         "p-locate": {
@@ -31186,22 +31173,15 @@
       }
     },
     "normalize-package-data": {
-      "version": "2.5.0",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
         "validate-npm-package-license": "^3.0.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "normalize-path": {
@@ -31221,6 +31201,7 @@
     },
     "npm-normalize-package-bin": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
       "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
       "dev": true
     },
@@ -32325,36 +32306,29 @@
         "enumerate-devices": "^1.1.1"
       }
     },
-    "read-installed": {
-      "version": "4.0.3",
-      "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
+    "read-installed-packages": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-installed-packages/-/read-installed-packages-1.0.0.tgz",
+      "integrity": "sha512-CZdFN0oYn7Iko+X8ynOztXNfbpO7UvAw1qEboRXCASP/psVrdt8LTvmwUYhAUF9q1dnD5R7lW4pmbpO6CQsfOg==",
       "dev": true,
       "requires": {
-        "debuglog": "^1.0.1",
+        "debug": "^4.3.1",
         "graceful-fs": "^4.1.2",
-        "read-package-json": "^2.0.0",
+        "read-package-json": "^4.0.0",
         "readdir-scoped-modules": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "slide": "~1.1.3",
-        "util-extend": "^1.0.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "semver": "2 || 3 || 4 || 5 || 6 || 7",
+        "slide": "~1.1.3"
       }
     },
     "read-package-json": {
-      "version": "2.1.2",
-      "integrity": "sha512-D1KmuLQr6ZSJS0tW8hf3WGpRlwszJOXZ3E8Yd/DNRaM5d+1wVRZdHlpGBLAuovjr28LbWvjpWkBHMxpRGGjzNA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-4.1.2.tgz",
+      "integrity": "sha512-Dqer4pqzamDE2O4M55xp1qZMuLPqi4ldk2ya648FOMHRjwMzFhuxVrG04wd0c38IsvkVdr3vgHI6z+QTPdAjrQ==",
       "dev": true,
       "requires": {
         "glob": "^7.1.1",
         "json-parse-even-better-errors": "^2.3.0",
-        "normalize-package-data": "^2.0.0",
+        "normalize-package-data": "^3.0.0",
         "npm-normalize-package-bin": "^1.0.0"
       }
     },
@@ -32381,6 +32355,7 @@
     },
     "readdir-scoped-modules": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
       "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
       "dev": true,
       "requires": {
@@ -32999,7 +32974,8 @@
     },
     "slide": {
       "version": "1.1.6",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
       "dev": true
     },
     "socket.io-client": {
@@ -33085,8 +33061,9 @@
       }
     },
     "spdx-correct": {
-      "version": "3.1.0",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -33099,8 +33076,9 @@
       "dev": true
     },
     "spdx-expression-parse": {
-      "version": "3.0.0",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -34037,11 +34015,6 @@
     "util-deprecate": {
       "version": "1.0.2",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
-    "util-extend": {
-      "version": "1.0.3",
-      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
       "dev": true
     },
     "utila": {

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "jest-cli": "^27.5.1",
     "jest-environment-jsdom": "^27.5.1",
     "jest-fetch-mock": "^3.0.3",
-    "license-checker-rseidelsohn": "^1.1.2",
+    "license-checker-rseidelsohn": "^3.1.0",
     "mini-css-extract-plugin": "^2.5.3",
     "modify-source-webpack-plugin": "^3.0.0",
     "moment": "^2.29.3",


### PR DESCRIPTION
Amongst other changes, it fixes the relative path to `onfido-sdk-ui`, which was previously showing the developer's repository absolute path.

# Problem

# Solution

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
