### PR TITLE
🏗️ Fix Motion camera permission integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.3.0",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
-        "@onfido/active-video-capture": "^0.8.0",
+        "@onfido/active-video-capture": "^0.9.0",
         "@sentry/browser": "^7.2.0",
         "blueimp-load-image": "~2.29.0",
         "classnames": "~2.2.5",
@@ -3072,9 +3072,9 @@
       }
     },
     "node_modules/@onfido/active-video-capture": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@onfido/active-video-capture/-/active-video-capture-0.8.0.tgz",
-      "integrity": "sha512-HGGYEBvYiWFd81frBYxzV1/R7gLgjevRBO9i8VPkTNdkv/zh7gEqz/btlbskKDhMaY500psiZ2d4eCqcYDJn4Q==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@onfido/active-video-capture/-/active-video-capture-0.9.0.tgz",
+      "integrity": "sha512-mFo+uPsxL5LqmOYqxqe0X5U+qrIYnHSp9EBE+6cKkdM8UZnChpeaPsCh0WWzn9sbRaB/IdSElhJrAn0e2V838w==",
       "dependencies": {
         "@vladmandic/human": "^2.9.1",
         "preact": "^10.7.3",
@@ -21221,9 +21221,9 @@
       }
     },
     "@onfido/active-video-capture": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@onfido/active-video-capture/-/active-video-capture-0.8.0.tgz",
-      "integrity": "sha512-HGGYEBvYiWFd81frBYxzV1/R7gLgjevRBO9i8VPkTNdkv/zh7gEqz/btlbskKDhMaY500psiZ2d4eCqcYDJn4Q==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@onfido/active-video-capture/-/active-video-capture-0.9.0.tgz",
+      "integrity": "sha512-mFo+uPsxL5LqmOYqxqe0X5U+qrIYnHSp9EBE+6cKkdM8UZnChpeaPsCh0WWzn9sbRaB/IdSElhJrAn0e2V838w==",
       "requires": {
         "@vladmandic/human": "^2.9.1",
         "preact": "^10.7.3",

--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
     "yn": "^3.0.0"
   },
   "dependencies": {
-    "@onfido/active-video-capture": "^0.8.0",
+    "@onfido/active-video-capture": "^0.9.0",
     "@sentry/browser": "^7.2.0",
     "blueimp-load-image": "~2.29.0",
     "classnames": "~2.2.5",

--- a/src/components/ActiveVideo/Lazy.tsx
+++ b/src/components/ActiveVideo/Lazy.tsx
@@ -3,15 +3,31 @@ import { localised } from '~locales'
 import { asyncComponent } from '~utils/components'
 import Spinner from 'components/Spinner'
 
-import type { StepComponentProps } from '~types/routers'
+import type { RenderFallbackProp, StepComponentProps } from '~types/routers'
+import FallbackButton from 'components/Button/FallbackButton'
 
 const ActiveVideo = asyncComponent(
   () => import(/* webpackChunkName: "activeVideo" */ './ActiveVideo'),
   Spinner
 )
 
-const LazyActiveVideo = (props: StepComponentProps) => (
-  <ActiveVideo {...props} />
-)
+const LazyActiveVideo = (props: StepComponentProps) => {
+  const { changeFlowTo } = props
+  const renderCrossDeviceFallback: RenderFallbackProp = ({ text }) => {
+    return (
+      <FallbackButton
+        text={text}
+        onClick={() => changeFlowTo('crossDeviceSteps')}
+      />
+    )
+  }
+
+  return (
+    <ActiveVideo
+      renderCrossDeviceFallback={renderCrossDeviceFallback}
+      {...props}
+    />
+  )
+}
 
 export default localised(LazyActiveVideo)

--- a/src/components/CameraPermissions/withPermissionsFlow.tsx
+++ b/src/components/CameraPermissions/withPermissionsFlow.tsx
@@ -6,13 +6,14 @@ import PermissionsRecover from '../CameraPermissions/Recover'
 import { checkIfWebcamPermissionGranted } from '~utils'
 
 import type { WithTrackingProps, WithPermissionsFlowProps } from '~types/hocs'
-import type { ErrorProp } from '~types/routers'
 
 const permissionErrors = [
   'PermissionDeniedError',
   'NotAllowedError',
   'NotFoundError',
-]
+] as const
+
+export type PermissionError = typeof permissionErrors[number]
 
 type Props = WebcamProps & WithTrackingProps & WithPermissionsFlowProps
 
@@ -51,8 +52,8 @@ export default <P extends Props>(
       this.props.onUserMedia && this.props.onUserMedia()
     }
 
-    handleWebcamFailure = (error: ErrorProp) => {
-      if (permissionErrors.includes(error.name)) {
+    handleWebcamFailure = (error?: Error) => {
+      if (error && permissionErrors.includes(error.name as PermissionError)) {
         this.setState({ hasGrantedPermission: false })
       } else {
         this.props.onFailure && this.props.onFailure()


### PR DESCRIPTION
In the current integration, when no camera is available, a red alert appears with a "Try using your phone instead" link. This works, but differs from other product flows. The camera detection should immediately fall back to cross-device.

Similarly, when a camera is available but permissions were denied, the appropriate error screen would not appear. The error was silently ignored, leaving the SDK in a dangling state.

The solution is to make use of the existing HOC helper `withFailureHandling` instead of re-implementing the error handling in the component, and to bubble the `react-webcam`-emitted permission errors instead of hiding them in a `LivenessError` enumeration.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
