### PR TITLE
Fix/biomanu 2202 fallback to initial step on cross device

### DIFF
--- a/src/components/Router/CrossDeviceMobileRouter.tsx
+++ b/src/components/Router/CrossDeviceMobileRouter.tsx
@@ -234,10 +234,24 @@ export default class CrossDeviceMobileRouter extends Component<
       return this.setError()
     }
 
+    // NOTE, This is should be removed as soon as motion is supported on Mobile
+    const convertMotionStepToInitialConfig = (steps: StepConfig[]) => {
+      const initialFaceStep =
+        //@ts-ignore
+        steps.find((s) => s.type === 'activeVideo')?.original
+
+      if (!initialFaceStep) return steps
+
+      return (
+        steps &&
+        steps.map((t) => (t.type === 'activeVideo' ? initialFaceStep : t))
+      )
+    }
+
     this.setState(
       {
         token,
-        steps,
+        steps: convertMotionStepToInitialConfig(steps),
         step: stepIndex,
         stepIndexType: 'client',
         crossDeviceError: undefined,

--- a/src/contexts/useActiveVideo.tsx
+++ b/src/contexts/useActiveVideo.tsx
@@ -24,6 +24,8 @@ const useActiveVideo = () => {
 
       const activeVideo: StepConfig = {
         type: 'activeVideo',
+        //@ts-ignore
+        original: steps[faceIndex],
       }
 
       return [


### PR DESCRIPTION
# Problem
Motion should not be enabled on mobile browsers when going for the cross device flow

# Solution
When Motion is enabled, we replace the initial face step with the `activeVideo` step. but if the user is unable to complete the IDV on desktop, we should revert motion back to the original step when users go over to mobile via cross device.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
