### PR TITLE
Add integration tests for the binary media endpoint

### DIFF
--- a/src/components/utils/__integrations__/onfidoApi/document.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/document.integration.js
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import { uploadDocument } from '../../onfidoApi'
+import { uploadDocument, uploadBinaryMedia } from '../../onfidoApi'
 import {
   getTestJwtToken,
   createEmptyFile,
@@ -113,5 +113,46 @@ describe('API uploadDocument endpoint', () => {
       (response) => done(response),
       onErrorCallback
     )
+  })
+})
+
+describe('API uploadBinaryMedia endpoint', () => {
+  beforeEach(async () => {
+    jwtToken = await getTestJwtToken()
+  })
+
+  test('uploadBinaryMedia returns expected response on successful upload', async () => {
+    const testFileName = 'passport.jpg'
+    const data = fs.readFileSync(`${PATH_TO_RESOURCE_FILES}${testFileName}`)
+    const testFile = new File([data], testFileName, {
+      type: 'image/jpeg',
+    })
+
+    const documentData = {
+      file: testFile,
+      filename: testFileName,
+      sdkMetadata: {},
+    }
+
+    expect.assertions(2)
+
+    const res = await uploadBinaryMedia(documentData, API_URL, jwtToken)
+    expect(res).toHaveProperty('error', null)
+    expect(res).toHaveProperty('media_id')
+  })
+
+  test('uploadBinaryMedia returns 422 on empty file upload', async () => {
+    const documentData = {
+      file: createEmptyFile(),
+      filename: 'fileName.jpg',
+      sdkMetadata: {},
+    }
+
+    expect.assertions(1)
+
+    await uploadBinaryMedia(documentData, API_URL, jwtToken).catch((res) => {
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(res).toHaveProperty('status', 422)
+    })
   })
 })


### PR DESCRIPTION
# Problem

Binary media endpoint has no integration tests 🔥 

# Solution

Add a couple of tests to the binary media endpoint!

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [x] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
