### PR TITLE
feat(orc-1253): SSN input autocomplete with mask

### DIFF
--- a/src/components/Capture/ProfileData.tsx
+++ b/src/components/Capture/ProfileData.tsx
@@ -17,6 +17,7 @@ import theme from '../Theme/style.scss'
 import { CountrySelector } from './CountrySelector'
 import { StateSelector } from './StateSelector'
 import { DateOfBirthInput, getMaxDay } from './DateOfBirthInput'
+import { SSNInput } from './SSNInput'
 import style from './style.scss'
 
 import type { StepComponentDataProps, CompleteStepValue } from '~types/routers'
@@ -290,16 +291,7 @@ const getFieldComponent = (
     case 'postcode':
       return <Input {...props} type="text" style={{ width: space(22) }} />
     case 'ssn':
-      return (
-        <Input
-          {...props}
-          placeholder={'999-99-9999'}
-          pattern={'d{3}-d{2}-d{4}'}
-          maxLength={11}
-          type="text"
-          style={{ width: space(22) }}
-        />
-      )
+      return <SSNInput {...props} style={{ width: space(22) }} />
     default:
       return <Input {...props} type="text" />
   }

--- a/src/components/Capture/SSNInput/index.tsx
+++ b/src/components/Capture/SSNInput/index.tsx
@@ -1,0 +1,85 @@
+import { h } from 'preact'
+import { Input } from '@onfido/castor-react'
+import { useEffect, useState } from 'preact/hooks'
+
+export type SSNInputProps = {
+  name?: string
+  placeholder?: string
+  style?: { [key: string]: string | number }
+  value?: number | string
+  maxLength?: number
+  invalid?: boolean
+  onChange?: (ev: { target: { value: string } }) => void
+}
+
+const isCharacterNumber = (char: string) => {
+  return /^\d/.test(char)
+}
+
+const formatValueWithMask = (value: string) => {
+  const currentValue = value.split('').filter(isCharacterNumber)
+  return currentValue
+    .reduce((newValue: string[], value: string, idx: number) => {
+      if (idx === 3 || idx === 5) {
+        return [...newValue, ...['-', value]]
+      }
+
+      return [...newValue, value]
+    }, [])
+    .join('')
+}
+
+const handleCopyText = () => {
+  navigator.clipboard
+    .readText()
+    .then((text) => {
+      const formattedCopiedText = text.replaceAll('-', '')
+      navigator.clipboard.writeText(formattedCopiedText)
+    })
+    .catch((err) => {
+      console.error('Failed to read clipboard contents: ', err)
+    })
+}
+
+export const SSNInput = (props: SSNInputProps) => {
+  const [formattedSSNValue, setFormattedSSNValue] = useState('')
+
+  useEffect(() => {
+    window.addEventListener('copy', handleCopyText)
+
+    return () => {
+      window.removeEventListener('copy', handleCopyText)
+    }
+  }, [])
+
+  const handleOnInputValueChange = ({
+    currentTarget: { value },
+  }: {
+    currentTarget: { value: string }
+  }) => {
+    const newValue = formatValueWithMask(value)
+    setFormattedSSNValue(newValue)
+  }
+
+  const handleOnInputChange = ({
+    target: { value },
+  }: {
+    target: { value: string }
+  }) => {
+    const newValue = formatValueWithMask(value)
+    setFormattedSSNValue(newValue)
+    props.onChange?.({ target: { value: newValue } })
+  }
+
+  return (
+    <Input
+      {...props}
+      maxLength={11}
+      onChange={handleOnInputChange}
+      onInput={handleOnInputValueChange}
+      placeholder={'999-99-9999'}
+      type="text"
+      value={formattedSSNValue}
+    />
+  )
+}


### PR DESCRIPTION
# Problem

Currently people need to write the complete SSN with `-` for it to be valid
When copying it, everything gets copied

# Solution

automatically add the SSN mask when typing
remove the mask when copying from the input
