### PR TITLE
Add integration tests for the create document v4 endpoint

### DIFF
--- a/src/components/utils/__integrations__/onfidoApi/document.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/document.integration.js
@@ -1,5 +1,9 @@
 import fs from 'fs'
-import { uploadDocument, uploadBinaryMedia } from '../../onfidoApi'
+import {
+  uploadDocument,
+  uploadBinaryMedia,
+  createV4Document,
+} from '../../onfidoApi'
 import {
   getTestJwtToken,
   createEmptyFile,
@@ -154,5 +158,35 @@ describe('API uploadBinaryMedia endpoint', () => {
       // eslint-disable-next-line jest/no-conditional-expect
       expect(res).toHaveProperty('status', 422)
     })
+  })
+})
+
+describe('API createV4Document endpoint', () => {
+  beforeEach(async () => {
+    jwtToken = await getTestJwtToken()
+  })
+
+  test('createV4Document returns expected response on successful upload', async () => {
+    const testFileName = 'passport.jpg'
+    const data = fs.readFileSync(`${PATH_TO_RESOURCE_FILES}${testFileName}`)
+    const testFile = new File([data], testFileName, {
+      type: 'image/jpeg',
+    })
+    const documentData = {
+      file: testFile,
+      filename: testFileName,
+      sdkMetadata: {},
+    }
+
+    expect.assertions(1)
+
+    const { media_id: documentUUID } = await uploadBinaryMedia(
+      documentData,
+      API_URL,
+      jwtToken
+    )
+
+    const res = await createV4Document([documentUUID], API_URL, jwtToken)
+    expect(res).toHaveProperty('uuid')
   })
 })

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -50,6 +50,7 @@ export type ValidationReasons =
   | 'detect_blur'
   | 'face_detection'
   | 'file'
+  | 'media'
 
 export type ValidationError = {
   type: typeof API_ERROR_VALIDATION


### PR DESCRIPTION
# Problem

There are no tests for the document creation (v4) endpoint 🔥 

# Solution

There are tests now!

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [x] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
