### PR TITLE
refactor: don't use workflow run's "outcome"

### DIFF
--- a/src/components/App/__tests__/index.test.tsx
+++ b/src/components/App/__tests__/index.test.tsx
@@ -15,8 +15,6 @@ const defaultOptions: SDKOptionsWithRenderData = {
     { type: 'data' },
     { type: 'complete' },
     { type: 'retry' },
-    { type: 'pass' },
-    { type: 'reject' },
   ],
   containerId: 'onfido-mount',
   containerEl: document.createElement('div'),

--- a/src/components/RestrictedDocumentSelection/useDocumentTypesAdapter.ts
+++ b/src/components/RestrictedDocumentSelection/useDocumentTypesAdapter.ts
@@ -77,6 +77,7 @@ export const useDocumentTypesAdapter = () => {
           ...documentStep,
           options: {
             ...documentStep.options,
+            //@ts-ignore
             documentSelection,
             countryFilter,
           },

--- a/src/components/Router/StepComponentMap.tsx
+++ b/src/components/Router/StepComponentMap.tsx
@@ -179,8 +179,6 @@ const buildCaptureStepComponents = (
       ),
     ],
     complete,
-    pass: [Complete],
-    reject: [Complete],
     retry: [Retry],
   }
 }

--- a/src/components/Router/createWorkflowStepsHook.tsx
+++ b/src/components/Router/createWorkflowStepsHook.tsx
@@ -106,8 +106,7 @@ export const createWorkflowStepsHook = (
           loading: false,
           hasNextStep: false,
           taskId: workflow?.task_id,
-          // @ts-ignore
-          steps: [formatStep(workflowEngine.getOutcomeStep(workflow))],
+          steps: [formatStep('complete')],
         }))
         cb()
         return

