### PR TITLE
Add a utility tool to gain insights into our locales files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ out/
 /onfido-sdk-web-sample-app
 /aws
 .vscode
+/scripts/locales/base

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 ## [next-version]
 
 - Internal: Migrated onfido/react-webcam fork to typescript and absorbed it into this repo.
+- Internal: Add utility tool for locales
 
 ## Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,10 +89,12 @@
         "babel-plugin-auto-await": "^0.4.2",
         "chalk": "^2.4.2",
         "changelog-parser": "^2.8.1",
+        "commander": "^9.4.0",
         "concurrently": "^6.4.0",
         "copy-webpack-plugin": "^10.2.4",
         "css-loader": "^6.6.0",
         "custom-event-polyfill": "^1.0.7",
+        "deep-object-diff": "^1.1.7",
         "dotenv": "^16.0.0",
         "dts-bundle-generator": "^5.5.0",
         "enzyme": "^3.11.0",
@@ -213,6 +215,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -636,6 +647,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/node/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@babel/node/node_modules/regenerator-runtime": {
@@ -6049,11 +6069,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "4.1.1",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/commondir": {
@@ -6808,6 +6829,12 @@
       "version": "0.1.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deep-object-diff": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.7.tgz",
+      "integrity": "sha512-QkgBca0mL08P6HiOjoqvmm6xOAl2W6CT2+34Ljhg0OeFan8cwlcdq8jrLKsBBuUFAZLsN5b6y491KdKEoSo9lg==",
+      "dev": true
     },
     "node_modules/deepmerge": {
       "version": "4.2.2",
@@ -19287,6 +19314,14 @@
         "make-dir": "^2.1.0",
         "slash": "^2.0.0",
         "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        }
       }
     },
     "@babel/code-frame": {
@@ -19586,6 +19621,12 @@
         "v8flags": "^3.1.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.13.5",
           "dev": true
@@ -23297,7 +23338,9 @@
       }
     },
     "commander": {
-      "version": "4.1.1",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
       "dev": true
     },
     "commondir": {
@@ -23792,6 +23835,12 @@
     },
     "deep-is": {
       "version": "0.1.3",
+      "dev": true
+    },
+    "deep-object-diff": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.7.tgz",
+      "integrity": "sha512-QkgBca0mL08P6HiOjoqvmm6xOAl2W6CT2+34Ljhg0OeFan8cwlcdq8jrLKsBBuUFAZLsN5b6y491KdKEoSo9lg==",
       "dev": true
     },
     "deepmerge": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "test-server:run": "docker-compose up --abort-on-container-exit",
     "test-server:build": "docker-compose up --build --no-start",
     "test-server:prepare": "rm -rf ./test/mock-server/frontend && cp -r dist test/mock-server/frontend",
-    "mock-server": "cd ./test/mock-server && deno run --allow-net --allow-read --allow-write server.ts"
+    "mock-server": "cd ./test/mock-server && deno run --allow-net --allow-read --allow-write server.ts",
+    "websdk": "npx ts-node -T scripts/locales/index.ts"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -174,10 +175,12 @@
     "babel-plugin-auto-await": "^0.4.2",
     "chalk": "^2.4.2",
     "changelog-parser": "^2.8.1",
+    "commander": "^9.4.0",
     "concurrently": "^6.4.0",
     "copy-webpack-plugin": "^10.2.4",
     "css-loader": "^6.6.0",
     "custom-event-polyfill": "^1.0.7",
+    "deep-object-diff": "^1.1.7",
     "dotenv": "^16.0.0",
     "dts-bundle-generator": "^5.5.0",
     "enzyme": "^3.11.0",

