### PR TITLE
BIOMANU-2267 - Active video upload connection error screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 - Internal: Collect `FACE_LIVENESS_*` analytics events
 - Internal: Send OS name and version information in sdk configuration request
 - Internal: Update FaceTec SDK on Auth step from 9.4.11 to 9.4.12
+- Internal: Show connection error screen on active video upload errors
 
 ## [8.3.0] - 2022-08-02
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,44 @@ The guides below are provided to ease the transition of existing applications us
 
 ## `8.2.0` -> `next`
 
+The **English**, **Spanish**, **German**, **French**, **Italian**, **Dutch** and **Portuguese** copy for the following string(s) has been added:
+
+### Added strings
+
+- `avc_confirmation.button_primary_upload`
+- `avc_confirmation.subtitle`
+- `avc_confirmation.title`
+- `avc_connection_error.button_primary_retry_upload`
+- `avc_connection_error.button_secondary_restart_recording`
+- `avc_connection_error.subtitle`
+- `avc_connection_error.title`
+- `avc_face_alignment.feedback_move_back`
+- `avc_face_alignment.feedback_move_closer`
+- `avc_face_alignment.feedback_no_face_detected`
+- `avc_face_alignment.feedback_not_centered`
+- `avc_face_alignment.title`
+- `avc_face_capture.alert.timeout_body`
+- `avc_face_capture.alert.timeout_button_primary`
+- `avc_face_capture.alert.timeout_title`
+- `avc_face_capture.alert.too_fast_body`
+- `avc_face_capture.alert.too_fast_button_primary`
+- `avc_face_capture.alert_too_fast_title`
+- `avc_face_capture.title`
+- `avc_face_capture.title_completed`
+- `avc_intro.button_primary_ready`
+- `avc_intro.disclaimer`
+- `avc_intro.list_item_one`
+- `avc_intro.list_item_two`
+- `avc_intro.subtitle`
+- `avc_intro.title`
+- `avc_no_face_detected.button_primary_restart`
+- `avc_no_face_detected.list_item_eyes`
+- `avc_no_face_detected.list_item_face`
+- `avc_no_face_detected.list_item_lighting`
+- `avc_no_face_detected.list_item_mask`
+- `avc_no_face_detected.title`
+- `avc_uploading.title`
+
 ## `8.1.1` -> `8.2.0`
 
 The **English**, **Spanish**, **German**, **French**, **Italian**, **Dutch** and **Portuguese** copy for the following string(s) has been added:

--- a/src/components/ActiveVideo/Confirm/index.tsx
+++ b/src/components/ActiveVideo/Confirm/index.tsx
@@ -1,0 +1,55 @@
+import { h, FunctionComponent } from 'preact'
+import type { WithLocalisedProps, WithTrackingProps } from '~types/hocs'
+import { useState } from 'preact/hooks'
+import RecordingComplete from '../RecordingComplete'
+import Uploading from '../Uploading'
+import ConnectionError from '../ConnectionError'
+import { StepComponentProps } from '~types/routers'
+import { localised } from '~locales'
+
+type Props = StepComponentProps & WithLocalisedProps & WithTrackingProps
+
+enum ConfirmationStep {
+  RECORDING_COMPLETE,
+  UPLOADING,
+  UPLOAD_ERROR,
+}
+
+const Confirm: FunctionComponent<Props> = (props: Props) => {
+  const { previousStep } = props
+
+  const [confirmationStep, setConfirmationStep] = useState<ConfirmationStep>(
+    ConfirmationStep.RECORDING_COMPLETE
+  )
+
+  switch (confirmationStep) {
+    case ConfirmationStep.RECORDING_COMPLETE:
+      return (
+        <RecordingComplete
+          {...props}
+          nextStep={() => setConfirmationStep(ConfirmationStep.UPLOADING)}
+        />
+      )
+    case ConfirmationStep.UPLOADING:
+      return (
+        <Uploading
+          {...props}
+          triggerOnError={() =>
+            setConfirmationStep(ConfirmationStep.UPLOAD_ERROR)
+          }
+        />
+      )
+    case ConfirmationStep.UPLOAD_ERROR:
+      return (
+        <ConnectionError
+          {...props}
+          retry={() => setConfirmationStep(ConfirmationStep.UPLOADING)}
+          restart={() => previousStep()}
+        />
+      )
+    default:
+      return <RecordingComplete {...props} />
+  }
+}
+
+export default localised(Confirm)

