### PR TITLE
Fix document type selection

### DIFF
--- a/src/components/RestrictedDocumentSelection/useDocumentTypesAdapter.ts
+++ b/src/components/RestrictedDocumentSelection/useDocumentTypesAdapter.ts
@@ -40,7 +40,10 @@ export const useDocumentTypesAdapter = () => {
       const documentSelection: documentSelectionType[] = []
 
       documentTypesKeys.forEach((type) => {
-        if (typeof documentTypes[type] === 'boolean') {
+        if (
+          typeof documentTypes[type] === 'boolean' &&
+          documentTypes[type] === true
+        ) {
           // Display this document type for all supported countries
           getSupportedCountriesForDocument(type).map((countryData) =>
             documentSelection.push({

--- a/src/demo/demoUtils.ts
+++ b/src/demo/demoUtils.ts
@@ -156,6 +156,7 @@ const getPreselectedDocumentTypes = (): Partial<
     return {
       driving_licence: true,
       national_identity_card: true,
+      passport: false,
     }
   }
 

--- a/test/webtest/src/main/java/com/onfido/qa/websdk/page/RestrictedDocumentSelection.java
+++ b/test/webtest/src/main/java/com/onfido/qa/websdk/page/RestrictedDocumentSelection.java
@@ -110,6 +110,10 @@ public class RestrictedDocumentSelection extends BasePage {
         return _getOption(documentType);
     }
 
+    public Boolean optionExists(DocumentType documentType) {
+        return !driver.findElements(ByUtil.onfidoQa(documentType.canonicalName())).isEmpty();
+    }
+
     public List<DocumentType> getOptions() {
 
         return driver.findElements(By.cssSelector(".onfido-sdk-ui-DocumentSelector-DocumentList-list li button"))

--- a/test/webtest/src/test/java/com/onfido/qa/websdk/sdk/DocumentStep.java
+++ b/test/webtest/src/test/java/com/onfido/qa/websdk/sdk/DocumentStep.java
@@ -87,6 +87,16 @@ public class DocumentStep extends Step {
         return this;
     }
 
+    public DocumentStep withoutDocumentType(DocumentType documentType) {
+
+        if (this.options.documentTypes == null) {
+            this.options.documentTypes = new HashMap<>();
+        }
+
+        this.options.documentTypes.put(documentType.canonicalName(), false);
+        return this;
+    }
+
     public DocumentStep withForceCrossDevice(Boolean forceCrossDevice) {
         this.options.forceCrossDevice = forceCrossDevice;
         return this;

--- a/test/webtest/src/test/java/com/onfido/qa/websdk/test/DocumentIT.java
+++ b/test/webtest/src/test/java/com/onfido/qa/websdk/test/DocumentIT.java
@@ -381,4 +381,22 @@ public class DocumentIT extends WebSdkIT {
         }
 
     }
+
+    @Test(description = "should verify UI elements not present when disabled on the document selection screen")
+    public void testShouldVerifyUiElementsWithDisabledOptionsOnTheDocumentSelectionScreen() {
+
+        var documentSelector = onfido().withSteps(new DocumentStep()
+            .withDocumentType(DRIVING_LICENCE,new DocumentStep.Option("FRA"))
+            .withDocumentType(PASSPORT,new DocumentStep.Option("FRA"))
+            .withoutDocumentType(IDENTITY_CARD)
+        )
+            .init(RestrictedDocumentSelection.class)
+            .selectSupportedCountry();
+
+        assertThat(documentSelector.optionExists(DocumentType.DRIVING_LICENCE)).isEqualTo(true);
+        assertThat(documentSelector.optionExists(DocumentType.PASSPORT)).isEqualTo(true);
+
+        assertThat(documentSelector.optionExists(DocumentType.IDENTITY_CARD)).isEqualTo(false);
+        assertThat(documentSelector.optionExists(DocumentType.RESIDENT_PERMIT)).isEqualTo(false);
+    }
 }


### PR DESCRIPTION
# Problem
- We didn't take into account documentTypes `false` configuration
- See https://github.com/onfido/onfido-sdk-ui/issues/2029

# Solution
- Add a filter to the RestrictedDocumentSelection.tsx file

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