--- a/scripts/locales/download.sh
+++ b/scripts/locales/download.sh
@@ -1,0 +1,11 @@
+rm -rf scripts/locales/base
+mkdir scripts/locales/base
+cd scripts/locales/base
+
+# TODO: use git filter or spare checkout to only download the locales directory
+echo "Downloading the locales from the development branch..."
+git clone https://github.com/onfido/onfido-sdk-ui.git
+mv onfido-sdk-ui/src/locales/** ./
+
+echo "Cleaning up..."
+rm -rf onfido-sdk-ui

--- a/scripts/locales/index.ts
+++ b/scripts/locales/index.ts
@@ -1,0 +1,65 @@
+import { Command } from 'commander'
+import { generateChangelog } from './src/generateChangeLog'
+import { compareLanguageVersions } from './src/compareLanguageVersions'
+import { compareAgainstBaseLanguage } from './src/compareAgainstBaseLanguage'
+import { findEmptyTranslations } from './src/findEmptyTranslations'
+import { download } from './src/download'
+
+const program = new Command()
+
+program
+  .name('websdk')
+  .description('Utility tools for WebSDK contributers')
+  .version('0.0.0')
+
+// Locales
+program
+  .command('locales:download')
+  .description('Download the locales from the development branch')
+  .action(() => {
+    download()
+  })
+
+program
+  .command('locales:compare')
+  .description('Compare your current locales against the development branch')
+  .action(() => {
+    console.log(compareLanguageVersions())
+  })
+
+program
+  .command('locales:changelog')
+  .description('Generate a new section of changelog for MIGRATION.md')
+  .action(() => {
+    console.log('Generating markdown...')
+    generateChangelog()
+    console.log('A new markdown file has been generated: locale-changes.md')
+  })
+
+program
+  .command('locales:bugs')
+  .description('Generate a new section of changelog for MIGRATION.md')
+  .action(() => {
+    console.log(
+      [
+        '----------------------------------------',
+        'Explanation:',
+        '- added: Not available in base language',
+        '- deleted: Missing from this language',
+        '----------------------------------------',
+      ].join('\n')
+    )
+
+    console.log(compareAgainstBaseLanguage())
+
+    console.log(
+      [
+        '----------------------------------------',
+        'Empty translations:',
+        '----------------------------------------',
+      ].join('\n')
+    )
+    console.log(findEmptyTranslations())
+  })
+
+program.parse()

--- a/scripts/locales/readme.md
+++ b/scripts/locales/readme.md
@@ -1,0 +1,18 @@
+## Locales utility
+
+A small utility tool to help gain insights in to our locale files.
+
+**Step 1:**
+Download the locales from our development branch:
+`npm run websdk locales:download`
+
+###Commands:
+
+**List the difference between current branch and development:**
+`npm run websdk locales:compare`
+
+**Compare all languages against the base language (en_US) and find differences**
+`npm run websdk locales:bugs`
+
+**Generate a new section for the MIGRATION md changelog**
+`npm run websdk locales:changelog`

--- a/scripts/locales/src/compareAgainstBaseLanguage.ts
+++ b/scripts/locales/src/compareAgainstBaseLanguage.ts
@@ -1,0 +1,46 @@
+// @ts-nocheck
+import fs from 'fs'
+import { addedDiff, deletedDiff } from 'deep-object-diff'
+import { getLanguages, srcDir, objectToKeyStrings } from './util'
+
+const languagesNew = getLanguages(srcDir)
+
+/*
+  Compare the a language against a base language and see which keys are different
+
+  Output:
+    - baseLanguage: The language we take as source of truth
+    - secondaryLanguage: A secondary language we compare to our source of truth
+    - added: Keys are the NOT available in the base language, but are in the secondary language. Probably should be removed from secondary language
+    - delted: Missing keys in secondary, should be added
+*/
+const baseLanguage = 'en_US'
+export const compareAgainstBaseLanguage = () => {
+  const langDiffs = []
+
+  languagesNew.forEach((secondaryLanguage) => {
+    const baseFile = JSON.parse(
+      fs.readFileSync(`${srcDir}/${baseLanguage}/${baseLanguage}.json`, 'utf-8')
+    )
+    const compareFile = JSON.parse(
+      fs.readFileSync(
+        `${srcDir}/${secondaryLanguage}/${secondaryLanguage}.json`,
+        'utf-8'
+      )
+    )
+
+    const added = addedDiff(baseFile, compareFile) || {}
+    const deleted = deletedDiff(baseFile, compareFile) || {}
+
+    const keyDiff = {
+      baseLanguage,
+      secondaryLanguage,
+      added: objectToKeyStrings(added),
+      deleted: objectToKeyStrings(deleted),
+    }
+
+    langDiffs.push(keyDiff)
+  })
+
+  return langDiffs
+}

--- a/scripts/locales/src/compareLanguageVersions.ts
+++ b/scripts/locales/src/compareLanguageVersions.ts
@@ -1,0 +1,35 @@
+// @ts-nocheck
+import fs from 'fs'
+import { detailedDiff } from 'deep-object-diff'
+import { getLanguages, baseDir, srcDir, objectToKeyStrings } from './util'
+
+const languagesBase = getLanguages(baseDir)
+
+export const compareLanguageVersions = () => {
+  const langDiffs = []
+
+  languagesBase.forEach((language) => {
+    const baseFile = `${baseDir}/${language}/${language}.json`
+    const newFile = `${srcDir}/${language}/${language}.json`
+
+    const baseData = fs.existsSync(baseFile)
+      ? JSON.parse(fs.readFileSync(baseFile, 'utf-8'))
+      : {}
+    const newData = fs.existsSync(newFile)
+      ? JSON.parse(fs.readFileSync(newFile, 'utf-8'))
+      : {}
+
+    const { added, deleted, updated } = detailedDiff(baseData, newData) || {}
+
+    const keyDiff = {
+      language,
+      added: objectToKeyStrings(added),
+      deleted: objectToKeyStrings(deleted),
+      updated: objectToKeyStrings(updated),
+    }
+
+    langDiffs.push(keyDiff)
+  })
+
+  return langDiffs
+}

