### PR TITLE
Re-enable integration tests for selfie

### DIFF
--- a/jest.env.js
+++ b/jest.env.js
@@ -1,3 +1,7 @@
+import 'dotenv/config'
+
 // Jest runs in js-dom, therefore missing setImmediate (node & IE only)
 import { setImmediate } from 'timers'
 global.setImmediate = setImmediate
+
+jest.setTimeout(15000)

--- a/src/components/utils/__integrations__/onfidoApi/document.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/document.integration.js
@@ -28,7 +28,6 @@ const TEST_DOCUMENT_DATA = {
 
 describe('API uploadDocument endpoint', () => {
   beforeEach(async () => {
-    jest.setTimeout(15000)
     jwtToken = await getTestJwtToken()
   })
 

--- a/src/components/utils/__integrations__/onfidoApi/selfie.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/selfie.integration.js
@@ -20,7 +20,6 @@ let jwtToken = null
 
 describe('API uploadFacePhoto endpoint', () => {
   beforeEach(async () => {
-    jest.setTimeout(15000)
     jwtToken = await getTestJwtToken()
   })
 
@@ -190,9 +189,7 @@ describe('API uploadSnapshot endpoint', () => {
   })
 })
 
-// FIXME: consistently fails with 403 error, as separate test suites uploadSnapshot, uploadFacePhoto tests work
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('API sendMultiframeSelfie endpoint', () => {
+describe('API sendMultiframeSelfie endpoint', () => {
   beforeEach(async () => {
     jwtToken = await getTestJwtToken()
   })
@@ -239,8 +236,8 @@ describe.skip('API sendMultiframeSelfie endpoint', () => {
     sendMultiframeSelfie(
       snapshotData,
       selfieData,
-      API_URL,
       jwtToken,
+      API_URL,
       (response) => onSuccessCallback(response),
       (error) => {
         console.error(error.response)
@@ -279,8 +276,8 @@ describe.skip('API sendMultiframeSelfie endpoint', () => {
     sendMultiframeSelfie(
       snapshotData,
       selfieData,
-      API_URL,
       EXPIRED_JWT_TOKEN,
+      API_URL,
       () => done(),
       (e) => ASSERT_EXPIRED_JWT_ERROR(done, e),
       (eventString) => console.log(eventString)
@@ -288,13 +285,14 @@ describe.skip('API sendMultiframeSelfie endpoint', () => {
   })
 
   test('sendMultiframeSelfie returns an error on uploading empty files', (done) => {
-    expect.assertions(3)
+    expect.assertions(4)
     const onErrorCallback = (error) => {
       try {
         expect(error.status).toBe(422)
         expect(error.response.error.type).toBe('validation_error')
+        expect(error.response.error.fields).toHaveProperty('attachment')
         expect(error.response.error.fields).toHaveProperty(
-          'attachment_file_size'
+          'attachment_content_type'
         )
         done()
       } catch (err) {
@@ -326,8 +324,8 @@ describe.skip('API sendMultiframeSelfie endpoint', () => {
     sendMultiframeSelfie(
       snapshotData,
       selfieData,
-      API_URL,
       jwtToken,
+      API_URL,
       (response) => done(response),
       onErrorCallback,
       (eventString) => console.log(eventString)

--- a/src/components/utils/__integrations__/onfidoApi/video.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/video.integration.js
@@ -35,7 +35,6 @@ const TEST_VIDEO_DATA = {
 
 describe('API uploadFaceVideo endpoint', () => {
   beforeEach(async () => {
-    jest.setTimeout(15000)
     jwtToken = await getTestJwtToken()
   })
 


### PR DESCRIPTION
# Problem

1. Three of the selfie tests were skipped on our CI.
2. Parameters were being passed wrongly

# Solution

Fixed the test parameters order and re-enabled them.

A minor touch on the `jest.env.js` file to spread jest's global timeout and import the dotenv dependency.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [x] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
