### PR TITLE
Add integration testing to the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,21 @@ $ npm run test:unit # unit testing
 $ npm run test:integration # integration testing, for internal contributors only but executed during CI
 ```
 
-The Web SDK has a large coverage of UI tests. To set up your environment, please refer to the [testing guidelines](./test/README.md).
+### Integration testing
+
+We use integration testing to ensure that our API call implementations work as expected.
+
+You are encouraged to add integration tests when
+* Adding a brand-new API call to the code
+* Updating an existing API call
+* New features added to an existing endpoint
+* Covering edge cases or negative cases
+
+You should place the integration tests at the `__integrations__` package.
+
+### Ui Testing
+
+The Web SDK has a large coverage of UI tests. To set up your environment, please refer to the [UI testing guidelines](./test/README.md).
 
 You should also manually test any change in all the supported browsers, both on desktop and mobile. To facilitate this process, every time a new pull request is created, a new demo app link will be generated. If you don't have enough devices to test your changes, you can perform manual tests on different devices on Browserstack.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,10 +82,11 @@ $ npm run test:integration # integration testing, for internal contributors only
 We use integration testing to ensure that our API call implementations work as expected.
 
 You are encouraged to add integration tests when
-* Adding a brand-new API call to the code
-* Updating an existing API call
-* New features added to an existing endpoint
-* Covering edge cases or negative cases
+
+- Adding a brand-new API call to the code
+- Updating an existing API call
+- New features added to an existing endpoint
+- Covering edge cases or negative cases
 
 You should place the integration tests at the `__integrations__` package.
 


### PR DESCRIPTION
# Problem

Not very clear when to add new integration tests to the source code when contributing.

# Solution

Make it clear, and simple.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [x] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
