### PR TITLE
🏗️ Fix Motion navigation bar integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.3.0",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
-        "@onfido/active-video-capture": "^0.7.0",
+        "@onfido/active-video-capture": "^0.8.0",
         "@sentry/browser": "^7.2.0",
         "blueimp-load-image": "~2.29.0",
         "classnames": "~2.2.5",
@@ -3072,9 +3072,9 @@
       }
     },
     "node_modules/@onfido/active-video-capture": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@onfido/active-video-capture/-/active-video-capture-0.7.0.tgz",
-      "integrity": "sha512-Apo0x7huJOf4oaB9qIuddGUgReR7Omj/qrnpQrLzQ9n6JXmh+5/3r2CVE2rginmPTI1VPVr6P3wx00S+BojG7g==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@onfido/active-video-capture/-/active-video-capture-0.8.0.tgz",
+      "integrity": "sha512-HGGYEBvYiWFd81frBYxzV1/R7gLgjevRBO9i8VPkTNdkv/zh7gEqz/btlbskKDhMaY500psiZ2d4eCqcYDJn4Q==",
       "dependencies": {
         "@vladmandic/human": "^2.9.1",
         "preact": "^10.7.3",
@@ -21221,9 +21221,9 @@
       }
     },
     "@onfido/active-video-capture": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@onfido/active-video-capture/-/active-video-capture-0.7.0.tgz",
-      "integrity": "sha512-Apo0x7huJOf4oaB9qIuddGUgReR7Omj/qrnpQrLzQ9n6JXmh+5/3r2CVE2rginmPTI1VPVr6P3wx00S+BojG7g==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@onfido/active-video-capture/-/active-video-capture-0.8.0.tgz",
+      "integrity": "sha512-HGGYEBvYiWFd81frBYxzV1/R7gLgjevRBO9i8VPkTNdkv/zh7gEqz/btlbskKDhMaY500psiZ2d4eCqcYDJn4Q==",
       "requires": {
         "@vladmandic/human": "^2.9.1",
         "preact": "^10.7.3",

--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
     "yn": "^3.0.0"
   },
   "dependencies": {
-    "@onfido/active-video-capture": "^0.7.0",
+    "@onfido/active-video-capture": "^0.8.0",
     "@sentry/browser": "^7.2.0",
     "blueimp-load-image": "~2.29.0",
     "classnames": "~2.2.5",

--- a/src/components/ActiveVideo/ActiveVideo.tsx
+++ b/src/components/ActiveVideo/ActiveVideo.tsx
@@ -26,6 +26,7 @@ import { trackComponent } from 'Tracker'
 import CameraError from 'components/CameraError'
 import FallbackButton from 'components/Button/FallbackButton'
 import withCrossDeviceWhenNoCamera from 'components/Capture/withCrossDeviceWhenNoCamera'
+import NavigationBar from 'components/NavigationBar'
 
 type Props = StepComponentBaseProps & {
   onUserMedia: () => void
@@ -36,6 +37,7 @@ type Props = StepComponentBaseProps & {
 const ActiveVideo: FunctionComponent<Props> = (props) => {
   const {
     nextStep,
+    back,
     translate,
     trackScreen,
     actions,
@@ -108,6 +110,7 @@ const ActiveVideo: FunctionComponent<Props> = (props) => {
       onSuccess={onSuccess}
       onUserMedia={onUserMedia}
       hasGrantedPermission={!!hasGrantedPermission}
+      navigationBar={<NavigationBar back={back} transparent={true} />}
     />
   )
 }

--- a/src/components/Router/StepsRouter.tsx
+++ b/src/components/Router/StepsRouter.tsx
@@ -73,8 +73,8 @@ class StepsRouter extends Component<StepsRouterProps> {
       ? logoCobrand
       : globalUserOptions.enterpriseFeatures?.logoCobrand && logoCobrand
 
-    const edgeToEdgeContent =
-      CurrentComponent.displayName === 'ActiveVideoCapture'
+    // FIXME: Clean up this hack (see 163ed120, 10d9de1a, and e56fada0)
+    const edgeToEdgeContent = false
 
     return (
       //TODO: Wrap CurrentComponent in themeWrap HOC

--- a/src/components/Router/__tests__/index.test.tsx
+++ b/src/components/Router/__tests__/index.test.tsx
@@ -66,35 +66,5 @@ describe('Router', () => {
       expect(wrapper.find('MainRouter').exists()).toBeFalsy()
       expect(wrapper.find('CrossDeviceMobileRouter').exists()).toBeTruthy()
     })
-
-    it('renders with edgeToEdgeContent=true on specific components', async () => {
-      render(
-        <MockedReduxProvider>
-          <SdkOptionsProvider options={defaultOptions}>
-            <MockedLocalised>
-              <HistoryRouterWrapper
-                options={defaultOptions}
-                triggerOnError={() => {}}
-                allowCrossDeviceFlow={false}
-                useSteps={createMockStepsHook({
-                  steps: [{ type: 'activeVideo' }],
-                })}
-                {...mockedReduxProps}
-              />
-            </MockedLocalised>
-          </SdkOptionsProvider>
-        </MockedReduxProvider>
-      )
-
-      let back = screen.getByText(/generic.back/)
-      let navigationBar = back.closest('.navigationBar')
-      expect(navigationBar?.classList.contains('transparent')).toBeFalsy()
-
-      await userEvent.click(screen.getByText(/avc_intro.button_primary_ready/))
-
-      back = screen.getByText(/generic.back/)
-      navigationBar = back.closest('.navigationBar')
-      expect(navigationBar?.classList.contains('transparent')).toBeTruthy()
-    })
   })
 })

--- a/src/components/Theme/style.scss
+++ b/src/components/Theme/style.scss
@@ -124,7 +124,6 @@
   $non-content-height: $footer-height + $footer-margin + $navigation-height +
     $navigation-padding-top;
   height: calc(100% - #{$non-content-height});
-  position: relative;
   display: flex;
   flex-direction: column;
   -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
The hack introduced in the Web SDK to allow the navigation bar to appear transparent and the component to take the full height didn't really work correctly because the error screens (e.g. face not detected) required a classic navigation bar, causing various visual bugs (scrollbars, unexpected gradient, white-on-white back button). Now, this capture screen do need to integrate with the router and take the full height.

The solution is to remove the relative positioning on the `content` class, so the specific capture screen can be absolutely positioned relatively to the top of the frame. This is a risky change as it impacts *all* Web SDK screens. Luckily, the parent component is also relatively positioned thanks to the `step` class and this solution shouldn't change the layout in any way for other screens.

The navigation bar (back button, close icon on modal) needs to render transparently and white-on-black, so it is pre-rendered and passed to the component so it can display it on top thanks to a high-enough z-index. It's unusual, but better than duplicating the navigation logic and style in Motion components.

This change does not remove the technical debt that was previously introduced. It will be done in a follow-up commit.

Requires [this MR](https://gitlab.eu-west-1.mgmt.onfido.xyz/onfido/biometrics/experience/active-video-capture/-/merge_requests/73) on the `active-video-capture` package.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
