### PR TITLE
Fix error message for locale issue

### DIFF
--- a/src/components/utils/__integrations__/onfidoApi/selfie.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/selfie.integration.js
@@ -78,9 +78,7 @@ describe('API uploadFacePhoto endpoint', () => {
       try {
         expect(error.status).toBe(422)
         expect(error.response.error.type).toBe('validation_error')
-        expect(error.response.error.fields).toHaveProperty(
-          'attachment_file_size'
-        )
+        expect(error.response.error.fields).toHaveProperty('attachment')
         done()
       } catch (err) {
         done(err)

--- a/src/components/utils/__integrations__/onfidoApi/video.integration.js
+++ b/src/components/utils/__integrations__/onfidoApi/video.integration.js
@@ -105,9 +105,7 @@ describe('API uploadFaceVideo endpoint', () => {
       try {
         expect(error.status).toBe(422)
         expect(error.response.error.type).toBe('validation_error')
-        expect(error.response.error.fields).toHaveProperty(
-          'attachment_file_size'
-        )
+        expect(error.response.error.fields).toHaveProperty('attachment')
         done()
       } catch (err) {
         done(err)

--- a/src/locales/__tests__/index.test.ts
+++ b/src/locales/__tests__/index.test.ts
@@ -70,15 +70,15 @@ describe('locales', () => {
 
         const minLength = Math.min(splitted.length, splitted2.length)
 
-        for (let i = 0; i < minLength; i++) {
-          // we compare each level of the key, either the level is -1, meaning [i] is before [i-1] and we stop, or it's zero and we must compare next level
-          if (splitted[i].localeCompare(splitted2[i]) === -1) {
+        for (let j = 0; j < minLength; j++) {
+          // we compare each level of the key, either the level is -1, meaning [j] is before [j-1] and we stop, or it's zero and we must compare next level
+          if (splitted[j].localeCompare(splitted2[j]) === -1) {
             break
           }
-          if (splitted[i].localeCompare(splitted2[i]) === 0) {
+          if (splitted[j].localeCompare(splitted2[j]) === 0) {
             // continue
           }
-          if (splitted[i].localeCompare(splitted2[i]) === 1) {
+          if (splitted[j].localeCompare(splitted2[j]) === 1) {
             // eslint-disable-next-line jest/no-conditional-expect
             expect(false).toBe(
               `the key '${keys_locale[i]}' should be after the key '${


### PR DESCRIPTION
# Problem
- When we were testing for alphabetical order, we were not displaying a useful debug message because the i was overwriting the previous i in the scope
# Solution
- Use j instead of i in nested for loop
## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
