### PR TITLE
Add git commit hash to console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Internal: Add Network module
 - Internal: Move all network calls to the Network module
 - Internal: Add `trackPropertiesBeforeMount` to internal analytics api
+- Public: Add commit hash in console
 
 ## [8.1.1] - 2022-07-13
 

--- a/build/webpack/plugins.ts
+++ b/build/webpack/plugins.ts
@@ -2,6 +2,7 @@ import webpack from 'webpack'
 import { ModifySourcePlugin } from 'modify-source-webpack-plugin'
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer'
 import { getSourceFileAsString } from '../morph/build.morph'
+import { GitRevisionPlugin } from 'git-revision-webpack-plugin'
 // @ts-ignore
 import Visualizer from 'webpack-visualizer-plugin2'
 import {
@@ -15,6 +16,8 @@ import {
   BASE_32_VERSION,
   BASE_DIR,
 } from './constants'
+
+const gitRevisionPlugin = new GitRevisionPlugin()
 
 const formatDefineHash = (defineHash: Record<string, unknown>) => {
   const formatted: Record<string, unknown> = {}
@@ -67,6 +70,7 @@ export const basePlugins = (bundle_name = '') =>
         SDK_TOKEN_FACTORY_SECRET,
         WOOPRA_WINDOW_KEY,
         WOOPRA_IMPORT: `imports-loader?this=>Window.prototype["${WOOPRA_WINDOW_KEY}"],window=>Window.prototype["${WOOPRA_WINDOW_KEY}"]!wpt/wpt.js`,
+        COMMITHASH: gitRevisionPlugin.commithash(),
       })
     ),
   ].filter(Boolean)

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,7 @@
         "eslint-plugin-prettier": "^3.1.4",
         "eslint-plugin-react": "^7.20.6",
         "eslint-plugin-react-hooks": "^4.3.0",
+        "git-revision-webpack-plugin": "^5.0.0",
         "html-webpack-plugin": "^5.5.0",
         "imports-loader": "^0.8.0",
         "jest": "^27.5.1",
@@ -8833,6 +8834,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/git-revision-webpack-plugin": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/git-revision-webpack-plugin/-/git-revision-webpack-plugin-5.0.0.tgz",
+      "integrity": "sha512-RptQN/4UKcEPkCBmRy8kLPo5i8MnF8+XfAgFYN9gbwmKLTLx4YHsQw726H+C5+sIGDixDkmGL3IxPA2gKo+u4w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
       }
     },
     "node_modules/glob": {
@@ -24675,6 +24688,13 @@
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
       }
+    },
+    "git-revision-webpack-plugin": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/git-revision-webpack-plugin/-/git-revision-webpack-plugin-5.0.0.tgz",
+      "integrity": "sha512-RptQN/4UKcEPkCBmRy8kLPo5i8MnF8+XfAgFYN9gbwmKLTLx4YHsQw726H+C5+sIGDixDkmGL3IxPA2gKo+u4w==",
+      "dev": true,
+      "requires": {}
     },
     "glob": {
       "version": "7.1.6",

--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.6",
     "eslint-plugin-react-hooks": "^4.3.0",
+    "git-revision-webpack-plugin": "^5.0.0",
     "html-webpack-plugin": "^5.5.0",
     "imports-loader": "^0.8.0",
     "jest": "^27.5.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -153,7 +153,11 @@ const getContainerElementById = (containerId: string) => {
 }
 
 export const init = (opts: SdkOptions): SdkHandle => {
-  console.log('onfido_sdk_version', process.env.SDK_VERSION)
+  console.log(
+    'onfido_sdk_version',
+    process.env.SDK_VERSION,
+    process.env.COMMITHASH
+  )
   const options = formatOptions({ ...defaults, ...opts })
 
   experimentalFeatureWarnings(options)


### PR DESCRIPTION
# Problem
Only the version is logged in the console when the SDK starts, would be handy to have to specific commit for the release too.

# Solution
Add git commit hash to console

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
