### PR TITLE
Send OS name and version on sdk configuration request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ## Changed
 
+- Internal: Send OS name and version information in sdk configuration request
 - Internal: Add dynamically loaded files (except en_US)
 - Internal: Upgraded Sentry to v7, added ErrorBoundary, fingerprinting and moved into its own module
 - Internal: Move Woopra into it's own core module

--- a/src/components/utils/onfidoApi.ts
+++ b/src/components/utils/onfidoApi.ts
@@ -586,6 +586,7 @@ export const getSdkConfiguration = (
   new Promise((resolve, reject) => {
     try {
       const browserInfo = detectSystem('browser')
+      const osInfo = detectSystem('os')
 
       const requestParams: HttpRequestParams = {
         endpoint: `${url}/v3.3/sdk/configurations`,
@@ -599,6 +600,8 @@ export const getSdkConfiguration = (
             system: {
               browser: browserInfo.name,
               browser_version: browserInfo.version,
+              os: osInfo.name,
+              os_version: osInfo.version,
             },
           },
         }),


### PR DESCRIPTION
# Problem

Currently we're sending just the browser name/version on the request,
but the sdk configuration service accepts also the OS name/version and
it can be used to provide different configurations for web on
mobile/desktop devices.

# Solution

Add OS name/version information on the request payload

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
