### PR TITLE
Add new property to DOCUMENT_TYPE_SELECTION screen

### DIFF
--- a/src/Tracker/trackerData.tsx
+++ b/src/Tracker/trackerData.tsx
@@ -266,7 +266,10 @@ export const analyticsEventsMapping = new Map<
     'screen_document_type_select',
     {
       eventName: 'DOCUMENT_TYPE_SELECTION',
-      properties: { event_type: 'screen' },
+      properties: {
+        event_type: 'screen',
+        combined_country_and_document_selection: true,
+      },
     },
   ],
   [

--- a/src/types/tracker.ts
+++ b/src/types/tracker.ts
@@ -309,6 +309,7 @@ export type CaptureFormat = 'photo' | 'camera' // I think this maps 1-1 to Reque
 
 export type AnalyticsEventProperties = {
   event_type?: TrackedEventTypes
+  combined_country_and_document_selection?: boolean
   step?: string
   is_cross_device?: boolean
   is_custom_ui?: boolean


### PR DESCRIPTION
# Problem
- See https://onfido.slack.com/archives/C01F3S5HE2F/p1659957145688729

# Solution
- Differentiate the old screen with the new one with a new `combined_country_and_document_selection` property
 
## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