--- a/src/components/ActiveVideo/ConnectionError/index.tsx
+++ b/src/components/ActiveVideo/ConnectionError/index.tsx
@@ -1,0 +1,57 @@
+import { h, FunctionComponent } from 'preact'
+import { Button } from '../Button'
+import { Footer } from '../Footer'
+import { Header } from '../Header'
+import { ErrorIcon } from '../assets/ErrorIcon'
+import { Wrapper } from '../Wrapper'
+import { BaseScreen } from '../BaseScreen'
+import { localised } from '~locales'
+import { trackComponent } from 'Tracker'
+import type { WithLocalisedProps, WithTrackingProps } from '~types/hocs'
+import { StepComponentProps } from '~types/routers'
+
+type Props = StepComponentProps &
+  WithTrackingProps &
+  WithLocalisedProps & {
+    restart: () => void
+    retry: () => void
+  }
+
+const ConnectionError: FunctionComponent<Props> = ({
+  restart,
+  retry,
+  trackScreen,
+  translate,
+}: Props) => {
+  const handleRestart = (): void => {
+    trackScreen('connection_error_restart_clicked')
+    restart()
+  }
+
+  const handleRetry = (): void => {
+    trackScreen('connection_error_retry_clicked')
+    retry()
+  }
+
+  return (
+    <BaseScreen>
+      <Wrapper>
+        <Header title={translate('avc_connection_error.title')}>
+          <ErrorIcon />
+        </Header>
+        {translate('avc_connection_error.subtitle')}
+      </Wrapper>
+
+      <Footer>
+        <Button onClick={() => handleRetry()}>
+          {translate('avc_connection_error.button_primary_retry_upload')}
+        </Button>
+        <Button onClick={() => handleRestart()}>
+          {translate('avc_connection_error.button_secondary_restart_recording')}
+        </Button>
+      </Footer>
+    </BaseScreen>
+  )
+}
+
+export default trackComponent(localised(ConnectionError), 'connection_error')

