### PR TITLE
Add integration tests for the configurations endpoint

### DIFF
--- a/src/components/utils/__integrations__/helpers/mockExpiredJwtAndResponse.js
+++ b/src/components/utils/__integrations__/helpers/mockExpiredJwtAndResponse.js
@@ -1,18 +1,20 @@
 export const EXPIRED_JWT_TOKEN =
   'eyJhbGciOiJFUzUxMiJ9.eyJleHAiOjE2NDUxMTQ3MDYsInBheWxvYWQiOnsiYXBwIjoiYmQ3NzMzOGYtYWI5MC00N2JjLThmNTMtNDA0N2ExMTA4NWJmIiwiY2xpZW50X3V1aWQiOiJjZTY5ZjE4Zi04MDA2LTQyM2QtYWZkYS1mY2FmZjBkZTIxNTQiLCJpc19zYW5kYm94IjpmYWxzZSwicmVmIjoiKjovLyovKiIsInNhcmRpbmVfc2Vzc2lvbiI6IjY2ZjZiNjI4LWQ0N2ItNDhkZS1hMWFlLTkwZmQwY2JlOWQxNSJ9LCJ1dWlkIjoiYnE5WmxmLW5kY0IiLCJlbnRlcnByaXNlX2ZlYXR1cmVzIjp7ImNvYnJhbmQiOnRydWUsImxvZ29Db2JyYW5kIjp0cnVlLCJoaWRlT25maWRvTG9nbyI6dHJ1ZSwiZGlzYWJsZU1vYmlsZVNka0FuYWx5dGljcyI6dHJ1ZX0sInVybHMiOnsidGVsZXBob255X3VybCI6Imh0dHBzOi8vdGVsZXBob255Lm9uZmlkby5jb20iLCJkZXRlY3RfZG9jdW1lbnRfdXJsIjoiaHR0cHM6Ly9zZGsub25maWRvLmNvbSIsInN5bmNfdXJsIjoiaHR0cHM6Ly9zeW5jLm9uZmlkby5jb20iLCJob3N0ZWRfc2RrX3VybCI6Imh0dHBzOi8vaWQub25maWRvLmNvbSIsImF1dGhfdXJsIjoiaHR0cHM6Ly9hcGkub25maWRvLmNvbSIsIm9uZmlkb19hcGlfdXJsIjoiaHR0cHM6Ly9hcGkub25maWRvLmNvbSJ9fQ.MIGHAkIBfuA8iir66_fd5iXTbZIBPXYPJ5yTrbiSwiMQi5wLLM1L9FS3xuyOFtKprebFLMJyzhXufmtgWgfgPcPSi7GrI28CQVjGdUokkdNP6PqzEWluaJA49AaWuWXQzM7gC_E7lHuLbOQa0gXGgHgKgTTAypGDBRU_GfzX_WYHfZJwmvMElOkh'
 
+export const ASSERT_EXPIRED_JWT_ERROR_OBJECT = {
+  status: 401,
+  response: {
+    error: {
+      fields: {},
+      message: 'The token has expired, please request a new one',
+      type: 'expired_token',
+    },
+  },
+}
+
 export const ASSERT_EXPIRED_JWT_ERROR = (done, error) => {
   try {
-    expect(error).toEqual({
-      status: 401,
-      response: {
-        error: {
-          fields: {},
-          message: 'The token has expired, please request a new one',
-          type: 'expired_token',
-        },
-      },
-    })
+    expect(error).toEqual(ASSERT_EXPIRED_JWT_ERROR_OBJECT)
     done()
   } catch (err) {
     done(err)

--- a/src/components/utils/__integrations__/onfidoApi/configurations.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/configurations.integration.js
@@ -1,0 +1,66 @@
+import { getTestJwtToken } from '../helpers'
+import { getSdkConfiguration } from '../../onfidoApi'
+import { API_URL } from '../helpers/testUrls'
+import {
+  ASSERT_EXPIRED_JWT_ERROR_OBJECT,
+  EXPIRED_JWT_TOKEN,
+} from '../helpers/mockExpiredJwtAndResponse'
+
+let jwtToken = null
+
+describe('API configurations endpoint', () => {
+  beforeEach(async () => {
+    jwtToken = await getTestJwtToken()
+  })
+
+  test('getSdkConfiguration returns sdk features', async () => {
+    process.env.SDK_SOURCE = 'onfido_web_sdk'
+    process.env.SDK_VERSION = '8.3.0'
+
+    const configurations = await getSdkConfiguration(API_URL, jwtToken)
+
+    expect(configurations).toHaveProperty('sdk_features', {
+      enable_in_house_analytics: false,
+      enable_on_device_face_detection: true,
+      enable_require_applicant_consents: true,
+    })
+  })
+
+  test('getSdkConfiguration for unknown source returns all sdk features disabled', async () => {
+    process.env.SDK_SOURCE = 'i_am_unknown'
+    process.env.SDK_VERSION = '8.3.0'
+
+    const configurations = await getSdkConfiguration(API_URL, jwtToken)
+
+    expect(configurations).toHaveProperty('sdk_features', {
+      enable_in_house_analytics: false,
+      enable_on_device_face_detection: false,
+      enable_require_applicant_consents: false,
+    })
+  })
+
+  test('getSdkConfiguration for unknown sdk version returns configurations for the latest version', async () => {
+    process.env.SDK_SOURCE = 'onfido_web_sdk'
+    process.env.SDK_VERSION = '-1.0.007'
+
+    const configurations = await getSdkConfiguration(API_URL, jwtToken)
+
+    expect(configurations).toHaveProperty('sdk_features', {
+      enable_in_house_analytics: false,
+      enable_on_device_face_detection: true,
+      enable_require_applicant_consents: true,
+    })
+  })
+
+  test('getSdkConfiguration returns an error if request is made with an expired JWT token', async () => {
+    process.env.SDK_SOURCE = 'onfido_web_sdk'
+    process.env.SDK_VERSION = '8.3.0'
+
+    expect.assertions(1)
+
+    await getSdkConfiguration(API_URL, EXPIRED_JWT_TOKEN).catch((err) => {
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(err).toMatchObject(ASSERT_EXPIRED_JWT_ERROR_OBJECT)
+    })
+  })
+})


### PR DESCRIPTION
# Problem

Currently, there is no integration testing for the configurations endpoint.

# Solution

Add integration tests to the configurations endpoint ✨ 

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [x] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