--- a/scripts/locales/src/download.ts
+++ b/scripts/locales/src/download.ts
@@ -1,0 +1,13 @@
+import { spawn } from 'child_process'
+
+export const download = () => {
+  const child = spawn('sh', ['scripts/locales/download.sh'])
+
+  child.stdout.on('data', (data) => {
+    console.log(data)
+  })
+
+  child.stderr.on('data', (data) => {
+    console.error(data)
+  })
+}

--- a/scripts/locales/src/findEmptyTranslations.ts
+++ b/scripts/locales/src/findEmptyTranslations.ts
@@ -1,0 +1,26 @@
+// @ts-nocheck
+import fs from 'fs'
+import { getLanguages, objectToKeyStrings, srcDir } from './util'
+
+const languagesNew = getLanguages(srcDir)
+
+export const findEmptyTranslations = () => {
+  const langDiffs = []
+
+  languagesNew.forEach((language) => {
+    const file = JSON.parse(
+      fs.readFileSync(`${srcDir}/${language}/${language}.json`, 'utf-8')
+    )
+
+    const emptyKeys = []
+    objectToKeyStrings(file, (key, value) => {
+      if (value.length === 0) {
+        emptyKeys.push(key)
+      }
+    })
+
+    langDiffs.push({ language, emptyKeys })
+  })
+
+  return langDiffs
+}

--- a/scripts/locales/src/generateChangeLog.ts
+++ b/scripts/locales/src/generateChangeLog.ts
@@ -1,0 +1,128 @@
+// @ts-nocheck
+import fs from 'fs'
+import {
+  combine,
+  convertLanguageKeysToReadable,
+  getNewAndRemovedLanguages,
+  capitalizeString,
+} from './util'
+import { compareLanguageVersions } from './compareLanguageVersions'
+
+const langDiffs = compareLanguageVersions()
+
+// TODO: handle deleted & new languages
+export const generateChangelog = () => {
+  const languages = getNewAndRemovedLanguages()
+
+  const diffByKey = {
+    added: {},
+    deleted: {},
+    updated: {},
+  }
+
+  // Combine the difss in object: [key] = [language_1, language_2]
+  langDiffs.forEach(({ language, ...diffs }) => {
+    diffByKey.added = combine(diffByKey.added, diffs.added, language)
+    diffByKey.updated = combine(diffByKey.updated, diffs.updated, language)
+    diffByKey.deleted = combine(diffByKey.deleted, diffs.deleted, language)
+  })
+
+  /*
+    Format:
+    - Most keys (all - 2) -> normal format
+    - By language
+  */
+
+  const organisedChangelog = {
+    all: {
+      added: {},
+      deleted: {},
+      updated: {},
+    },
+    language: {},
+  }
+
+  // Added
+  const organise = (obj, type) => {
+    Object.entries(obj)
+      .sort((a, b) => b[1].length - a[1].length)
+      .forEach(([key, languages]) => {
+        if (languages.length === langDiffs.length) {
+          organisedChangelog.all[type][key] = languages
+          return
+        }
+
+        languages.forEach((language) => {
+          if (!organisedChangelog.language[language]) {
+            organisedChangelog.language[language] = {}
+          }
+          if (!organisedChangelog.language[language][type]) {
+            organisedChangelog.language[language][type] = []
+          }
+          organisedChangelog.language[language][type].push(key)
+        })
+      })
+  }
+
+  organise(diffByKey.added, 'added')
+  organise(diffByKey.updated, 'updated')
+  organise(diffByKey.deleted, 'deleted')
+
+  // Write the markdown file
+  const markdown = []
+
+  const writeMarkdown = (language, changes, all = false) => {
+    let entry = [
+      `The **${convertLanguageKeysToReadable(
+        language
+      )}** copy for the following string(s) has been changed:`,
+      '', // new line
+    ]
+
+    // By language
+    if (all) {
+      Object.entries(changes).forEach(([type, diff]) => {
+        entry = entry.concat([
+          `## ${capitalizeString(type)}:`,
+          '',
+          ...Object.keys(diff).map((key) => ` - \`${key}\``),
+          '',
+        ])
+      })
+    } else {
+      Object.entries(changes).forEach(([type, diff]) => {
+        entry = entry.concat([
+          `## ${capitalizeString(type)}:`,
+          '',
+          ...diff.map((key) => ` - \`${key}\``),
+          '',
+        ])
+      })
+    }
+    markdown.push(entry.join('\n'))
+  }
+
+  // Mention newly added / removed languages
+  languages.added?.length &&
+    markdown.push(
+      `We have added new language(s): **${convertLanguageKeysToReadable(
+        languages.added
+      )}** `
+    )
+  languages.deleted?.length &&
+    markdown.push(
+      `We have deleted new language(s): **${convertLanguageKeysToReadable(
+        languages.deleted
+      )}** `
+    )
+
+  // Changes for all languages
+  writeMarkdown(languages.base, organisedChangelog.all, true)
+
+  // Rest of the changes by language
+  Object.entries(organisedChangelog.language).forEach(([language, changes]) =>
+    writeMarkdown(language, changes)
+  )
+
+  fs.writeFileSync('./locale-changes.md', markdown.join('\n\n'))
+}

