### PR TITLE
Allow for sub name in branch name in prepare release flow

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Setup env
         run: |
-          clean_release_version=$(echo $RELEASE_VERSION | sed -e 's/-.*//g')
+          clean_release_version=$(echo $RELEASE_VERSION | sed -e 's/-rc.*//g')
           echo "RELEASE_BRANCH_NAME=release/$clean_release_version" >> $GITHUB_ENV
 
       - name: Validate Input


### PR DESCRIPTION
# Problem
The releases for non rc releases cutoff the sub name of the branch name (9.0.0-beta.1 becomes 9.0.0)

# Solution
The branch name should only be stripped of the `-rc.*`. 

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