--- a/src/components/ActiveVideo/Uploading/index.tsx
+++ b/src/components/ActiveVideo/Uploading/index.tsx
@@ -111,7 +111,7 @@ const Uploading: FunctionComponent<Props> = ({
   return (
     <BaseScreen>
       <Wrapper>
-        <Header title={translate("avc_uploading.title")}>
+        <Header title={translate('avc_uploading.title')}>
           <LoaderIcon />
         </Header>
       </Wrapper>

--- a/src/components/ActiveVideo/Uploading/index.tsx
+++ b/src/components/ActiveVideo/Uploading/index.tsx
@@ -41,6 +41,7 @@ const Uploading: FunctionComponent<Props> = ({
   capture,
   urls,
   trackScreen,
+  translate,
 }) => {
   const onApiSuccess = (apiResponse: ActiveVideoResponse) => {
     actions.setCaptureMetadata({ capture, apiResponse })
@@ -72,7 +73,6 @@ const Uploading: FunctionComponent<Props> = ({
       triggerOnError({ status, response })
       trackException(`${status} - ${response}`)
       setError('REQUEST_ERROR', response?.error?.message)
-      trackScreen('connection_error')
     }
   }
 
@@ -85,7 +85,7 @@ const Uploading: FunctionComponent<Props> = ({
     resetSdkFocus()
   }
 
-  useEffect(() => {
+  const upload = (): void => {
     if (capture) {
       const metadata = {
         sdk_metadata: capture.sdkMetadata,
@@ -102,12 +102,16 @@ const Uploading: FunctionComponent<Props> = ({
         onApiError
       )
     }
+  }
+
+  useEffect(() => {
+    upload()
   }, [])
 
   return (
     <BaseScreen>
       <Wrapper>
-        <Header title="Uploading">
+        <Header title={translate("avc_uploading.title")}>
           <LoaderIcon />
         </Header>
       </Wrapper>

--- a/src/components/Router/StepComponentMap.tsx
+++ b/src/components/Router/StepComponentMap.tsx
@@ -31,8 +31,7 @@ import CrossDeviceIntro from '../crossDevice/Intro'
 import FaceVideoIntro from '../FaceVideo/Intro'
 import LazyActiveVideo from '../ActiveVideo/Lazy'
 import ActiveVideoIntro from '../ActiveVideo/Intro'
-import ActiveVideoRecordingComplete from '../ActiveVideo/RecordingComplete'
-import ActiveVideoUpload from '../ActiveVideo/Uploading'
+import ActiveVideoConfirm from '../ActiveVideo/Confirm'
 import { shouldUseCameraForDocumentCapture } from '~utils/shouldUseCamera'
 import { buildStepFinder, hasOnePreselectedDocument } from '~utils/steps'
 
@@ -284,8 +283,7 @@ const buildActiveVideoComponents = (
   const allActiveVideoSteps: ComponentType<StepComponentProps>[] = [
     ActiveVideoIntro,
     ActiveVideoCapture,
-    ActiveVideoRecordingComplete,
-    ActiveVideoUpload,
+    ActiveVideoConfirm,
   ]
 
   if (mobileFlow) {

--- a/src/locales/de_DE/de_DE.json
+++ b/src/locales/de_DE/de_DE.json
@@ -203,6 +203,9 @@
         "list_item_mask": "Achten Sie darauf, dass Sie Gesichtsmasken oder andere Gegenstände, die Ihr Gesicht verdecken, abnehmen. Brillen sind zulässig",
         "title": "Wir können Ihr Gesicht nicht erkennen"
     },
+    "avc_uploading": {
+        "title": "Hochladen"
+    },
     "country_select": {
         "poa_alert": {
             "intro": "Can't find your country?",

--- a/src/locales/en_US/en_US.json
+++ b/src/locales/en_US/en_US.json
@@ -214,6 +214,9 @@
         "list_item_mask": "Make sure to remove masks or other items that cover your face. Eyeglasses are okay",
         "title": "We can't detect your face"
     },
+    "avc_uploading": {
+        "title": "Uploading"
+    },
     "country_select": {
         "poa_alert": {
             "intro": "Can't find your country?",

--- a/src/locales/es_ES/es_ES.json
+++ b/src/locales/es_ES/es_ES.json
@@ -203,6 +203,9 @@
         "list_item_mask": "Asegúrese de retirar mascarillas o cualquier otro objeto que le cubra el rostro. Puede llevar gafas para ver",
         "title": "No podemos detectar su cara"
     },
+    "avc_uploading": {
+        "title": "Cargando"
+    },
     "country_select": {
         "poa_alert": {
             "intro": "Can't find your country?",

--- a/src/locales/fr_FR/fr_FR.json
+++ b/src/locales/fr_FR/fr_FR.json
@@ -203,6 +203,9 @@
         "list_item_mask": "Assurez-vous d'ôter le masque ou outres éléments qui couvrent votre visage. Les lunettes sont acceptées",
         "title": "Nous ne pouvons pas détecter votre visage"
     },
+    "avc_uploading": {
+        "title": "Téléversement"
+    },
     "country_select": {
         "poa_alert": {
             "intro": "Can't find your country?",

--- a/src/locales/it_IT/it_IT.json
+++ b/src/locales/it_IT/it_IT.json
@@ -116,6 +116,9 @@
         "list_item_mask": "Assicurati di rimuovere la mascherina o altri oggetti che coprono il viso. Puoi tenere gli occhiali da vista.",
         "title": "Non riusciamo a rilevare il tuo viso"
     },
+    "avc_uploading": {
+        "title": "Caricamento in corso"
+    },
     "country_select": {
         "poa_alert": {
             "intro": "Can't find your country?",

--- a/src/locales/nl_NL/nl_NL.json
+++ b/src/locales/nl_NL/nl_NL.json
@@ -116,6 +116,9 @@
         "list_item_mask": "Zorg ervoor dat u maskers of andere voorwerpen die uw gezicht bedekken afzet. Een bril mag wel.",
         "title": "We kunnen uw gezicht niet detecteren"
     },
+    "avc_uploading": {
+        "title": "Uploaden"
+    },
     "country_select": {
         "poa_alert": {
             "intro": "Can't find your country?",

--- a/src/locales/pt_PT/pt_PT.json
+++ b/src/locales/pt_PT/pt_PT.json
@@ -116,6 +116,9 @@
         "list_item_mask": "Certifique-se de que remove as máscaras ou outros artigos que cobrem o seu rosto. Os óculos não precisa de retirar",
         "title": "Não conseguimos detetar o seu rosto"
     },
+    "avc_uploading": {
+        "title": "Carregamento em curso"
+    },
     "country_select": {
         "poa_alert": {
             "intro": "Can't find your country?",


### PR DESCRIPTION
# Problem

On upload errors, the screen just keeps "Uploading" forever.

# Solution

Show a generic upload error screen with two actions - retry and restart. Retry attempts to upload the payload again while Restart goes back to the capture screen.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [x] Have any new strings been translated or the existing ones changed?
