### PR TITLE
Add support for api token to the demo app

### DIFF
--- a/src/demo/SdkDemo.tsx
+++ b/src/demo/SdkDemo.tsx
@@ -83,7 +83,8 @@ const SdkDemo: FunctionComponent<Props> = ({
         (respondedToken, responedApplicantId) => {
           setToken(respondedToken)
           setApplicantId(responedApplicantId)
-        }
+        },
+        queryParamToValueString.apiToken
       )
     }
   }, [hasPreview, applicantData, messagePort, sdkOptions])

--- a/src/demo/demoUtils.ts
+++ b/src/demo/demoUtils.ts
@@ -72,6 +72,7 @@ export type QueryParams = {
   applicantId?: StringifiedBoolean
   workflowRunId?: StringifiedBoolean
   testCase?: string
+  apiToken?: string
 }
 
 export type CheckData = {
@@ -553,7 +554,8 @@ export const getToken = (
   url: string,
   applicantData: ApplicantData | undefined,
   eventEmitter: MessagePort | undefined,
-  onSuccess: (token: string, applicantId: string) => void
+  onSuccess: (token: string, applicantId: string) => void,
+  apiToken?: string
 ): void => {
   const request = new XMLHttpRequest()
 
@@ -567,6 +569,10 @@ export const getToken = (
     'Authorization',
     `BASIC ${process.env.SDK_TOKEN_FACTORY_SECRET}`
   )
+
+  if (apiToken) {
+    request.setRequestHeader('x-onfido-api-token', apiToken)
+  }
 
   request.onload = () => {
     if (request.status >= 200 && request.status < 400) {


### PR DESCRIPTION
# Problem
The demo app only support 1 IMS account

# Solution
Add support for api token so people with access to an api token can use different IMS acount(s)

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
