### PR TITLE
🥅 Propose cross-device flow when no camera is detected for Motion

### DIFF
--- a/src/components/Capture/withCrossDeviceWhenNoCamera.tsx
+++ b/src/components/Capture/withCrossDeviceWhenNoCamera.tsx
@@ -67,7 +67,9 @@ const withCrossDeviceWhenNoCamera = <P extends CaptureComponentProps>(
         !photoCaptureFallback
       const cameraRequiredButNoneDetected =
         (!hasCamera || shouldSelfieFallbackBeDisabled) &&
-        (requestedVariant === 'video' || currentStep === 'face')
+        (requestedVariant === 'video' ||
+          currentStep === 'face' ||
+          currentStep === 'activeVideo')
 
       if (
         cameraRequiredButNoneDetected ||


### PR DESCRIPTION
# Problem

When no camera is detected, Motion would proceed.

# Solution

Re-use the existing HOCs to fallback to cross-device.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