--- a/scripts/locales/src/util.ts
+++ b/scripts/locales/src/util.ts
@@ -1,0 +1,111 @@
+// @ts-nocheck
+import fs from 'fs'
+import { join } from 'path'
+import { addedDiff, deletedDiff } from 'deep-object-diff'
+
+export const baseDir = join(__dirname, '../base')
+export const srcDir = 'src/locales'
+
+export const getLanguages = (dir: string) => {
+  return fs
+    .readdirSync(dir)
+    .filter((path) => path.match(/[a-z]{2}_[A-Z]{2}/))
+    .sort((a, b) => a.localeCompare(b))
+}
+
+export const languageMap = {
+  de_DE: 'German',
+  en_US: 'English',
+  es_ES: 'Spanish',
+  fr_FR: 'French',
+  nl_NL: 'Dutch',
+  it_IT: 'Italian',
+  pt_PT: 'Portuguese',
+  ro_RO: 'Romanian',
+  pl_PL: 'Polish',
+  cs_CZ: 'Tsjechisch', // TODO: check if is right word
+}
+
+export const convertLanguageKeysToReadable = (languages) => {
+  if (typeof languages === 'string') {
+    return languageMap[languages]
+  }
+
+  const lastLanguage = languages.pop()
+
+  return [
+    ...languages.map((key) => languageMap[key]),
+    `and ${languageMap[lastLanguage]}`,
+  ].join(', ')
+}
+
+export const arrayToObject = (array) => {
+  const obj = {}
+  array.forEach((i) => (obj[i] = i))
+  return obj
+}
+
+export function objectToKeyStrings(obj, cb) {
+  const list = []
+  const convert = (obj, keyString) => {
+    // Handle deleted values
+    if (obj === undefined) {
+      obj = 'undefined'
+    }
+
+    if (typeof obj === 'string') {
+      cb && cb(keyString, obj)
+      list.push(keyString)
+      return
+    }
+
+    const children = Object.entries(obj)
+
+    if (children) {
+      children.forEach(([key, value]) => {
+        convert(value, keyString ? `${keyString}.${key}` : key)
+      })
+      return
+    }
+  }
+
+  convert(obj, undefined)
+  return list
+}
+
+// Combine objects of strings
+// Format: { [key]: [language_1, language_2]}
+export function combine(base, addition, language) {
+  const changes = base || {}
+
+  addition.forEach((key) => {
+    if (!(key in changes)) {
+      changes[key] = []
+    }
+    changes[key].push(language)
+  })
+
+  return changes
+}
+
+export const getNewAndRemovedLanguages = () => {
+  const languagesBase = getLanguages(baseDir)
+  const languagesNew = getLanguages(srcDir)
+
+  const added = Object.values(
+    addedDiff(arrayToObject(languagesBase), arrayToObject(languagesNew))
+  )
+
+  const removed = Object.values(
+    deletedDiff(arrayToObject(languagesBase), arrayToObject(languagesNew))
+  )
+
+  return { added, removed, base: languagesBase, new: languagesNew }
+}
+
+export const capitalizeString = (string) => {
+  return [
+    string.slice(0, 1).toUpperCase(),
+    ...string.slice(1, string.length),
+  ].join('')
+}


### PR DESCRIPTION
# Problem
- A lot of changes have been made to the locale files, making manual changelog is hard and time consuming
- There are empty translations, missing translation or extra translations in specifics languages, sorting this by hand is time consuming.
- These issues have happened before and will continue to exists.

# Solution

Add a small utility tool to help gain insights into our locale files:
- Compare current version against development
- Generate a markdown section for our Migration.md
- Find possible bugs / inconsistencies in our locale files (like missing key, extra keys, empty translations).

See `scripts/locales/readme.md` for instructions

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
