### PR TITLE
Allow crossdevice sms feature to be disabled by feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Internal: Send OS name and version information in sdk configuration request
 - Internal: Update FaceTec SDK on Auth step from 9.4.11 to 9.4.12
 - Internal: Show connection error screen on active video upload errors
+- Internal: Place cross device SMS feature behind a feature flag
 
 ## [8.3.0] - 2022-08-02
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "SEE LICENSE IN ./LICENSE",
   "scripts": {
     "dev": "HOT_RELOAD_ENABLED=true NODE_ENV=development HTTPS=true webpack serve --progress",
+    "dev:staging": "HOT_RELOAD_ENABLED=true NODE_ENV=staging HTTPS=true webpack serve --progress",
     "dev:activeVideo": "SAFE_SOURCE_MAPS=true npm run dev",
     "dev:auth": "HOT_RELOAD_ENABLED=true NODE_ENV=development SDK_ENV=Auth HTTPS=true webpack serve --progress",
     "dev:insecure": "HOT_RELOAD_ENABLED=true NODE_ENV=development webpack serve --progress",

--- a/src/components/crossDevice/CrossDeviceLink/CrossDeviceLinkUI.tsx
+++ b/src/components/crossDevice/CrossDeviceLink/CrossDeviceLinkUI.tsx
@@ -19,6 +19,10 @@ import CopyLink from './CopyLink'
 import { LegacyTrackedEventNames } from '~types/tracker'
 import { CrossDeviceLinkProps } from '.'
 import { Country } from 'react-phone-number-input'
+import {
+  withSdkConfigurationService,
+  SDKConfigurationServiceProps,
+} from '~contexts/useSdkConfigurationService'
 
 export type SecureLinkViewType = {
   id: string
@@ -81,7 +85,9 @@ type CrossDeviceLinkUIProps = {
   _crossDeviceLinkMethods?: Array<string> | null
 }
 
-type Props = CrossDeviceLinkUIProps & CrossDeviceLinkProps
+type Props = CrossDeviceLinkUIProps &
+  CrossDeviceLinkProps &
+  SDKConfigurationServiceProps
 
 type State = {
   currentViewId: string
@@ -319,6 +325,7 @@ class CrossDeviceLinkUI extends Component<Props, State> {
     requiredViewRenders: viewRendersMapType
   ): SecureLinkViewType => {
     const { _crossDeviceLinkMethods } = this.props
+
     if (
       _crossDeviceLinkMethods?.length &&
       !configHasInvalidViewIds(_crossDeviceLinkMethods)
@@ -330,7 +337,14 @@ class CrossDeviceLinkUI extends Component<Props, State> {
         .filter(Boolean)
       return result as SecureLinkViewType
     }
-    return SECURE_LINK_VIEWS.filter((view) => view.id in requiredViewRenders)
+
+    let result = SECURE_LINK_VIEWS
+
+    if (this.props.sdkConfiguration?.sdk_features?.disable_cross_device_sms) {
+      result = result.filter((view) => view.id !== 'sms')
+    }
+
+    return result.filter((view) => view.id in requiredViewRenders)
   }
 
   componentWillUnmount() {
@@ -400,4 +414,4 @@ class CrossDeviceLinkUI extends Component<Props, State> {
   }
 }
 
-export default CrossDeviceLinkUI
+export default withSdkConfigurationService(CrossDeviceLinkUI)

--- a/src/contexts/useSdkConfigurationService.tsx
+++ b/src/contexts/useSdkConfigurationService.tsx
@@ -1,6 +1,12 @@
 import { getSdkConfiguration } from '~utils/onfidoApi'
 import { useContext, useEffect, useState } from 'preact/compat'
-import { h, ComponentChildren, createContext, Fragment } from 'preact'
+import {
+  h,
+  ComponentChildren,
+  createContext,
+  Fragment,
+  ComponentType,
+} from 'preact'
 import { ParsedError, SdkConfiguration, ErrorCallback } from '~types/api'
 import deepmerge from 'deepmerge'
 import withTheme from '../components/Theme'
@@ -27,6 +33,7 @@ const defaultConfiguration: SdkConfiguration = {
   },
   sdk_features: {
     enable_require_applicant_consents: true,
+    disable_cross_device_sms: false,
   },
   document_capture: {
     max_total_retries: 1,
@@ -91,5 +98,22 @@ export const SdkConfigurationServiceProvider = ({
 const useSdkConfigurationService = () => {
   return useContext(SdkConfigurationServiceContext)
 }
+
+export type SDKConfigurationServiceProps = {
+  sdkConfiguration: SdkConfiguration
+}
+
+export const withSdkConfigurationService = <P,>(
+  WrapperComponent: ComponentType<P & SDKConfigurationServiceProps>
+): ComponentType<P> =>
+  function SDKConfigurationWrapper(props) {
+    return (
+      <SdkConfigurationServiceContext.Consumer>
+        {(sdkConfiguration) => (
+          <WrapperComponent {...props} sdkConfiguration={sdkConfiguration} />
+        )}
+      </SdkConfigurationServiceContext.Consumer>
+    )
+  }
 
 export default useSdkConfigurationService

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -279,6 +279,7 @@ export interface ExperimentalFeatures {
 
 export interface SdkFeatures {
   enable_require_applicant_consents?: boolean
+  disable_cross_device_sms?: boolean
 }
 
 export interface OnDeviceValidation {


### PR DESCRIPTION
# Problem
The sms feature can't be disabled remotely

# Solution
Add a feature flag to disable the sms feature when needed

TODO:
- [x] Changelog
- [x] Wait for MR to be merged: https://gitlab.eu-west-1.mgmt.onfido.xyz/onfido/sdks/sdk-configuration-service/-/merge_requests/90
- [x] Test against updated backend

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
