### PR TITLE
Update readme and remove beta warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ For example, if you want to allow only Spanish (ESP) driving licences, and natio
   }
   ```
 
-- `useLiveDocumentCapture` (boolean - default: `false`)
+- `useLiveDocumentCapture` (boolean - default: `true`)
   **This feature is only available on mobile devices.**
 
   When set to `true`, users on mobile browsers with camera support will be able to capture document images using an optimised camera UI, where the SDK directly controls the camera feed to ensure live capture. Configuring this option minimises the risk of fraudulent upload by bypassing the device's default camera application. For unsupported scenarios, see the `uploadFallback` section below.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -99,12 +99,6 @@ const experimentalFeatureWarnings = ({ steps }: NormalisedSdkOptions) => {
     )
   }
 
-  if (documentStep?.options?.useLiveDocumentCapture) {
-    console.warn(
-      '`useLiveDocumentCapture` is a beta feature and is still subject to ongoing changes'
-    )
-  }
-
   const activeVideoStep = buildStepFinder(steps)('activeVideo')
 
   if (activeVideoStep) {


### PR DESCRIPTION
# Problem
useLiveDocumentCapture is 'true' by default. It's not in beta anymore.

# Solution

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
