### PR TITLE
Add integration tests for the applicant consents endpoint

### DIFF
--- a/src/components/utils/__integrations__/helpers/index.js
+++ b/src/components/utils/__integrations__/helpers/index.js
@@ -1,4 +1,4 @@
-export const getTestJwtToken = async () => {
+const requestToTokenFactory = async () => {
   return new Promise((resolve, reject) => {
     const secret = process.env.SDK_TOKEN_FACTORY_SECRET
 
@@ -13,12 +13,24 @@ export const getTestJwtToken = async () => {
     xhr.onload = function () {
       if (xhr.status >= 200 && xhr.status < 400) {
         const data = JSON.parse(xhr.responseText)
-        resolve(data.message)
+        resolve(data)
       } else {
         reject(xhr.responseText)
       }
     }
     xhr.send()
+  })
+}
+
+export const getTestJwtToken = async () => {
+  return await requestToTokenFactory().then((res) => {
+    return res.message
+  })
+}
+
+export const getTestApplicantUUID = async () => {
+  return await requestToTokenFactory().then((res) => {
+    return res.applicant_id
   })
 }
 

--- a/src/components/utils/__integrations__/onfidoApi/applicant.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/applicant.integration.js
@@ -1,0 +1,69 @@
+import { getApplicantConsents, updateApplicantConsents } from '../../onfidoApi'
+import { getTestApplicantUUID, getTestJwtToken } from '../helpers'
+import { API_URL } from '../helpers/testUrls'
+
+let jwtToken = null
+let applicantUUID = null
+
+describe('API consents endpoint', () => {
+  beforeEach(async () => {
+    jwtToken = await getTestJwtToken()
+    applicantUUID = await getTestApplicantUUID()
+  })
+
+  test('getApplicantConsents returns expected properties in response', async () => {
+    const applicantConsents = await getApplicantConsents(
+      applicantUUID,
+      API_URL,
+      jwtToken
+    )
+
+    expect(applicantConsents).toHaveLength(1)
+    expect(applicantConsents[0]).toHaveProperty('granted', false)
+    expect(applicantConsents[0]).toHaveProperty('name', 'privacy_notices_read')
+    expect(applicantConsents[0]).toHaveProperty('required', true)
+  })
+
+  test('updateApplicantConsents returns an empty response', async () => {
+    const applicantConsents = [
+      {
+        name: 'privacy_notices_read',
+        granted: true,
+      },
+    ]
+
+    const applicantConsentsUpdated = await updateApplicantConsents(
+      applicantUUID,
+      applicantConsents,
+      API_URL,
+      jwtToken
+    )
+
+    expect(applicantConsentsUpdated).toStrictEqual('')
+  })
+
+  test('getApplicantConsents returns updated consents', async () => {
+    const applicantConsents = [
+      {
+        name: 'privacy_notices_read',
+        granted: true,
+      },
+    ]
+
+    await updateApplicantConsents(
+      applicantUUID,
+      applicantConsents,
+      API_URL,
+      jwtToken
+    )
+
+    const applicantConsentsUpdated = await getApplicantConsents(
+      applicantUUID,
+      API_URL,
+      jwtToken
+    )
+
+    expect(applicantConsents).toHaveLength(1)
+    expect(applicantConsentsUpdated[0]).toHaveProperty('granted', true)
+  })
+})


### PR DESCRIPTION
# Problem

There are no tests for the applicant consents endpoint 🔥 

# Solution

Now there are!

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [x] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
