### PR TITLE
Update integration test for empty document due to api change

### DIFF
--- a/src/components/utils/__integrations__/onfidoApi/document.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/document.integration.js
@@ -97,7 +97,7 @@ describe('API uploadDocument endpoint', () => {
       try {
         expect(error.status).toBe(422)
         expect(error.response.error.type).toBe('validation_error')
-        expect(error.response.error.fields).toHaveProperty('file')
+        expect(error.response.error.fields).toHaveProperty('content_type')
         done()
       } catch (err) {
         done(err)


### PR DESCRIPTION
# Problem
The error response for IQS changed to:
```diff
// new
{
  error: {
    message: 'Invalid content type',
    type: 'validation_error',
    fields: {
      content_type: {
+        messages: [
+          'the content_type of the file could not be identified or is not allowed',
+        ],
      },
    },
  },
}

// old
{
  error: {
    message: 'There was a validation error on this request',
    type: 'validation_error',
    fields: { 
-       content_type: [
-          '<error message>'
-      ]
     },
  },
}

```

# Solution
It doesn't look like there is a breaking change as 

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