--- a/src/locales/en_US/en_US.json
+++ b/src/locales/en_US/en_US.json
@@ -1,14 +1,4 @@
 {
-    "workflow_complete": {
-        "pass": {
-            "title": "Passed",
-            "description": "We have been able to verify your identity"
-        },
-        "reject": {
-            "title": "Rejected",
-            "description": "We haven't been able to verify your identity"
-        }
-    },
     "workflow_erros": {
         "task_not_supported": "Task is currently not supported.",
         "task_not_completed": "Could not complete workflow task.",

--- a/src/types/steps.ts
+++ b/src/types/steps.ts
@@ -7,8 +7,6 @@ const STEP_COMPLETE = 'complete'
 const STEP_AUTH = 'auth'
 const STEP_ACTIVE_VIDEO = 'activeVideo'
 const STEP_CROSS_DEVICE_SESSION_INTRO = 'crossDeviceSessionIntro'
-const STEP_WORKFLOW_PASS = 'pass'
-const STEP_WORKFLOW_REJECT = 'reject'
 const STEP_DATA_CAPTURE = 'data'
 const STEP_WORKFLOW_RETRY = 'retry'
 
@@ -20,8 +18,6 @@ export type PublicStepTypes =
   | typeof STEP_COMPLETE
   | typeof STEP_AUTH
   | typeof STEP_CROSS_DEVICE_SESSION_INTRO
-  | typeof STEP_WORKFLOW_PASS
-  | typeof STEP_WORKFLOW_REJECT
   | typeof STEP_DATA_CAPTURE
 
 export type PrivateStepTypes =
@@ -98,14 +94,6 @@ export type StepOptionComplete = {
   submessage?: string
 }
 
-export type StepOptionPass = {
-  // nothing
-}
-
-export type StepOptionReject = {
-  // nothing
-}
-
 export type StepOptionData = {
   first_name?: string
   last_name?: string
@@ -140,8 +128,6 @@ type StepOptionsMap = {
   face: StepOptionFace
   activeVideo: never
   complete: StepOptionComplete
-  pass: StepOptionPass
-  reject: StepOptionReject
   data: StepOptionData
   retry: StepOptionRetry
 }
@@ -162,8 +148,6 @@ export type StepConfigDocument = StepConfigMap['document']
 export type StepConfigPoa = StepConfigMap['poa']
 export type StepConfigFace = StepConfigMap['face']
 export type StepConfigComplete = StepConfigMap['complete']
-export type StepConfigPass = StepConfigMap['pass']
-export type StepConfigReject = StepConfigMap['reject']
 export type StepConfigData = StepConfigMap['data']
 export type StepConfigRetry = StepConfigMap['retry']
 
@@ -176,8 +160,6 @@ export type PublicStepConfig =
   | StepConfigAuth
   | StepConfigActiveVideo
   | StepConfigCrossDeviceSessionIntro
-  | StepConfigPass
-  | StepConfigReject
   | StepConfigData
   | StepConfigRetry
 

--- a/src/workflow-engine/__mocks__/_engineMock.ts
+++ b/src/workflow-engine/__mocks__/_engineMock.ts
@@ -1,7 +1,6 @@
 import { EngineInterface, EngineProps } from '../engine'
 import type {
   WorkflowResponse,
-  OutcomeStepKeys,
   GetWorkflowFunc,
   WorkflowStepConfig,
 } from '../utils/WorkflowTypes'
@@ -13,14 +12,6 @@ export class MockEngine implements EngineInterface {
     this.engineProps = engineProps
   }
 
-  getOutcomeStep = (workflow: WorkflowResponse): OutcomeStepKeys => {
-    return !workflow.has_remaining_interactive_tasks
-      ? 'complete'
-      : workflow.outcome
-      ? 'pass'
-      : 'reject'
-  }
-
   getWorkflow: GetWorkflowFunc = async (): Promise<WorkflowResponse> => {
     return {
       id: 'ec9013ea',
@@ -30,7 +21,6 @@ export class MockEngine implements EngineInterface {
       task_def_id: 'upload_document_photo',
       task_id: '2a11059f-b2dd-4374-9e72-58bb2cb410b8',
       task_type: 'INTERACTIVE',
-      outcome: false,
       error: 'error',
       has_remaining_interactive_tasks: true,
     }
@@ -49,7 +39,6 @@ export class MockEngine implements EngineInterface {
       task_def_id: 'upload_document_photo',
       task_id: '2a11059f-b2dd-4374-9e72-58bb2cb410b8',
       task_type: 'INTERACTIVE',
-      outcome: undefined,
       error: undefined,
       has_remaining_interactive_tasks: true,
     }

--- a/src/workflow-engine/__tests__/engine.test.ts
+++ b/src/workflow-engine/__tests__/engine.test.ts
@@ -26,56 +26,6 @@ describe('Workflow Engine', () => {
     })
   })
 
-  describe('with Workflow Outcome', () => {
-    it('should return outcome step: "complete"', async () => {
-      const workflow = {
-        id: 'Xec9013ea',
-        applicant_id: 'd8034341-5ca2-4f90-a1c6-ae92c9519a21',
-        config: { name: 'timeout', value: 1209600, document_selection: [] },
-        finished: true,
-        task_def_id: 'upload_document_photo',
-        task_id: '2a11059f-b2dd-4374-9e72-58bb2cb410b8',
-        outcome: undefined,
-        error: undefined,
-        has_remaining_interactive_tasks: false,
-      }
-      const outcomeStep = workflowEngine1.getOutcomeStep(workflow)
-      expect(outcomeStep).toEqual('complete')
-    })
-
-    it('should return outcome step as: "Pass"', async () => {
-      const workflow1 = {
-        id: 'Xec9013ea',
-        applicant_id: 'd8034341-5ca2-4f90-a1c6-ae92c9519a21',
-        config: { name: 'timeout', value: 1209600, document_selection: [] },
-        finished: true,
-        task_def_id: 'upload_document_photo',
-        task_id: '2a11059f-b2dd-4374-9e72-58bb2cb410b8',
-        outcome: true,
-        error: undefined,
-        has_remaining_interactive_tasks: true,
-      }
-      const outcomeStep = workflowEngine1.getOutcomeStep(workflow1)
-      expect(outcomeStep).toEqual('pass')
-    })
-
-    it('should return outcome step as: "Reject"', async () => {
-      const workflow2 = {
-        id: 'Xec9013ea',
-        applicant_id: 'd8034341-5ca2-4f90-a1c6-ae92c9519a21',
-        config: { name: 'timeout', value: 1209600, document_selection: [] },
-        finished: true,
-        task_def_id: 'upload_document_photo',
-        task_id: '2a11059f-b2dd-4374-9e72-58bb2cb410b8',
-        outcome: undefined,
-        error: undefined,
-        has_remaining_interactive_tasks: true,
-      }
-      const outcomeStep = workflowEngine1.getOutcomeStep(workflow2)
-      expect(outcomeStep).toEqual('reject')
-    })
-  })
-
   describe('WorkflowStep task', () => {
     beforeEach(() => {
       workflowEngine1 = new Engine({

--- a/src/workflow-engine/engine.ts
+++ b/src/workflow-engine/engine.ts
@@ -3,14 +3,12 @@ import { formatError } from '~utils/onfidoApi'
 import type { documentSelectionType } from '~types/commons'
 import type {
   WorkflowResponse,
-  OutcomeStepKeys,
   GetWorkflowFunc,
   CompleteWorkflowFunc,
   GetFlowStepFunc,
 } from './utils/WorkflowTypes'
 
 export interface EngineInterface {
-  getOutcomeStep(workflow: WorkflowResponse | undefined): OutcomeStepKeys
   getWorkflow: GetWorkflowFunc
   completeWorkflow: CompleteWorkflowFunc
   getWorkFlowStep: GetFlowStepFunc
@@ -31,14 +29,6 @@ export class Engine implements EngineInterface {
 
   constructor(engineProps: EngineProps) {
     this.engineProps = engineProps
-  }
-
-  getOutcomeStep = (workflow: WorkflowResponse): OutcomeStepKeys => {
-    return !workflow.has_remaining_interactive_tasks
-      ? 'complete'
-      : workflow.outcome
-      ? 'pass'
-      : 'reject'
   }
 
   getWorkflow: GetWorkflowFunc = async (): Promise<WorkflowResponse> => {

--- a/src/workflow-engine/utils/WorkflowTypes.ts
+++ b/src/workflow-engine/utils/WorkflowTypes.ts
@@ -29,8 +29,7 @@ export type documentSelectionConfigType = {
 }
 
 export type WorklowTaskStepKeys = string
-export type OutcomeStepKeys = 'pass' | 'reject' | 'complete'
-export type StepKeys = 'loading' | WorklowTaskStepKeys | OutcomeStepKeys
+export type StepKeys = 'loading' | WorklowTaskStepKeys | 'complete'
 export type WorkflowTaskTypes =
   | 'START'
   | 'INTERACTIVE'
@@ -47,7 +46,6 @@ export type WorkflowResponse = {
   task_def_id?: string | undefined
   config: WorkflowStepConfig
   finished: boolean
-  outcome: boolean | undefined
   error: string | undefined
   has_remaining_interactive_tasks: boolean
 }


### PR DESCRIPTION
# Problem

"outcome" to be removed from workflow run's response.

# Solution

Don't use "outcome" in code anymore.

Although it was not used already - here just removing leftovers.
