### PR TITLE
Add integration tests for the applicant locations endpoint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,7 +45,7 @@ module.exports = {
     'jest/no-export': 'off',
     'jest/valid-describe': 'off',
     'jest/valid-expect': 'off',
-
+    'jest/no-conditional-expect': 'off',
     'jest/no-done-callback': 'off',
     /**  NOTE: This rule is disabled for these integration tests as onfidoApi.js were implemented using callbacks.
           Hence it is necessary to use Jest' done() callback function as per Jest's documentation for

--- a/src/components/utils/__integrations__/onfidoApi/applicant.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/applicant.integration.js
@@ -91,6 +91,8 @@ describe('API applicant location endpoint', () => {
   test('updateApplicantLocation returns error response on applicant not found', async () => {
     const invalidApplicantUUID = '12345678-1234-1234-1234-123456789abc'
 
+    expect.assertions(1)
+
     await updateApplicantLocation(
       invalidApplicantUUID,
       API_URL,

--- a/src/components/utils/__integrations__/onfidoApi/applicant.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/applicant.integration.js
@@ -1,4 +1,8 @@
-import { getApplicantConsents, updateApplicantConsents } from '../../onfidoApi'
+import {
+  getApplicantConsents,
+  updateApplicantConsents,
+  updateApplicantLocation,
+} from '../../onfidoApi'
 import { getTestApplicantUUID, getTestJwtToken } from '../helpers'
 import { API_URL } from '../helpers/testUrls'
 
@@ -65,5 +69,37 @@ describe('API consents endpoint', () => {
 
     expect(applicantConsents).toHaveLength(1)
     expect(applicantConsentsUpdated[0]).toHaveProperty('granted', true)
+  })
+})
+
+describe('API applicant location endpoint', () => {
+  beforeEach(async () => {
+    jwtToken = await getTestJwtToken()
+    applicantUUID = await getTestApplicantUUID()
+  })
+
+  test('updateApplicantLocation returns empty response on success', async () => {
+    const applicantLocation = await updateApplicantLocation(
+      applicantUUID,
+      API_URL,
+      jwtToken
+    )
+
+    expect(applicantLocation).toStrictEqual('')
+  })
+
+  test('updateApplicantLocation returns error response on applicant not found', async () => {
+    const invalidApplicantUUID = '12345678-1234-1234-1234-123456789abc'
+
+    await updateApplicantLocation(
+      invalidApplicantUUID,
+      API_URL,
+      jwtToken
+    ).catch((applicantLocation) => {
+      expect(applicantLocation).toHaveProperty(
+        'response.error.type',
+        'resource_not_found'
+      )
+    })
   })
 })

--- a/src/components/utils/__integrations__/onfidoApi/configurations.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/configurations.integration.js
@@ -62,7 +62,6 @@ describe('API configurations endpoint', () => {
     expect.assertions(1)
 
     await getSdkConfiguration(API_URL, EXPIRED_JWT_TOKEN).catch((err) => {
-      // eslint-disable-next-line jest/no-conditional-expect
       expect(err).toMatchObject(ASSERT_EXPIRED_JWT_ERROR_OBJECT)
     })
   })

--- a/src/components/utils/__integrations__/onfidoApi/document.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/document.integration.js
@@ -151,7 +151,6 @@ describe('API uploadBinaryMedia endpoint', () => {
     expect.assertions(1)
 
     await uploadBinaryMedia(documentData, API_URL, jwtToken).catch((res) => {
-      // eslint-disable-next-line jest/no-conditional-expect
       expect(res).toHaveProperty('status', 422)
     })
   })


### PR DESCRIPTION
# Problem

No tests for the applicant location update endpoint 🔥 

# Solution

There are tests now!

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [x] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
