### PR TITLE
🩹 Fix Active Video UI

### DIFF
--- a/src/components/ActiveVideo/BaseScreen/style.module.scss
+++ b/src/components/ActiveVideo/BaseScreen/style.module.scss
@@ -7,4 +7,5 @@
   align-items: center;
   border-radius: var(--ods-border-radius-large);
   background: var(--osdk-color-background-surface-modal);
+  padding: 0;
 }

--- a/src/components/ActiveVideo/Button/style.module.scss
+++ b/src/components/ActiveVideo/Button/style.module.scss
@@ -17,7 +17,7 @@
   text-decoration: none;
   width: fit-content;
   min-width: 272px;
-  min-height: 56px;
+  min-height: 48px;
   cursor: pointer;
   outline: none;
 


### PR DESCRIPTION
# Problem

- The button height on ActiveVideo is different from the other buttons.
- The `BaseScreen` component is inheriting undesired padding.

# Solution

- Update the ActiveVideo Button height from `56px` to `48px` to keep the consistency.
- Add `padding: 0` to the `BaseScreen` component, to ensure that this component has no padding.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
