### PR TITLE
add disable_cross_device_sms: false to integration test

### DIFF
--- a/src/components/utils/__integrations__/onfidoApi/configurations.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/configurations.integration.js
@@ -20,6 +20,7 @@ describe('API configurations endpoint', () => {
     const configurations = await getSdkConfiguration(API_URL, jwtToken)
 
     expect(configurations).toHaveProperty('sdk_features', {
+      disable_cross_device_sms: false,
       enable_in_house_analytics: false,
       enable_on_device_face_detection: true,
       enable_require_applicant_consents: true,
@@ -33,6 +34,7 @@ describe('API configurations endpoint', () => {
     const configurations = await getSdkConfiguration(API_URL, jwtToken)
 
     expect(configurations).toHaveProperty('sdk_features', {
+      disable_cross_device_sms: false,
       enable_in_house_analytics: false,
       enable_on_device_face_detection: false,
       enable_require_applicant_consents: false,
@@ -46,6 +48,7 @@ describe('API configurations endpoint', () => {
     const configurations = await getSdkConfiguration(API_URL, jwtToken)
 
     expect(configurations).toHaveProperty('sdk_features', {
+      disable_cross_device_sms: false,
       enable_in_house_analytics: false,
       enable_on_device_face_detection: true,
       enable_require_applicant_consents: true,


### PR DESCRIPTION
# Problem
The field `disable_cross_device_sms` got added and it's failing our tests

# Solution
Add the field to our tests

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
