### PR TITLE
fix:call onComplete and nextStep outside imageQualityWanring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2924,12 +2924,45 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.0.7",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -14288,9 +14321,10 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.3",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -17675,13 +17709,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.12.1",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
         "source-map-support": "~0.5.20"
       },
       "bin": {
@@ -17764,14 +17799,6 @@
       "version": "2.20.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/terser/node_modules/source-map": {
-      "version": "0.7.3",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -21115,9 +21142,36 @@
         }
       }
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
     "@jridgewell/resolve-uri": {
       "version": "3.0.7",
       "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.13",
@@ -28627,7 +28681,9 @@
       }
     },
     "moment": {
-      "version": "2.29.3",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "dev": true
     },
     "moo": {
@@ -30904,12 +30960,14 @@
       }
     },
     "terser": {
-      "version": "5.12.1",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "dev": true,
       "requires": {
+        "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
         "source-map-support": "~0.5.20"
       },
       "dependencies": {
@@ -30919,10 +30977,6 @@
         },
         "commander": {
           "version": "2.20.3",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.7.3",
           "dev": true
         }
       }

--- a/src/components/Confirm/Confirm.tsx
+++ b/src/components/Confirm/Confirm.tsx
@@ -301,8 +301,15 @@ export const Confirm = (props: ConfirmProps) => {
 
     const documentImageResponse = apiResponse as DocumentImageResponse
     const imageQualityWarning = onImageQualityWarning(documentImageResponse)
+    const isImageQualityWarningBlocker =
+      props.imageQualityRetries >
+      sdkConfiguration.document_capture.max_total_retries
 
-    if (imageQualityWarning) {
+    if (!imageQualityWarning || isImageQualityWarningBlocker) {
+      actions.resetImageQualityRetries()
+      completeStep([{ id: apiResponse.id }])
+      nextStep()
+    } else {
       setWarning(
         imageQualityWarning,
         {
@@ -312,15 +319,11 @@ export const Confirm = (props: ConfirmProps) => {
           count_attempt: props.imageQualityRetries,
           max_retry_count: sdkConfiguration.document_capture.max_total_retries,
           // not sure what is_blocking refers to, but its the correct way to compute it
-          is_blocking:
-            props.imageQualityRetries >
-            sdkConfiguration.document_capture.max_total_retries,
+          is_blocking: isImageQualityWarningBlocker,
         },
         documentImageResponse.sdk_warnings
       )
     }
-    completeStep([{ id: apiResponse.id }])
-    nextStep()
   }
 
   const handleSelfieUpload = (

--- a/src/components/Confirm/Confirm.tsx
+++ b/src/components/Confirm/Confirm.tsx
@@ -302,10 +302,7 @@ export const Confirm = (props: ConfirmProps) => {
     const documentImageResponse = apiResponse as DocumentImageResponse
     const imageQualityWarning = onImageQualityWarning(documentImageResponse)
 
-    if (!imageQualityWarning) {
-      completeStep([{ id: apiResponse.id }])
-      nextStep()
-    } else {
+    if (imageQualityWarning) {
       setWarning(
         imageQualityWarning,
         {
@@ -322,6 +319,8 @@ export const Confirm = (props: ConfirmProps) => {
         documentImageResponse.sdk_warnings
       )
     }
+    completeStep([{ id: apiResponse.id }])
+    nextStep()
   }
 
   const handleSelfieUpload = (

--- a/src/components/Confirm/Confirm.tsx
+++ b/src/components/Confirm/Confirm.tsx
@@ -301,11 +301,11 @@ export const Confirm = (props: ConfirmProps) => {
 
     const documentImageResponse = apiResponse as DocumentImageResponse
     const imageQualityWarning = onImageQualityWarning(documentImageResponse)
-    const isImageQualityWarningBlocker =
+    const isIQWarningBlocker =
       props.imageQualityRetries >
       sdkConfiguration.document_capture.max_total_retries
 
-    if (!imageQualityWarning || isImageQualityWarningBlocker) {
+    if (!imageQualityWarning || isIQWarningBlocker) {
       actions.resetImageQualityRetries()
       completeStep([{ id: apiResponse.id }])
       nextStep()
@@ -319,7 +319,7 @@ export const Confirm = (props: ConfirmProps) => {
           count_attempt: props.imageQualityRetries,
           max_retry_count: sdkConfiguration.document_capture.max_total_retries,
           // not sure what is_blocking refers to, but its the correct way to compute it
-          is_blocking: isImageQualityWarningBlocker,
+          is_blocking: isIQWarningBlocker,
         },
         documentImageResponse.sdk_warnings
       )

--- a/src/components/Confirm/Confirm.tsx
+++ b/src/components/Confirm/Confirm.tsx
@@ -301,12 +301,8 @@ export const Confirm = (props: ConfirmProps) => {
 
     const documentImageResponse = apiResponse as DocumentImageResponse
     const imageQualityWarning = onImageQualityWarning(documentImageResponse)
-    const isIQWarningBlocker =
-      props.imageQualityRetries >
-      sdkConfiguration.document_capture.max_total_retries
 
-    if (!imageQualityWarning || isIQWarningBlocker) {
-      actions.resetImageQualityRetries()
+    if (!imageQualityWarning) {
       completeStep([{ id: apiResponse.id }])
       nextStep()
     } else {
@@ -319,10 +315,13 @@ export const Confirm = (props: ConfirmProps) => {
           count_attempt: props.imageQualityRetries,
           max_retry_count: sdkConfiguration.document_capture.max_total_retries,
           // not sure what is_blocking refers to, but its the correct way to compute it
-          is_blocking: isIQWarningBlocker,
+          is_blocking:
+            props.imageQualityRetries >
+            sdkConfiguration.document_capture.max_total_retries,
         },
         documentImageResponse.sdk_warnings
       )
+      completeStep([{ id: apiResponse.id }])
     }
   }
 


### PR DESCRIPTION
# Problem
https://onfido.atlassian.net/browse/IX-2608
Uploading a document that has glare detected.
The user is asked 3 times to Redo the capture/upload after that the /document endpoint throws a 422 error and present the user to redo or upload anyway. At this point if the user choose upload anyway the /complete payload is empty
# Solution
**OnApiSuccess:** The **completeStep** was not being called after the upload success, it was only being called if there was no warning, here we have warning but we have also reached the number of retries and the upload is compeleted therefor we need to pass the payload the for completing the workflow task. 
I have added the call after the warning is set for the successful upload has been. 
## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
