### PR TITLE
Remove locales from prettierignore to minimize diffs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,6 @@
 /node_modules
 /lib
 /dist
-/src/locales/**/*.json
 /src/supported-documents/*.json
 /test/mock-server/frontend
 /test/mock-server/local

--- a/src/locales/cs_CZ/cs_CZ.json
+++ b/src/locales/cs_CZ/cs_CZ.json
@@ -1,678 +1,678 @@
 {
-    "avc_confirmation": {
-        "button_primary_upload": "Nahrávání záznamu",
-        "subtitle": "Video vašeho obličeje bylo úspěšně nahráno",
-        "title": "Nahrávání bylo dokončeno"
+  "avc_confirmation": {
+    "button_primary_upload": "Nahrávání záznamu",
+    "subtitle": "Video vašeho obličeje bylo úspěšně nahráno",
+    "title": "Nahrávání bylo dokončeno"
+  },
+  "avc_connection_error": {
+    "button_primary_reload": "Pokyny pro opětovné nahrávání",
+    "button_primary_retry_upload": "Opakování nahrávání",
+    "button_secondary_restart_recording": "Restart nahrávání",
+    "subtitle": "Zkontrolujte, zda je připojení stabilní, a opakujte akci",
+    "title": "Chyba připojení"
+  },
+  "avc_face_alignment": {
+    "feedback_move_back": "Posuňte se dozadu",
+    "feedback_move_closer": "Přibližte se",
+    "feedback_no_face_detected": "Obličej nebyl rozpoznán",
+    "feedback_not_centered": "Obličej není vycentrovaný",
+    "title": "Umístěte obličej do záběru"
+  },
+  "avc_face_capture": {
+    "alert": {
+      "timeout_body": "Na dokončení záznamu máte až 15 sekund",
+      "timeout_button_primary": "Opakování",
+      "timeout_title": "Litujeme, musíme znovu spustit nahrávání",
+      "too_fast_body": "Zkuste to znovu a otáčejte hlavou pomaleji",
+      "too_fast_button_primary": "Opakování",
+      "too_fast_title": "Otočil/a jste hlavu příliš rychle"
     },
-    "avc_connection_error": {
-        "button_primary_reload": "Pokyny pro opětovné nahrávání",
-        "button_primary_retry_upload": "Opakování nahrávání",
-        "button_secondary_restart_recording": "Restart nahrávání",
-        "subtitle": "Zkontrolujte, zda je připojení stabilní, a opakujte akci",
-        "title": "Chyba připojení"
+    "title": "Pomalu otáčejte hlavou na obě strany",
+    "title_completed": "Nahrávání bylo dokončeno"
+  },
+  "avc_intro": {
+    "button_primary_ready": "Jsem připraven",
+    "disclaimer": "Mějte prosím na paměti, že budeme zaznamenávat váš obličej a pozadí obrazu",
+    "list_item_one": "Nejprve umístěte obličej do záběru",
+    "list_item_two": "Pak pomalu otáčejte hlavu na obě strany",
+    "subtitle": "Tím se ověří, že jste skutečná osoba",
+    "title": "Nahrávání videa"
+  },
+  "avc_no_face_detected": {
+    "button_primary_restart": "Restart nahrávání",
+    "list_item_eyes": "Ujistěte se, že jsou vaše oči dobře viditelné",
+    "list_item_face": "Stačí, když se ukážete, nepotřebujeme vidět váš průkaz totožnosti.",
+    "list_item_lighting": "Ujistěte se, že jste na místě s dobrým osvětlením",
+    "list_item_mask": "Nezapomeňte si sundat roušku nebo jiné předměty, které vám zakrývají obličej. Brýle jsou v pořádku",
+    "title": "Nemůžeme rozpoznat váš obličej"
+  },
+  "avc_uploading": {
+    "title": "Nahrávání"
+  },
+  "country_select": {
+    "alert": {
+      "another_doc": "Dokumenty z této země nejsou v současné době podporovány - <fallback>zkuste jiný typ dokumentu</fallback>."
     },
-    "avc_face_alignment": {
-        "feedback_move_back": "Posuňte se dozadu",
-        "feedback_move_closer": "Přibližte se",
-        "feedback_no_face_detected": "Obličej nebyl rozpoznán",
-        "feedback_not_centered": "Obličej není vycentrovaný",
-        "title": "Umístěte obličej do záběru"
+    "alert_dropdown": {
+      "country_not_found": "Země nebyla nalezena"
     },
-    "avc_face_capture": {
-        "alert": {
-            "timeout_body": "Na dokončení záznamu máte až 15 sekund",
-            "timeout_button_primary": "Opakování",
-            "timeout_title": "Litujeme, musíme znovu spustit nahrávání",
-            "too_fast_body": "Zkuste to znovu a otáčejte hlavou pomaleji",
-            "too_fast_button_primary": "Opakování",
-            "too_fast_title": "Otočil\/a jste hlavu příliš rychle"
-        },
-        "title": "Pomalu otáčejte hlavou na obě strany",
-        "title_completed": "Nahrávání bylo dokončeno"
+    "button_primary": "Odeslat dokument",
+    "poa_alert": {
+      "country_not_found": "Litujeme. Pracujeme na budoucí podpoře dalších zemí.",
+      "intro": "Nemůžete najít svou zemi?"
     },
-    "avc_intro": {
-        "button_primary_ready": "Jsem připraven",
-        "disclaimer": "Mějte prosím na paměti, že budeme zaznamenávat váš obličej a pozadí obrazu",
-        "list_item_one": "Nejprve umístěte obličej do záběru",
-        "list_item_two": "Pak pomalu otáčejte hlavu na obě strany",
-        "subtitle": "Tím se ověří, že jste skutečná osoba",
-        "title": "Nahrávání videa"
+    "search": {
+      "accessibility": "Zvolte zemi",
+      "input_placeholder": "např. Spojené státy",
+      "label": "Hledání země"
     },
-    "avc_no_face_detected": {
-        "button_primary_restart": "Restart nahrávání",
-        "list_item_eyes": "Ujistěte se, že jsou vaše oči dobře viditelné",
-        "list_item_face": "Stačí, když se ukážete, nepotřebujeme vidět váš průkaz totožnosti.",
-        "list_item_lighting": "Ujistěte se, že jste na místě s dobrým osvětlením",
-        "list_item_mask": "Nezapomeňte si sundat roušku nebo jiné předměty, které vám zakrývají obličej. Brýle jsou v pořádku",
-        "title": "Nemůžeme rozpoznat váš obličej"
+    "title": "Vyberte zemi, kde došlo k vydání"
+  },
+  "cross_device_checklist": {
+    "button_primary": "Odeslat ověření",
+    "info": "Tipy",
+    "list_item_doc_multiple": "Dokumenty",
+    "list_item_doc_one": "Dokument",
+    "list_item_poa": "Doklad o adrese",
+    "list_item_selfie": "Selfie",
+    "list_item_video": "Video",
+    "subtitle": "Zde je vše, co jste nahráli:",
+    "title": "Poslední krok"
+  },
+  "cross_device_error_desktop": {
+    "subtitle": "Odkaz funguje pouze na mobilních zařízeních",
+    "title": "Něco se pokazilo"
+  },
+  "cross_device_error_restart": {
+    "subtitle": "Budete muset restartovat ověřování v počítači",
+    "title": "Něco se pokazilo"
+  },
+  "cross_device_intro": {
+    "button_primary": "Získejte zabezpečený odkaz",
+    "list_accessibility": "Kroky potřebné k pokračování ověřování v mobilním telefonu",
+    "list_item_finish": "Zkontrolujte, zda jste dokončili odesílání",
+    "list_item_open_link": "Otevřete odkaz a dokončete úkoly",
+    "list_item_send_phone": "Odeslání zabezpečeného odkazu do telefonu",
+    "subtitle": "Zde je postup:",
+    "title": "Pokračovat v telefonu"
+  },
+  "cross_device_return": {
+    "body": "Aktualizace počítače může trvat několik sekund",
+    "subtitle": "Nyní se můžete vrátit k počítači a pokračovat dále",
+    "title": "Úspěšné nahrávání"
+  },
+  "cross_device_session_linked": {
+    "button_primary": "Pokračovat",
+    "info": "Dvojitá kontrola",
+    "list_item_desktop_open": "Okno plochy je stále otevřené",
+    "list_item_sent_by_you": "Tento odkaz jste poslali vy - pokud si myslíte, že by mohlo jít o podvod, požádejte o radu.",
+    "subtitle": "Pokračujte v ověřování",
+    "title": "Mobilní relace propojená s počítačem"
+  },
+  "doc_capture": {
+    "button_primary": "Spuštění skenování dokumentů",
+    "detail": {
+      "folded_doc_front": "Položte dokument na plocho a připojte všechny vnitřní stránky (musí obsahovat vaši fotografii)"
     },
-    "avc_uploading": {
-        "title": "Nahrávání"
+    "header_folded_doc_front": "Strana s profilovou fotografií",
+    "prompt": {
+      "button_card": "Plastová karta",
+      "button_paper": "Papírový dokument",
+      "title_id": "Jaký typ průkazu totožnosti máte?",
+      "title_license": "Jaký typ licence máte?"
+    }
+  },
+  "doc_confirmation": {
+    "alert": {
+      "blur_detail": "Ujistěte se, že je vše jasné a čisté",
+      "blur_title": "Detekce rozmazané fotografie",
+      "crop_detail": "Ujistěte se, že je viditelný celý dokument",
+      "crop_title": "Zjištěný obraz s oříznutým okrajem",
+      "glare_detail": "Odstupte od přímého světla",
+      "glare_title": "Zjištěno oslnění",
+      "no_doc_detail": "Ujistěte se, že je tento dokument zcela v rámečku",
+      "no_doc_title": "Dokument nebyl zjištěn"
     },
-    "country_select": {
-        "alert": {
-            "another_doc": "Dokumenty z této země nejsou v současné době podporovány - <fallback>zkuste jiný typ dokumentu<\/fallback>."
-        },
-        "alert_dropdown": {
-            "country_not_found": "Země nebyla nalezena"
-        },
-        "button_primary": "Odeslat dokument",
-        "poa_alert": {
-            "country_not_found": "Litujeme. Pracujeme na budoucí podpoře dalších zemí.",
-            "intro": "Nemůžete najít svou zemi?"
-        },
-        "search": {
-            "accessibility": "Zvolte zemi",
-            "input_placeholder": "např. Spojené státy",
-            "label": "Hledání země"
-        },
-        "title": "Vyberte zemi, kde došlo k vydání"
+    "body": "Ujistěte se, že jste nahráli celou stránku dokumentu a detaily jsou dobře čitelné bez rozmazání nebo odlesků.",
+    "body_bank_statement": "Ujistěte se, že jste nahráli celou stránku dokumentu a detaily jsou dobře čitelné bez rozmazání nebo odlesků.",
+    "body_benefits_letter": "Ujistěte se, že jste nahráli celou stránku dokumentu a detaily jsou dobře čitelné bez rozmazání nebo odlesků.",
+    "body_bill": "Ujistěte se, že jste nahráli celou stránku dokumentu a detaily jsou dobře čitelné bez rozmazání nebo odlesků.",
+    "body_id": "Ujistěte se, že jsou vaše údaje jasné a nezkreslené",
+    "body_image_medium": "Ověření bude trvat déle, pokud nebudeme moci dokument přečíst",
+    "body_image_poor": "Pro hladké ověření potřebujeme lepší fotografii",
+    "body_license": "Ujistěte se, že jsou vaše údaje jasné a nezkreslené",
+    "body_passport": "Ujistěte se, že jsou vaše údaje jasné a nezkreslené",
+    "body_permit": "Ujistěte se, že jsou vaše údaje jasné a nezkreslené",
+    "body_tax_letter": "Ujistěte se, že jste nahráli celou stránku dokumentu a detaily jsou dobře čitelné bez rozmazání nebo odlesků.",
+    "button_close": "Zavřít",
+    "button_primary_redo": "Přepracovat",
+    "button_primary_upload": "Nahrát",
+    "button_primary_upload_anyway": "Stejně nahrát",
+    "button_secondary_redo": "Přepracovat",
+    "button_zoom": "Zvětšit obrázek",
+    "image_accessibility": "Fotografie vašeho dokumentu",
+    "title": "Zkontrolujte svůj snímek"
+  },
+  "doc_multi_frame_capture": {
+    "capture_progress_title": "Skenování dokumentu",
+    "instructions_title_back": "Umístěte zadní stranu dokumentu do rámečku",
+    "instructions_title_front": "Umístěte přední stranu dokumentu do rámečku"
+  },
+  "doc_select": {
+    "button_bank_statement": "Výpis z účtu banky nebo stavební spořitelny",
+    "button_bank_statement_non_uk": "Bankovní výpis",
+    "button_benefits_letter": "Dopis o výhodách",
+    "button_benefits_letter_detail": "Vládou schválené dávky pro domácnosti, např. příspěvek pro uchazeče o zaměstnání, příspěvek na bydlení, daňové úlevy.",
+    "button_bill": "Účet za komunální služby",
+    "button_bill_detail": "Plyn, elektřina, voda, pevná linka nebo širokopásmové připojení",
+    "button_government_letter": "Vládní dopis",
+    "button_government_letter_detail": "Jakýkoli dopis vydaný vládou, například dopis o nároku na dávky, dopis o volbách, dopis o daních atd.",
+    "button_id": "Průkaz totožnosti",
+    "button_id_detail": "Přední a zadní strana",
+    "button_license": "Řidičský průkaz",
+    "button_license_detail": "Přední a zadní strana",
+    "button_passport": "Pas",
+    "button_passport_detail": "Stránka pro fotografie",
+    "button_permit": "Povolení k pobytu",
+    "button_permit_detail": "Přední a zadní strana",
+    "button_tax_letter": "Dopis o dani",
+    "extra_estatements_ok": "Přijímání elektronických výkazů",
+    "extra_no_mobile": "Litujeme, nemáme žádné účty za mobilní telefon",
+    "list_accessibility": "Doklady, které můžete použít k ověření své totožnosti",
+    "pill": "nejrychlejší",
+    "section": {
+      "header_country": "Vydávající země",
+      "header_doc_type": "Akceptované dokumenty",
+      "input_country_not_found": "Žádné výsledky",
+      "input_placeholder_country": "Vyberte zemi, kde došlo k vydání"
     },
-    "cross_device_checklist": {
-        "button_primary": "Odeslat ověření",
-        "info": "Tipy",
-        "list_item_doc_multiple": "Dokumenty",
-        "list_item_doc_one": "Dokument",
-        "list_item_poa": "Doklad o adrese",
-        "list_item_selfie": "Selfie",
-        "list_item_video": "Video",
-        "subtitle": "Zde je vše, co jste nahráli:",
-        "title": "Poslední krok"
+    "subtitle": "Musí se jednat o oficiální průkaz totožnosti s fotografií",
+    "subtitle_country": "Vyberte zemi vydání a podívejte se, které doklady přijímáme",
+    "subtitle_entire_page": "Celá stránka",
+    "subtitle_front_back": "Přední a zadní strana",
+    "subtitle_photo_page": "Stránka pro fotografie",
+    "subtitle_poa": "V těchto dokumentech je nejčastěji uvedena vaše současná adresa bydliště",
+    "title": "Vyberte svůj dokument",
+    "title_poa": "Vyberte dokument %{country}"
+  },
+  "doc_submit": {
+    "button_link_upload": "nebo nahrát fotografii - žádné skeny nebo fotokopie",
+    "button_primary": "Pokračujte v telefonu",
+    "subtitle": "Vyfotografujte se telefonem",
+    "title_bank_statement": "Odeslat prohlášení",
+    "title_benefits_letter": "Odeslat dopis",
+    "title_bill": "Předložit účet",
+    "title_government_letter": "Vládní dopis",
+    "title_id_back": "Předložit průkaz totožnosti (zadní strana)",
+    "title_id_front": "Předložit průkaz totožnosti (přední strana)",
+    "title_license_back": "Předložit licenci (zadní strana)",
+    "title_license_front": "Předložit licenci (přední strana)",
+    "title_passport": "Odeslat pasovou fotografii",
+    "title_permit_back": "Předložit povolení k pobytu (zadní stranu)",
+    "title_permit_front": "Předložit povolení k pobytu (přední stranu)",
+    "title_tax_letter": "Odeslat dopis"
+  },
+  "doc_video_capture": {
+    "button_primary_fallback": "Další krok",
+    "button_primary_fallback_end": "Dokončení nahrávání",
+    "detail_step2": "Mějte dokument stále na očích",
+    "header": "Při držení dokumentu držte přední stranu v rámečku",
+    "header_paper_doc_step2": "Pomalu otočte dokument tak, abyste viděli vnější stránky",
+    "header_passport": "Když držíte pas, držte stránku s fotografií v rámečku",
+    "header_passport_progress": "Vydržte v klidu",
+    "header_step1": "Nyní se nehýbejte",
+    "header_step2": "Pomalu otočte dokument tak, abyste viděli jeho zadní stranu",
+    "prompt": {
+      "detail_timeout": "Nahrávání videa je omezeno na <timeout></timeout> sekund. <fallback>Spusťte proces znovu</fallback>"
     },
-    "cross_device_error_desktop": {
-        "subtitle": "Odkaz funguje pouze na mobilních zařízeních",
-        "title": "Něco se pokazilo"
+    "stepper": "Krok <step></step> z <total></total>",
+    "success_accessibility": "Úspěch"
+  },
+  "doc_video_confirmation": {
+    "button_secondary": "Náhled videa",
+    "title": "Zkontrolujte své video"
+  },
+  "error_unsupported_browser": {
+    "subtitle_android": "Restartování v nejnovější verzi prohlížeče Google Chrome",
+    "subtitle_ios": "Restartování v nejnovější verzi prohlížeče Safari",
+    "title_android": "Nepodporovaný prohlížeč",
+    "title_ios": "Nepodporovaný prohlížeč"
+  },
+  "generic": {
+    "accessibility": {
+      "close_sdk_screen": "Zavření obrazovky pro ověření totožnosti",
+      "dismiss_alert": "Zrušit upozornění"
     },
-    "cross_device_error_restart": {
-        "subtitle": "Budete muset restartovat ověřování v počítači",
-        "title": "Něco se pokazilo"
+    "back": "zpět",
+    "close": "zavřít",
+    "errors": {
+      "expired_token": {
+        "instruction": "Zkuste to znovu",
+        "message": "Platnost vašeho tokenu vypršela"
+      },
+      "geoblocked_error": {
+        "instruction": "Litujeme, ale zdá se, že nemůžeme pokračovat dále, protože vaše aktuální umístění není podporováno.",
+        "message": "Služba není k dispozici"
+      },
+      "interrupted_flow_error": {
+        "instruction": "Restartování na jiném zařízení",
+        "message": "Kamera nebyla detekována"
+      },
+      "invalid_size": {
+        "instruction": "Musí mít velikost menší než 10 MB.",
+        "message": "Překročena velikost souboru."
+      },
+      "invalid_type": {
+        "instruction": "Zkuste použít jiný typ souboru.",
+        "message": "Soubor nebyl nahrán."
+      },
+      "lazy_loading": {
+        "message": "Při načítání komponentu došlo k chybě"
+      },
+      "multiple_faces": {
+        "instruction": "Na selfie může být pouze váš obličej",
+        "message": "Nalezeno více obličejů"
+      },
+      "no_face": {
+        "instruction": "Ujistěte se, že je váš obličej viditelný",
+        "message": "Obličej nebyl rozpoznán"
+      },
+      "request_error": {
+        "instruction": "Zkuste to znovu",
+        "message": "Něco se pokazilo"
+      },
+      "sms_failed": {
+        "instruction": "Zkopírujte odkaz do telefonu",
+        "message": "Něco se pokazilo"
+      },
+      "sms_overuse": {
+        "instruction": "Zkopírujte odkaz do telefonu",
+        "message": "Příliš mnoho neúspěšných pokusů"
+      },
+      "unsupported_file": {
+        "instruction": "Zkuste použít soubor JPG nebo PNG",
+        "message": "Typ souboru není podporován"
+      }
     },
-    "cross_device_intro": {
-        "button_primary": "Získejte zabezpečený odkaz",
-        "list_accessibility": "Kroky potřebné k pokračování ověřování v mobilním telefonu",
-        "list_item_finish": "Zkontrolujte, zda jste dokončili odesílání",
-        "list_item_open_link": "Otevřete odkaz a dokončete úkoly",
-        "list_item_send_phone": "Odeslání zabezpečeného odkazu do telefonu",
-        "subtitle": "Zde je postup:",
-        "title": "Pokračovat v telefonu"
-    },
-    "cross_device_return": {
-        "body": "Aktualizace počítače může trvat několik sekund",
-        "subtitle": "Nyní se můžete vrátit k počítači a pokračovat dále",
-        "title": "Úspěšné nahrávání"
-    },
-    "cross_device_session_linked": {
-        "button_primary": "Pokračovat",
-        "info": "Dvojitá kontrola",
-        "list_item_desktop_open": "Okno plochy je stále otevřené",
-        "list_item_sent_by_you": "Tento odkaz jste poslali vy - pokud si myslíte, že by mohlo jít o podvod, požádejte o radu.",
-        "subtitle": "Pokračujte v ověřování",
-        "title": "Mobilní relace propojená s počítačem"
-    },
-    "doc_capture": {
-        "button_primary": "Spuštění skenování dokumentů",
-        "detail": {
-            "folded_doc_front": "Položte dokument na plocho a připojte všechny vnitřní stránky (musí obsahovat vaši fotografii)"
-        },
-        "header_folded_doc_front": "Strana s profilovou fotografií",
-        "prompt": {
-            "button_card": "Plastová karta",
-            "button_paper": "Papírový dokument",
-            "title_id": "Jaký typ průkazu totožnosti máte?",
-            "title_license": "Jaký typ licence máte?"
-        }
-    },
-    "doc_confirmation": {
-        "alert": {
-            "blur_detail": "Ujistěte se, že je vše jasné a čisté",
-            "blur_title": "Detekce rozmazané fotografie",
-            "crop_detail": "Ujistěte se, že je viditelný celý dokument",
-            "crop_title": "Zjištěný obraz s oříznutým okrajem",
-            "glare_detail": "Odstupte od přímého světla",
-            "glare_title": "Zjištěno oslnění",
-            "no_doc_detail": "Ujistěte se, že je tento dokument zcela v rámečku",
-            "no_doc_title": "Dokument nebyl zjištěn"
-        },
-        "body": "Ujistěte se, že jste nahráli celou stránku dokumentu a detaily jsou dobře čitelné bez rozmazání nebo odlesků.",
-        "body_bank_statement": "Ujistěte se, že jste nahráli celou stránku dokumentu a detaily jsou dobře čitelné bez rozmazání nebo odlesků.",
-        "body_benefits_letter": "Ujistěte se, že jste nahráli celou stránku dokumentu a detaily jsou dobře čitelné bez rozmazání nebo odlesků.",
-        "body_bill": "Ujistěte se, že jste nahráli celou stránku dokumentu a detaily jsou dobře čitelné bez rozmazání nebo odlesků.",
-        "body_id": "Ujistěte se, že jsou vaše údaje jasné a nezkreslené",
-        "body_image_medium": "Ověření bude trvat déle, pokud nebudeme moci dokument přečíst",
-        "body_image_poor": "Pro hladké ověření potřebujeme lepší fotografii",
-        "body_license": "Ujistěte se, že jsou vaše údaje jasné a nezkreslené",
-        "body_passport": "Ujistěte se, že jsou vaše údaje jasné a nezkreslené",
-        "body_permit": "Ujistěte se, že jsou vaše údaje jasné a nezkreslené",
-        "body_tax_letter": "Ujistěte se, že jste nahráli celou stránku dokumentu a detaily jsou dobře čitelné bez rozmazání nebo odlesků.",
-        "button_close": "Zavřít",
-        "button_primary_redo": "Přepracovat",
-        "button_primary_upload": "Nahrát",
-        "button_primary_upload_anyway": "Stejně nahrát",
-        "button_secondary_redo": "Přepracovat",
-        "button_zoom": "Zvětšit obrázek",
-        "image_accessibility": "Fotografie vašeho dokumentu",
-        "title": "Zkontrolujte svůj snímek"
-    },
-    "doc_multi_frame_capture": {
-        "capture_progress_title": "Skenování dokumentu",
-        "instructions_title_back": "Umístěte zadní stranu dokumentu do rámečku",
-        "instructions_title_front": "Umístěte přední stranu dokumentu do rámečku"
-    },
-    "doc_select": {
-        "button_bank_statement": "Výpis z účtu banky nebo stavební spořitelny",
-        "button_bank_statement_non_uk": "Bankovní výpis",
-        "button_benefits_letter": "Dopis o výhodách",
-        "button_benefits_letter_detail": "Vládou schválené dávky pro domácnosti, např. příspěvek pro uchazeče o zaměstnání, příspěvek na bydlení, daňové úlevy.",
-        "button_bill": "Účet za komunální služby",
-        "button_bill_detail": "Plyn, elektřina, voda, pevná linka nebo širokopásmové připojení",
-        "button_government_letter": "Vládní dopis",
-        "button_government_letter_detail": "Jakýkoli dopis vydaný vládou, například dopis o nároku na dávky, dopis o volbách, dopis o daních atd.",
-        "button_id": "Průkaz totožnosti",
-        "button_id_detail": "Přední a zadní strana",
-        "button_license": "Řidičský průkaz",
-        "button_license_detail": "Přední a zadní strana",
-        "button_passport": "Pas",
-        "button_passport_detail": "Stránka pro fotografie",
-        "button_permit": "Povolení k pobytu",
-        "button_permit_detail": "Přední a zadní strana",
-        "button_tax_letter": "Dopis o dani",
-        "extra_estatements_ok": "Přijímání elektronických výkazů",
-        "extra_no_mobile": "Litujeme, nemáme žádné účty za mobilní telefon",
-        "list_accessibility": "Doklady, které můžete použít k ověření své totožnosti",
-        "pill": "nejrychlejší",
-        "section": {
-            "header_country": "Vydávající země",
-            "header_doc_type": "Akceptované dokumenty",
-            "input_country_not_found": "Žádné výsledky",
-            "input_placeholder_country": "Vyberte zemi, kde došlo k vydání"
-        },
-        "subtitle": "Musí se jednat o oficiální průkaz totožnosti s fotografií",
-        "subtitle_country": "Vyberte zemi vydání a podívejte se, které doklady přijímáme",
-        "subtitle_entire_page": "Celá stránka",
-        "subtitle_front_back": "Přední a zadní strana",
-        "subtitle_photo_page": "Stránka pro fotografie",
-        "subtitle_poa": "V těchto dokumentech je nejčastěji uvedena vaše současná adresa bydliště",
-        "title": "Vyberte svůj dokument",
-        "title_poa": "Vyberte dokument %{country}"
-    },
-    "doc_submit": {
-        "button_link_upload": "nebo nahrát fotografii - žádné skeny nebo fotokopie",
-        "button_primary": "Pokračujte v telefonu",
-        "subtitle": "Vyfotografujte se telefonem",
-        "title_bank_statement": "Odeslat prohlášení",
-        "title_benefits_letter": "Odeslat dopis",
-        "title_bill": "Předložit účet",
-        "title_government_letter": "Vládní dopis",
-        "title_id_back": "Předložit průkaz totožnosti (zadní strana)",
-        "title_id_front": "Předložit průkaz totožnosti (přední strana)",
-        "title_license_back": "Předložit licenci (zadní strana)",
-        "title_license_front": "Předložit licenci (přední strana)",
-        "title_passport": "Odeslat pasovou fotografii",
-        "title_permit_back": "Předložit povolení k pobytu (zadní stranu)",
-        "title_permit_front": "Předložit povolení k pobytu (přední stranu)",
-        "title_tax_letter": "Odeslat dopis"
-    },
-    "doc_video_capture": {
-        "button_primary_fallback": "Další krok",
-        "button_primary_fallback_end": "Dokončení nahrávání",
-        "detail_step2": "Mějte dokument stále na očích",
-        "header": "Při držení dokumentu držte přední stranu v rámečku",
-        "header_paper_doc_step2": "Pomalu otočte dokument tak, abyste viděli vnější stránky",
-        "header_passport": "Když držíte pas, držte stránku s fotografií v rámečku",
-        "header_passport_progress": "Vydržte v klidu",
-        "header_step1": "Nyní se nehýbejte",
-        "header_step2": "Pomalu otočte dokument tak, abyste viděli jeho zadní stranu",
-        "prompt": {
-            "detail_timeout": "Nahrávání videa je omezeno na <timeout><\/timeout> sekund. <fallback>Spusťte proces znovu<\/fallback>"
-        },
-        "stepper": "Krok <step><\/step> z <total><\/total>",
-        "success_accessibility": "Úspěch"
-    },
-    "doc_video_confirmation": {
-        "button_secondary": "Náhled videa",
-        "title": "Zkontrolujte své video"
-    },
-    "error_unsupported_browser": {
-        "subtitle_android": "Restartování v nejnovější verzi prohlížeče Google Chrome",
-        "subtitle_ios": "Restartování v nejnovější verzi prohlížeče Safari",
-        "title_android": "Nepodporovaný prohlížeč",
-        "title_ios": "Nepodporovaný prohlížeč"
-    },
-    "generic": {
-        "accessibility": {
-            "close_sdk_screen": "Zavření obrazovky pro ověření totožnosti",
-            "dismiss_alert": "Zrušit upozornění"
-        },
-        "back": "zpět",
-        "close": "zavřít",
-        "errors": {
-            "expired_token": {
-                "instruction": "Zkuste to znovu",
-                "message": "Platnost vašeho tokenu vypršela"
-            },
-            "geoblocked_error": {
-                "instruction": "Litujeme, ale zdá se, že nemůžeme pokračovat dále, protože vaše aktuální umístění není podporováno.",
-                "message": "Služba není k dispozici"
-            },
-            "interrupted_flow_error": {
-                "instruction": "Restartování na jiném zařízení",
-                "message": "Kamera nebyla detekována"
-            },
-            "invalid_size": {
-                "instruction": "Musí mít velikost menší než 10 MB.",
-                "message": "Překročena velikost souboru."
-            },
-            "invalid_type": {
-                "instruction": "Zkuste použít jiný typ souboru.",
-                "message": "Soubor nebyl nahrán."
-            },
-            "lazy_loading": {
-                "message": "Při načítání komponentu došlo k chybě"
-            },
-            "multiple_faces": {
-                "instruction": "Na selfie může být pouze váš obličej",
-                "message": "Nalezeno více obličejů"
-            },
-            "no_face": {
-                "instruction": "Ujistěte se, že je váš obličej viditelný",
-                "message": "Obličej nebyl rozpoznán"
-            },
-            "request_error": {
-                "instruction": "Zkuste to znovu",
-                "message": "Něco se pokazilo"
-            },
-            "sms_failed": {
-                "instruction": "Zkopírujte odkaz do telefonu",
-                "message": "Něco se pokazilo"
-            },
-            "sms_overuse": {
-                "instruction": "Zkopírujte odkaz do telefonu",
-                "message": "Příliš mnoho neúspěšných pokusů"
-            },
-            "unsupported_file": {
-                "instruction": "Zkuste použít soubor JPG nebo PNG",
-                "message": "Typ souboru není podporován"
-            }
-        },
-        "lazy_load_placeholder": "Nahrávání...",
-        "loading": "Načítání"
-    },
-    "get_link": {
-        "alert_wrong_number": "Zkontrolujte, zda je vaše číslo správné",
-        "button_copied": "Zkopírováno",
-        "button_copy": "Kopírovat",
-        "button_submit": "Odeslat odkaz",
-        "info_qr_how": "Jak naskenovat kód QR",
-        "info_qr_how_list_item_camera": "Namiřte fotoaparát telefonu na kód QR",
-        "info_qr_how_list_item_download": "Pokud to nefunguje, stáhněte si z Google Play nebo App Store skener QR kódů",
-        "link_divider": "nebo zvolit alternativní metodu",
-        "link_qr": "Naskenování kódu QR",
-        "link_sms": "Získat odkaz prostřednictvím SMS",
-        "link_url": "Kopírovat odkaz",
-        "loader_sending": "Odesílání",
-        "number_field_input_placeholder": "Zadejte číslo mobilního telefonu",
-        "number_field_label": "Zadejte své mobilní číslo:",
-        "subtitle_qr": "Naskenujte kód QR pomocí telefonu",
-        "subtitle_sms": "Odeslání tohoto jednorázového odkazu do telefonu",
-        "subtitle_url": "Odeslání tohoto jednorázového odkazu do telefonu",
-        "title": "Získejte zabezpečený odkaz",
-        "url_field_label": "Zkopírujte odkaz do mobilního prohlížeče"
-    },
-    "livenessV2": {
-        "error_reload_instructions": "Pokyny pro opětovné nahrávání",
-        "intro_note_no1": "Nejprve umístěte obličej do záběru",
-        "intro_note_no2": "Pak pomalu otáčejte hlavu na obě strany",
-        "intro_ready_button": "Mějte prosím na paměti, že budeme zaznamenávat vaši tvář a pozadí obrazu",
-        "intro_subtitle": "Tím se ověří, že jste skutečná osoba",
-        "intro_warning": "Mějte prosím na paměti, že budeme zaznamenávat vaši tvář a pozadí obrazu",
-        "success_main_button": "Odeslat ověření",
-        "success_title": "To je vše, co potřebujeme, abychom mohli začít ověřovat vaši totožnost"
-    },
-    "mobilePhrases": {
-        "photo_upload": {
-            "body_id_back": "Vyfoťte zadní stranu občanského průkazu",
-            "body_id_front": "Vyfoťte přední stranu občanského průkazu",
-            "body_license_back": "Vyfoťte zadní stranu řidičského průkazu",
-            "body_license_front": "Vyfoťte přední stranu řidičského průkazu",
-            "body_passport": "Vyfoťte si stránku s fotografií v pasu",
-            "body_selfie": "Pořiďte si selfie se svým obličejem"
-        },
-        "selfie_capture": {
-            "alert": {
-                "camera_inactive": {
-                    "detail": "Místo toho pořiďte fotografii v <fallback>základním režimu kamery<\/fallback>"
-                },
-                "camera_not_working": {
-                    "detail": "Místo toho pořiďte fotografii v <fallback>základním režimu kamery<\/fallback>"
-                }
-            }
-        },
-        "upload_guide": {
-            "button_primary": "Vyfoťte se",
-            "title": "Nahrávání pasové fotografie"
-        }
-    },
-    "outro": {
-        "body": "To je vše, co potřebujeme, abychom mohli začít ověřovat vaši totožnost",
-        "body_government_letter": "Pro dosažení nejlepších výsledků použijte celou stránku dokumentu",
-        "title": "Děkujeme"
-    },
-    "permission": {
-        "body_both": "Bez použití kamery a mikrofonu vás nemůžeme ověřit",
-        "body_cam": "Bez kamery vás nemůžeme ověřit",
-        "button_primary_both": "Povolte obě možnosti",
-        "button_primary_cam": "Povolení kamery",
-        "subtitle_both": "Po výzvě musíte povolit přístup pro obě možnosti, potom můžete pokračovat",
-        "subtitle_cam": "Po výzvě musíte povolit přístup ke kameře, abyste mohli pokračovat dále",
-        "title_both": "Povolení přístupu ke kameře a mikrofonu",
-        "title_cam": "Povolení přístupu ke kameře"
-    },
-    "permission_recovery": {
-        "button_primary": "Obnovit",
-        "info": "Obnova",
-        "list_header_both": "Podle následujících kroků obnovíte přístup k oběma přístrojům:",
-        "list_header_cam": "Podle následujících kroků obnovíte přístup ke kameře:",
-        "list_item_action_cam": "Obnovením této stránky znovu spustíte proces ověření totožnosti",
-        "list_item_how_to_both": "Povolení přístupu ke kameře a mikrofonu v nastavení prohlížeče",
-        "list_item_how_to_cam": "Udělení přístupu ke kameře v nastavení prohlížeče",
-        "subtitle_both": "Obnovení přístupu ke kameře a mikrofonu pro pořízení videa a dokončení procesu ověřování",
-        "subtitle_cam": "Obnovení přístupu ke kameře a další ověřování",
-        "subtitle_cam_old": "Obnovení přístupu ke kameře pro další ověřování obličeje",
-        "title_both": "Zamezení přístupu ke kameře a mikrofonu",
-        "title_cam": "Přístup ke kameře byl odepřen"
-    },
+    "lazy_load_placeholder": "Nahrávání...",
+    "loading": "Načítání"
+  },
+  "get_link": {
+    "alert_wrong_number": "Zkontrolujte, zda je vaše číslo správné",
+    "button_copied": "Zkopírováno",
+    "button_copy": "Kopírovat",
+    "button_submit": "Odeslat odkaz",
+    "info_qr_how": "Jak naskenovat kód QR",
+    "info_qr_how_list_item_camera": "Namiřte fotoaparát telefonu na kód QR",
+    "info_qr_how_list_item_download": "Pokud to nefunguje, stáhněte si z Google Play nebo App Store skener QR kódů",
+    "link_divider": "nebo zvolit alternativní metodu",
+    "link_qr": "Naskenování kódu QR",
+    "link_sms": "Získat odkaz prostřednictvím SMS",
+    "link_url": "Kopírovat odkaz",
+    "loader_sending": "Odesílání",
+    "number_field_input_placeholder": "Zadejte číslo mobilního telefonu",
+    "number_field_label": "Zadejte své mobilní číslo:",
+    "subtitle_qr": "Naskenujte kód QR pomocí telefonu",
+    "subtitle_sms": "Odeslání tohoto jednorázového odkazu do telefonu",
+    "subtitle_url": "Odeslání tohoto jednorázového odkazu do telefonu",
+    "title": "Získejte zabezpečený odkaz",
+    "url_field_label": "Zkopírujte odkaz do mobilního prohlížeče"
+  },
+  "livenessV2": {
+    "error_reload_instructions": "Pokyny pro opětovné nahrávání",
+    "intro_note_no1": "Nejprve umístěte obličej do záběru",
+    "intro_note_no2": "Pak pomalu otáčejte hlavu na obě strany",
+    "intro_ready_button": "Mějte prosím na paměti, že budeme zaznamenávat vaši tvář a pozadí obrazu",
+    "intro_subtitle": "Tím se ověří, že jste skutečná osoba",
+    "intro_warning": "Mějte prosím na paměti, že budeme zaznamenávat vaši tvář a pozadí obrazu",
+    "success_main_button": "Odeslat ověření",
+    "success_title": "To je vše, co potřebujeme, abychom mohli začít ověřovat vaši totožnost"
+  },
+  "mobilePhrases": {
     "photo_upload": {
-        "body_bank_statement": "Pro dosažení nejlepších výsledků použijte celou stránku dokumentu",
-        "body_benefits_letter": "Pro dosažení nejlepších výsledků použijte celou stránku dokumentu",
-        "body_bill": "Pro dosažení nejlepších výsledků použijte celou stránku dokumentu",
-        "body_id_back": "Nahrání zadní strany karty z počítače",
-        "body_id_front": "Nahrát přední stranu karty z počítače",
-        "body_license_back": "Nahrání zadní části licence z počítače",
-        "body_license_front": "Nahrání přední části licence z počítače",
-        "body_passport": "Nahrát pasovou fotografii z počítače",
-        "body_selfie": "Nahrání selfie z počítače",
-        "body_tax_letter": "Pro dosažení nejlepších výsledků použijte celou stránku dokumentu",
-        "button_take_photo": "Vyfotografovat",
-        "button_upload": "Nahrát",
-        "title_selfie": "Selfie"
-    },
-    "poa_cancel": "Zrušit",
-    "poa_err_invalid_file": {
-        "message": "Vyberte jiný soubor.",
-        "ok": "OK",
-        "title": "Neplatný soubor"
-    },
-    "poa_guidance": {
-        "button_primary": "Pokračovat",
-        "instructions": {
-            "address": "Aktuální adresa",
-            "full_name": "Celé jméno",
-            "issue_date": "Datum vydání nebo souhrnné období",
-            "label": "Zachyťte celý dokument a ujistěte se o viditelnosti následujících údajů:",
-            "logo": "Logo"
-        },
-        "subtitle_bank_statement": "Musí být vydáno v <strong>posledních 3 měsících<\/strong>",
-        "subtitle_benefits_letter": "Musí být vydáno v <strong>posledních 12 měsících<\/strong>",
-        "subtitle_bill": "Musí být vydáno v <strong>posledních 3 měsících<\/strong>",
-        "subtitle_tax_letter": "Musí být vydáno v <strong>posledních 12 měsících<\/strong>"
-    },
-    "poa_intro": {
-        "button_primary": "Zahájení ověřování",
-        "list_matches_signup": "Údaj <strong>odpovídá<\/strong> adrese, kterou jste použili při registraci",
-        "list_most_recent": "Je to váš <strong>nejnovější<\/strong> dokument",
-        "list_shows_address": "Zobrazuje vaši <strong>aktuální<\/strong> adresu",
-        "subtitle": "Budete potřebovat dokument, který:",
-        "title": "Nyní ověříme vaši adresu"
-    },
-    "profile_data": {
-        "address_title": "Přidejte svou adresu",
-        "button_continue": "Pokračovat",
-        "components": {
-            "country_select": {
-                "placeholder": "Vybrat zemi"
-            },
-            "nationality_select": {
-                "placeholder": "Vybrat zemi"
-            },
-            "pan": {
-                "placeholder": "ABCDE1234F"
-            },
-            "ssn": {
-                "placeholder": "123-45-6789"
-            },
-            "state_select": {
-                "placeholder": "Vybrat stát"
-            }
-        },
-        "country_of_residence_title": "Země vašeho trvalého pobytu",
-        "field_labels": {
-            "country": "Země",
-            "dob": "Datum narození",
-            "email": "E-mail",
-            "first_name": "Křestní jméno",
-            "gbr_specific": {
-                "postcode": "Poštovní směrovací číslo",
-                "town": "Město\/obec"
-            },
-            "last_name": "Příjmení",
-            "line1": "Řádek adresy 1",
-            "line2": "Řádek adresy 2",
-            "line3": "Řádek adresy 3",
-            "mobile_number": "Číslo mobilního telefonu",
-            "nationality": "Státní příslušnost",
-            "pan": "Číslo trvalého účtu (PAN)",
-            "postcode": "Poštovní směrovací číslo",
-            "ssn": "Číslo sociálního pojištění (SSN)",
-            "town": "Město",
-            "usa_specific": {
-                "line1_helper_text": "Ulice, například: 200 Albert Street",
-                "line2_helper_text": "Byt, apartmá, bytová jednotka atd.",
-                "postcode": "Poštovní směrovací číslo",
-                "state": "Stát"
-            }
-        },
-        "field_optional": "(volitelná položka)",
-        "field_validation": {
-            "gbr_specific": {
-                "required_postcode": "Zadejte své poštovní směrovací číslo",
-                "too_long_postcode": "Poštovní směrovací číslo je příliš dlouhé",
-                "too_short_postcode": "Poštovní směrovací číslo je příliš krátké"
-            },
-            "invalid": "Zkontrolujte, zda zde nejsou neplatné znaky nebo symboly",
-            "invalid_dob": "Zadejte platné datum narození",
-            "required_country": "Vyberte zemi",
-            "required_dob": "Zadejte své datum narození",
-            "required_email": "Zadejte svůj e-mail",
-            "required_first_name": "Zadejte své křestní jméno",
-            "required_last_name": "Zadejte své příjmení",
-            "required_line1": "Zadejte svou adresu",
-            "required_mobile_number": "Zkontrolujte správnost svého čísla",
-            "required_nationality": "Vyberte zemi",
-            "required_pan": "Zadejte své PAN",
-            "required_postcode": "Zadejte své poštovní směrovací číslo",
-            "required_ssn": "Zadejte své číslo SSN",
-            "too_long__line1": "Adresní řádek je příliš dlouhý",
-            "too_long_first_name": "Křestní jméno je příliš dlouhé",
-            "too_long_last_name": "Příjmení je příliš dlouhé",
-            "too_long_postcode": "Poštovní směrovací číslo je příliš dlouhé",
-            "too_long_town": "Název města je příliš dlouhý",
-            "too_short_first_name": "Křestní jméno je příliš krátké",
-            "too_short_last_name": "Příjmení je příliš krátké",
-            "too_short_postcode": "Poštovní směrovací číslo je příliš krátké",
-            "usa_specific": {
-                "required_state": "Vyberte stát"
-            },
-            "valid_email": "Zadejte platný e-mail",
-            "valid_mobile_number": "Zadejte platné mobilní číslo",
-            "valid_pan": "Zadejte platné PAN",
-            "valid_ssn": "Zadejte platné číslo SSN"
-        },
-        "personal_information_title": "Přidejte své osobní údaje",
-        "prompt": {
-            "details_timeout": "Začít znovu",
-            "header_timeout": "Vypadá to, že vám to trvalo příliš dlouho"
-        }
-    },
-    "retry_feedback": {
-        "button_primary": "Zkuste to znovu"
-    },
-    "retry_feedback_id_expired": {
-        "subtitle": "Zkuste to znovu s platným průkazem totožnosti s fotografií a ujistěte se, že jsou vaše údaje jasně viditelné.",
-        "title": "Platnost vašeho dokumentu vypršela"
-    },
-    "retry_feedback_id_generic": {
-        "subtitle": "Zkuste to znovu s platným průkazem totožnosti s fotografií a ujistěte se, že jsou vaše údaje jasně viditelné.",
-        "title": "Došlo k problému ve vašem dokumentu"
-    },
-    "retry_feedback_id_unaccepted": {
-        "subtitle": "Zkuste to znovu s platným průkazem totožnosti s fotografií a ujistěte se, že jsou vaše údaje jasně viditelné.",
-        "title": "Neakceptovatelný dokument"
-    },
-    "retry_feedback_selfie_generic": {
-        "subtitle": "Zkuste to znovu a ujistěte se, že je váš obličej viditelný a dobře osvětlený.",
-        "title": "Došlo k problému s vaším selfie"
+      "body_id_back": "Vyfoťte zadní stranu občanského průkazu",
+      "body_id_front": "Vyfoťte přední stranu občanského průkazu",
+      "body_license_back": "Vyfoťte zadní stranu řidičského průkazu",
+      "body_license_front": "Vyfoťte přední stranu řidičského průkazu",
+      "body_passport": "Vyfoťte si stránku s fotografií v pasu",
+      "body_selfie": "Pořiďte si selfie se svým obličejem"
     },
     "selfie_capture": {
-        "alert": {
-            "camera_inactive": {
-                "detail": "Zkontrolujte připojení a funkčnost. V ověřování <fallback>můžete pokračovat v mobilním telefonu<\/fallback>",
-                "detail_no_fallback": "Ujistěte se, že má vaše zařízení funkční kameru",
-                "title": "Nefunguje kamera?"
-            },
-            "camera_not_working": {
-                "detail": "Může být odpojena. <fallback>Zkuste místo toho použít telefon<\/fallback>.",
-                "detail_no_fallback": "Ujistěte se, že kamera vašeho zařízení funguje",
-                "title": "Nefunguje kamera"
-            },
-            "timeout": {
-                "detail": "Po dokončení nezapomeňte stisknout tlačítko <fallback>Přepracování akcí videa<\/fallback>",
-                "title": "Vypadá to, že vám to trvalo příliš dlouho"
-            }
+      "alert": {
+        "camera_inactive": {
+          "detail": "Místo toho pořiďte fotografii v <fallback>základním režimu kamery</fallback>"
         },
-        "body": "Držte obličej v oválu",
-        "button_accessibility": "",
-        "button_primary": "Spuštění skenování obličeje",
-        "frame_accessibility": "Pohled z kamery",
-        "title": "Držte obličej v oválu"
-    },
-    "selfie_confirmation": {
-        "image_accessibility": "Fotografie vašeho obličeje",
-        "subtitle": "Ujistěte se, že je vidět celý váš obličej",
-        "title": "Zkontrolujte si své selfie"
-    },
-    "selfie_intro": {
-        "button_primary": "Pokračovat",
-        "list_accessibility": "Tipy, jak pořídit dobré selfie",
-        "list_item_face_forward": "Dívejte se dopředu a ujistěte se, že máte dobře viditelné oči",
-        "list_item_no_glasses": "V případě potřeby si sundejte brýle",
-        "subtitle": "Porovnáme to s vaším dokumentem",
-        "title": "Pořiďte si selfie"
-    },
-    "sms_sent": {
-        "info": "Tipy",
-        "info_link_expire": "Platnost vašeho odkazu vyprší za hodinu",
-        "info_link_window": "Při používání mobilního telefonu nechte toto okno otevřené",
-        "link": "Znovu odešlete odkaz",
-        "subtitle": "Odeslali jsme zabezpečený odkaz na %{number}",
-        "subtitle_minutes": "Může trvat několik minut, než dorazí",
-        "title": "Zkontrolujte svůj mobilní telefon"
-    },
-    "switch_phone": {
-        "info": "Tipy",
-        "info_link_expire": "Platnost vašeho mobilního odkazu vyprší za jednu hodinu",
-        "info_link_refresh": "Neobnovujte tuto stránku",
-        "info_link_window": "Při používání mobilního telefonu nechte toto okno otevřené",
-        "link": "Zrušit",
-        "subtitle": "Jakmile dokončíte tento krok, přejdeme k dalšímu kroku",
-        "title": "Připojení k mobilnímu telefonu"
+        "camera_not_working": {
+          "detail": "Místo toho pořiďte fotografii v <fallback>základním režimu kamery</fallback>"
+        }
+      }
     },
     "upload_guide": {
-        "button_primary": "Nahrajte fotografii",
-        "image_detail_blur_alt": "Příklad rozmazaného dokumentu",
-        "image_detail_blur_label": "Všechny detaily musí být jasné - nic nesmí být rozmazané",
-        "image_detail_cutoff_label": "Zobrazit všechny podrobnosti - včetně spodních 2 řádků",
-        "image_detail_glare_label": "Odstupte od přímého světla - žádné oslnění",
-        "image_detail_good_label": "Na fotografii musí být jasně vidět váš dokument",
-        "subtitle": "Skeny a fotokopie nemohou být akceptovány",
-        "title": "Nahrávání pasové fotografie"
-    },
-    "user_consent": {
-        "button_primary": "Accept",
-        "button_secondary": "Do not accept",
-        "prompt": {
-            "button_primary": "Review again",
-            "button_secondary": "Yes, don’t verify me",
-            "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
-            "no_consent_title": "Are you sure?"
-        }
-    },
-    "user_consent_load_fail": {
-        "button_primary": "Reload screen",
-        "detail": "Check that your connection is stable, then try again",
-        "title": "Content failed to load"
-    },
-    "video_capture": {
-        "body": "Držte obličej v oválu",
-        "body_record": "Až budete připraveni, stiskněte tlačítko",
-        "body_stop": "Po dokončení stiskněte tlačítko stop",
-        "button_primary_finish": "Dokončení nahrávání",
-        "button_primary_next": "Další krok",
-        "button_primary_start": "Spuštění nahrávání",
-        "button_record_accessibility": "Spuštění nahrávání",
-        "frame_accessibility": "Pohled z kamery",
-        "header": {
-            "challenge_digit_instructions": "Vyslovte každou číslici nahlas",
-            "challenge_turn_forward": "pak se otočte dopředu",
-            "challenge_turn_left": "Otočte hlavu doleva",
-            "challenge_turn_right": "Otočte hlavu doprava"
-        },
-        "prompt": {
-            "header_timeout": "Vypadá to, že vám to trvalo příliš dlouho"
-        }
-    },
-    "video_confirmation": {
-        "body": "Vaše video bylo nahráno",
-        "button_primary": "Nahrát video",
-        "button_secondary": "Znovu pořídit video",
-        "title": "Zkontrolujte své video",
-        "video_accessibility": "Přehrání nahraného videa"
-    },
-    "video_intro": {
-        "button_primary": "Nahrávání videa",
-        "list_accessibility": "Akce pro nahrávání selfie videa",
-        "list_item_actions": "Na dokončení máte 20 sekund",
-        "list_item_speak": "Postupujte podle pokynů k pohybu nebo mluvení",
-        "title": "Nahrajte video"
-    },
-    "welcome": {
-        "doc_video_subtitle": "",
-        "list_header_doc_video": "Nahrávejte pomocí svého zařízení:",
-        "list_header_webcam": "K fotografování použijte webovou kameru nebo telefon:",
-        "list_item_doc": "váš doklad totožnosti",
-        "list_item_doc_video_timeout": "Nahrávání je omezeno na <timeout><\/timeout> sekund",
-        "list_item_poa": "vás doklad o adrese",
-        "list_item_selfie": "váš obličej",
-        "next_button": "Vyberte dokument",
-        "start_workflow_button": "Zahájit proces ověřování",
-        "subtitle": "Mělo by to trvat několik minut",
-        "title": "Potvrďte svou totožnost"
-    },
-    "workflow_complete": {
-        "pass": {
-            "description": "Podařilo se nám ověřit vaši totožnost",
-            "title": "Úspěšný výsledek"
-        },
-        "reject": {
-            "description": "Nepodařilo se nám ověřit vaši totožnost.",
-            "title": "Odmítnuto"
-        }
-    },
-    "workflow_erros": {
-        "generic_title": "Došlo k chybě serveru!",
-        "no_workflow_run_id": "ID pro spuštění pracovního postupu není nastaveno.",
-        "reload_app": "Zkuste aplikaci znovu načíst a opakujte akci.",
-        "task_not_completed": "Nelze dokončit úlohu pracovního postupu.",
-        "task_not_retrieved": "Nepodařilo se načíst úlohu pracovního postupu.",
-        "task_not_supported": "Úloha není aktuálně podporována"
+      "button_primary": "Vyfoťte se",
+      "title": "Nahrávání pasové fotografie"
     }
+  },
+  "outro": {
+    "body": "To je vše, co potřebujeme, abychom mohli začít ověřovat vaši totožnost",
+    "body_government_letter": "Pro dosažení nejlepších výsledků použijte celou stránku dokumentu",
+    "title": "Děkujeme"
+  },
+  "permission": {
+    "body_both": "Bez použití kamery a mikrofonu vás nemůžeme ověřit",
+    "body_cam": "Bez kamery vás nemůžeme ověřit",
+    "button_primary_both": "Povolte obě možnosti",
+    "button_primary_cam": "Povolení kamery",
+    "subtitle_both": "Po výzvě musíte povolit přístup pro obě možnosti, potom můžete pokračovat",
+    "subtitle_cam": "Po výzvě musíte povolit přístup ke kameře, abyste mohli pokračovat dále",
+    "title_both": "Povolení přístupu ke kameře a mikrofonu",
+    "title_cam": "Povolení přístupu ke kameře"
+  },
+  "permission_recovery": {
+    "button_primary": "Obnovit",
+    "info": "Obnova",
+    "list_header_both": "Podle následujících kroků obnovíte přístup k oběma přístrojům:",
+    "list_header_cam": "Podle následujících kroků obnovíte přístup ke kameře:",
+    "list_item_action_cam": "Obnovením této stránky znovu spustíte proces ověření totožnosti",
+    "list_item_how_to_both": "Povolení přístupu ke kameře a mikrofonu v nastavení prohlížeče",
+    "list_item_how_to_cam": "Udělení přístupu ke kameře v nastavení prohlížeče",
+    "subtitle_both": "Obnovení přístupu ke kameře a mikrofonu pro pořízení videa a dokončení procesu ověřování",
+    "subtitle_cam": "Obnovení přístupu ke kameře a další ověřování",
+    "subtitle_cam_old": "Obnovení přístupu ke kameře pro další ověřování obličeje",
+    "title_both": "Zamezení přístupu ke kameře a mikrofonu",
+    "title_cam": "Přístup ke kameře byl odepřen"
+  },
+  "photo_upload": {
+    "body_bank_statement": "Pro dosažení nejlepších výsledků použijte celou stránku dokumentu",
+    "body_benefits_letter": "Pro dosažení nejlepších výsledků použijte celou stránku dokumentu",
+    "body_bill": "Pro dosažení nejlepších výsledků použijte celou stránku dokumentu",
+    "body_id_back": "Nahrání zadní strany karty z počítače",
+    "body_id_front": "Nahrát přední stranu karty z počítače",
+    "body_license_back": "Nahrání zadní části licence z počítače",
+    "body_license_front": "Nahrání přední části licence z počítače",
+    "body_passport": "Nahrát pasovou fotografii z počítače",
+    "body_selfie": "Nahrání selfie z počítače",
+    "body_tax_letter": "Pro dosažení nejlepších výsledků použijte celou stránku dokumentu",
+    "button_take_photo": "Vyfotografovat",
+    "button_upload": "Nahrát",
+    "title_selfie": "Selfie"
+  },
+  "poa_cancel": "Zrušit",
+  "poa_err_invalid_file": {
+    "message": "Vyberte jiný soubor.",
+    "ok": "OK",
+    "title": "Neplatný soubor"
+  },
+  "poa_guidance": {
+    "button_primary": "Pokračovat",
+    "instructions": {
+      "address": "Aktuální adresa",
+      "full_name": "Celé jméno",
+      "issue_date": "Datum vydání nebo souhrnné období",
+      "label": "Zachyťte celý dokument a ujistěte se o viditelnosti následujících údajů:",
+      "logo": "Logo"
+    },
+    "subtitle_bank_statement": "Musí být vydáno v <strong>posledních 3 měsících</strong>",
+    "subtitle_benefits_letter": "Musí být vydáno v <strong>posledních 12 měsících</strong>",
+    "subtitle_bill": "Musí být vydáno v <strong>posledních 3 měsících</strong>",
+    "subtitle_tax_letter": "Musí být vydáno v <strong>posledních 12 měsících</strong>"
+  },
+  "poa_intro": {
+    "button_primary": "Zahájení ověřování",
+    "list_matches_signup": "Údaj <strong>odpovídá</strong> adrese, kterou jste použili při registraci",
+    "list_most_recent": "Je to váš <strong>nejnovější</strong> dokument",
+    "list_shows_address": "Zobrazuje vaši <strong>aktuální</strong> adresu",
+    "subtitle": "Budete potřebovat dokument, který:",
+    "title": "Nyní ověříme vaši adresu"
+  },
+  "profile_data": {
+    "address_title": "Přidejte svou adresu",
+    "button_continue": "Pokračovat",
+    "components": {
+      "country_select": {
+        "placeholder": "Vybrat zemi"
+      },
+      "nationality_select": {
+        "placeholder": "Vybrat zemi"
+      },
+      "pan": {
+        "placeholder": "ABCDE1234F"
+      },
+      "ssn": {
+        "placeholder": "123-45-6789"
+      },
+      "state_select": {
+        "placeholder": "Vybrat stát"
+      }
+    },
+    "country_of_residence_title": "Země vašeho trvalého pobytu",
+    "field_labels": {
+      "country": "Země",
+      "dob": "Datum narození",
+      "email": "E-mail",
+      "first_name": "Křestní jméno",
+      "gbr_specific": {
+        "postcode": "Poštovní směrovací číslo",
+        "town": "Město/obec"
+      },
+      "last_name": "Příjmení",
+      "line1": "Řádek adresy 1",
+      "line2": "Řádek adresy 2",
+      "line3": "Řádek adresy 3",
+      "mobile_number": "Číslo mobilního telefonu",
+      "nationality": "Státní příslušnost",
+      "pan": "Číslo trvalého účtu (PAN)",
+      "postcode": "Poštovní směrovací číslo",
+      "ssn": "Číslo sociálního pojištění (SSN)",
+      "town": "Město",
+      "usa_specific": {
+        "line1_helper_text": "Ulice, například: 200 Albert Street",
+        "line2_helper_text": "Byt, apartmá, bytová jednotka atd.",
+        "postcode": "Poštovní směrovací číslo",
+        "state": "Stát"
+      }
+    },
+    "field_optional": "(volitelná položka)",
+    "field_validation": {
+      "gbr_specific": {
+        "required_postcode": "Zadejte své poštovní směrovací číslo",
+        "too_long_postcode": "Poštovní směrovací číslo je příliš dlouhé",
+        "too_short_postcode": "Poštovní směrovací číslo je příliš krátké"
+      },
+      "invalid": "Zkontrolujte, zda zde nejsou neplatné znaky nebo symboly",
+      "invalid_dob": "Zadejte platné datum narození",
+      "required_country": "Vyberte zemi",
+      "required_dob": "Zadejte své datum narození",
+      "required_email": "Zadejte svůj e-mail",
+      "required_first_name": "Zadejte své křestní jméno",
+      "required_last_name": "Zadejte své příjmení",
+      "required_line1": "Zadejte svou adresu",
+      "required_mobile_number": "Zkontrolujte správnost svého čísla",
+      "required_nationality": "Vyberte zemi",
+      "required_pan": "Zadejte své PAN",
+      "required_postcode": "Zadejte své poštovní směrovací číslo",
+      "required_ssn": "Zadejte své číslo SSN",
+      "too_long__line1": "Adresní řádek je příliš dlouhý",
+      "too_long_first_name": "Křestní jméno je příliš dlouhé",
+      "too_long_last_name": "Příjmení je příliš dlouhé",
+      "too_long_postcode": "Poštovní směrovací číslo je příliš dlouhé",
+      "too_long_town": "Název města je příliš dlouhý",
+      "too_short_first_name": "Křestní jméno je příliš krátké",
+      "too_short_last_name": "Příjmení je příliš krátké",
+      "too_short_postcode": "Poštovní směrovací číslo je příliš krátké",
+      "usa_specific": {
+        "required_state": "Vyberte stát"
+      },
+      "valid_email": "Zadejte platný e-mail",
+      "valid_mobile_number": "Zadejte platné mobilní číslo",
+      "valid_pan": "Zadejte platné PAN",
+      "valid_ssn": "Zadejte platné číslo SSN"
+    },
+    "personal_information_title": "Přidejte své osobní údaje",
+    "prompt": {
+      "details_timeout": "Začít znovu",
+      "header_timeout": "Vypadá to, že vám to trvalo příliš dlouho"
+    }
+  },
+  "retry_feedback": {
+    "button_primary": "Zkuste to znovu"
+  },
+  "retry_feedback_id_expired": {
+    "subtitle": "Zkuste to znovu s platným průkazem totožnosti s fotografií a ujistěte se, že jsou vaše údaje jasně viditelné.",
+    "title": "Platnost vašeho dokumentu vypršela"
+  },
+  "retry_feedback_id_generic": {
+    "subtitle": "Zkuste to znovu s platným průkazem totožnosti s fotografií a ujistěte se, že jsou vaše údaje jasně viditelné.",
+    "title": "Došlo k problému ve vašem dokumentu"
+  },
+  "retry_feedback_id_unaccepted": {
+    "subtitle": "Zkuste to znovu s platným průkazem totožnosti s fotografií a ujistěte se, že jsou vaše údaje jasně viditelné.",
+    "title": "Neakceptovatelný dokument"
+  },
+  "retry_feedback_selfie_generic": {
+    "subtitle": "Zkuste to znovu a ujistěte se, že je váš obličej viditelný a dobře osvětlený.",
+    "title": "Došlo k problému s vaším selfie"
+  },
+  "selfie_capture": {
+    "alert": {
+      "camera_inactive": {
+        "detail": "Zkontrolujte připojení a funkčnost. V ověřování <fallback>můžete pokračovat v mobilním telefonu</fallback>",
+        "detail_no_fallback": "Ujistěte se, že má vaše zařízení funkční kameru",
+        "title": "Nefunguje kamera?"
+      },
+      "camera_not_working": {
+        "detail": "Může být odpojena. <fallback>Zkuste místo toho použít telefon</fallback>.",
+        "detail_no_fallback": "Ujistěte se, že kamera vašeho zařízení funguje",
+        "title": "Nefunguje kamera"
+      },
+      "timeout": {
+        "detail": "Po dokončení nezapomeňte stisknout tlačítko <fallback>Přepracování akcí videa</fallback>",
+        "title": "Vypadá to, že vám to trvalo příliš dlouho"
+      }
+    },
+    "body": "Držte obličej v oválu",
+    "button_accessibility": "",
+    "button_primary": "Spuštění skenování obličeje",
+    "frame_accessibility": "Pohled z kamery",
+    "title": "Držte obličej v oválu"
+  },
+  "selfie_confirmation": {
+    "image_accessibility": "Fotografie vašeho obličeje",
+    "subtitle": "Ujistěte se, že je vidět celý váš obličej",
+    "title": "Zkontrolujte si své selfie"
+  },
+  "selfie_intro": {
+    "button_primary": "Pokračovat",
+    "list_accessibility": "Tipy, jak pořídit dobré selfie",
+    "list_item_face_forward": "Dívejte se dopředu a ujistěte se, že máte dobře viditelné oči",
+    "list_item_no_glasses": "V případě potřeby si sundejte brýle",
+    "subtitle": "Porovnáme to s vaším dokumentem",
+    "title": "Pořiďte si selfie"
+  },
+  "sms_sent": {
+    "info": "Tipy",
+    "info_link_expire": "Platnost vašeho odkazu vyprší za hodinu",
+    "info_link_window": "Při používání mobilního telefonu nechte toto okno otevřené",
+    "link": "Znovu odešlete odkaz",
+    "subtitle": "Odeslali jsme zabezpečený odkaz na %{number}",
+    "subtitle_minutes": "Může trvat několik minut, než dorazí",
+    "title": "Zkontrolujte svůj mobilní telefon"
+  },
+  "switch_phone": {
+    "info": "Tipy",
+    "info_link_expire": "Platnost vašeho mobilního odkazu vyprší za jednu hodinu",
+    "info_link_refresh": "Neobnovujte tuto stránku",
+    "info_link_window": "Při používání mobilního telefonu nechte toto okno otevřené",
+    "link": "Zrušit",
+    "subtitle": "Jakmile dokončíte tento krok, přejdeme k dalšímu kroku",
+    "title": "Připojení k mobilnímu telefonu"
+  },
+  "upload_guide": {
+    "button_primary": "Nahrajte fotografii",
+    "image_detail_blur_alt": "Příklad rozmazaného dokumentu",
+    "image_detail_blur_label": "Všechny detaily musí být jasné - nic nesmí být rozmazané",
+    "image_detail_cutoff_label": "Zobrazit všechny podrobnosti - včetně spodních 2 řádků",
+    "image_detail_glare_label": "Odstupte od přímého světla - žádné oslnění",
+    "image_detail_good_label": "Na fotografii musí být jasně vidět váš dokument",
+    "subtitle": "Skeny a fotokopie nemohou být akceptovány",
+    "title": "Nahrávání pasové fotografie"
+  },
+  "user_consent": {
+    "button_primary": "Accept",
+    "button_secondary": "Do not accept",
+    "prompt": {
+      "button_primary": "Review again",
+      "button_secondary": "Yes, don’t verify me",
+      "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
+      "no_consent_title": "Are you sure?"
+    }
+  },
+  "user_consent_load_fail": {
+    "button_primary": "Reload screen",
+    "detail": "Check that your connection is stable, then try again",
+    "title": "Content failed to load"
+  },
+  "video_capture": {
+    "body": "Držte obličej v oválu",
+    "body_record": "Až budete připraveni, stiskněte tlačítko",
+    "body_stop": "Po dokončení stiskněte tlačítko stop",
+    "button_primary_finish": "Dokončení nahrávání",
+    "button_primary_next": "Další krok",
+    "button_primary_start": "Spuštění nahrávání",
+    "button_record_accessibility": "Spuštění nahrávání",
+    "frame_accessibility": "Pohled z kamery",
+    "header": {
+      "challenge_digit_instructions": "Vyslovte každou číslici nahlas",
+      "challenge_turn_forward": "pak se otočte dopředu",
+      "challenge_turn_left": "Otočte hlavu doleva",
+      "challenge_turn_right": "Otočte hlavu doprava"
+    },
+    "prompt": {
+      "header_timeout": "Vypadá to, že vám to trvalo příliš dlouho"
+    }
+  },
+  "video_confirmation": {
+    "body": "Vaše video bylo nahráno",
+    "button_primary": "Nahrát video",
+    "button_secondary": "Znovu pořídit video",
+    "title": "Zkontrolujte své video",
+    "video_accessibility": "Přehrání nahraného videa"
+  },
+  "video_intro": {
+    "button_primary": "Nahrávání videa",
+    "list_accessibility": "Akce pro nahrávání selfie videa",
+    "list_item_actions": "Na dokončení máte 20 sekund",
+    "list_item_speak": "Postupujte podle pokynů k pohybu nebo mluvení",
+    "title": "Nahrajte video"
+  },
+  "welcome": {
+    "doc_video_subtitle": "",
+    "list_header_doc_video": "Nahrávejte pomocí svého zařízení:",
+    "list_header_webcam": "K fotografování použijte webovou kameru nebo telefon:",
+    "list_item_doc": "váš doklad totožnosti",
+    "list_item_doc_video_timeout": "Nahrávání je omezeno na <timeout></timeout> sekund",
+    "list_item_poa": "vás doklad o adrese",
+    "list_item_selfie": "váš obličej",
+    "next_button": "Vyberte dokument",
+    "start_workflow_button": "Zahájit proces ověřování",
+    "subtitle": "Mělo by to trvat několik minut",
+    "title": "Potvrďte svou totožnost"
+  },
+  "workflow_complete": {
+    "pass": {
+      "description": "Podařilo se nám ověřit vaši totožnost",
+      "title": "Úspěšný výsledek"
+    },
+    "reject": {
+      "description": "Nepodařilo se nám ověřit vaši totožnost.",
+      "title": "Odmítnuto"
+    }
+  },
+  "workflow_erros": {
+    "generic_title": "Došlo k chybě serveru!",
+    "no_workflow_run_id": "ID pro spuštění pracovního postupu není nastaveno.",
+    "reload_app": "Zkuste aplikaci znovu načíst a opakujte akci.",
+    "task_not_completed": "Nelze dokončit úlohu pracovního postupu.",
+    "task_not_retrieved": "Nepodařilo se načíst úlohu pracovního postupu.",
+    "task_not_supported": "Úloha není aktuálně podporována"
+  }
 }

--- a/src/locales/de_DE/de_DE.json
+++ b/src/locales/de_DE/de_DE.json
@@ -1,765 +1,765 @@
 {
-    "auth_accessibility": {
-        "back_button": "Abbrechen"
+  "auth_accessibility": {
+    "back_button": "Abbrechen"
+  },
+  "auth_cam_encrypt": {
+    "loader": "Verschlüsselung von Kameraaufnahmen"
+  },
+  "auth_cam_start": {
+    "loader": "Starten der Kamera"
+  },
+  "auth_capture_start": {
+    "body": "Positionieren Sie Ihr Gesicht innerhalb des ovalen Rahmens",
+    "button_primary": "Starten Sie mit dem Scannen des Gesichts",
+    "feedback": {
+      "center_face": "Positionieren Sie Ihr Gesicht im Rahmen",
+      "conditions_too_bright": "Suchen Sie eine weniger helle Umgebung auf",
+      "conditions_too_dark": "Suchen Sie eine hellere Umgebung auf",
+      "head_not_upright": "Halten Sie Ihren Kopf aufrecht",
+      "neutral_expression": "Behalten Sie einen neutralen Gesichtsausdruck",
+      "not_looking_straight": "Schauen Sie nach vorne",
+      "remove_sunglasses": "Nehmen Sie Ihre Sonnenbrille ab",
+      "steady_count_1": "Halten Sie still: 1",
+      "steady_count_2": "Halten Sie still: 2",
+      "steady_count_3": "Halten Sie still: 3"
     },
-    "auth_cam_encrypt": {
-        "loader": "Verschlüsselung von Kameraaufnahmen"
+    "title": "Starten Sie mit dem Scannen des Gesichts"
+  },
+  "auth_capture": {
+    "feedback": {
+      "center_face": "Positionieren Sie Ihr Gesicht im Rahmen",
+      "even_lighting": "Stellen Sie sicher, dass Ihre Beleuchtung gleichmäßig ist",
+      "eye_level": "Halten Sie Ihre Kamera auf Augenhöhe",
+      "face_not_found": "Stellen Sie sicher, dass Ihr Gesicht sichtbar ist",
+      "head_not_upright": "Halten Sie Ihren Kopf aufrecht",
+      "move_back": "Gehen sie jetzt zurück",
+      "move_close": "Rücken Sie jetzt näher heran",
+      "move_closer": "Rücken Sie näher heran",
+      "not_looking_straight": "Schauen Sie nach vorne",
+      "steady": "Halten Sie still"
+    }
+  },
+  "auth_error": {
+    "cam_encryption": {
+      "body": "Diese App blockiert verdächtige Webcam-Konfigurationen. <fallback>Mehr erfahren</fallback>.",
+      "button_primary": "Erneut versuchen",
+      "button_primary_firefox": "Erneut versuchen",
+      "subtitle": "Dieses System kann aufgrund des Folgenden nicht überprüft werden:",
+      "table_header_1": "Mögliches Problem",
+      "table_header_2": "Behebung",
+      "table_row_1_cell_1": "Kamera wird bereits von einer anderen App verwendet.",
+      "table_row_1_cell_1_firefox": "Kameraberechtigungen werden in Firefox nicht gespeichert.",
+      "table_row_1_cell_2": "Die andere App schließen.",
+      "table_row_1_cell_2_firefox": "\"Berechtigungen speichern\" überprüfen.",
+      "table_row_2_cell_1": "Eine Drittanbieter-App modifiziert das Video.",
+      "table_row_2_cell_2": "Die andere App schließen/deinstallieren.",
+      "table_row_3_cell_1": "Hardware kann nicht gesichert werden.",
+      "table_row_3_cell_2": "Anderes Gerät verwenden.",
+      "title": "<b>Problem bei der Verschlüsselung von Kameraaufnahmen</b>"
+    }
+  },
+  "auth_full_screen": {
+    "body": "Dadurch wird die Selfie-Erfassung im Vollbild-Modus gestartet",
+    "button_primary": "Als Vollbild öffnen",
+    "title": "Vollbild-Selfie-Modus"
+  },
+  "auth_permission_denied": {
+    "body_cam": "Um fortzufahren, müssen Sie die Kameraberechtigungen in Ihren Geräteeinstellungen aktivieren.",
+    "button_primary_cam": "Einstellungen starten"
+  },
+  "auth_permission": {
+    "body_cam": "Um fortzufahren, müssen Sie bei Aufforderung die Kameraberechtigungen aktivieren.",
+    "button_primary_cam": "Kamera aktivieren",
+    "title_cam": "Zugriff auf Kamera erlauben"
+  },
+  "auth_progress": {
+    "loader": "Hochladen"
+  },
+  "auth_retry": {
+    "body_blur": "Reinigen Sie Ihr Kameraobjektiv",
+    "body_neutral_expression": "Behalten Sie einen neutralen Gesichtsausdruck",
+    "body_too_bright": "Suchen Sie eine weniger helle Umgebung auf",
+    "button_primary": "Kamera starten",
+    "subtitle": "Wir konnten Ihr Gesicht nicht ordnungsgemäß erfassen",
+    "title": "Scannen Sie Ihr Gesicht erneut"
+  },
+  "auth_upload_pass": {
+    "body": "Hochladen erfolgreich"
+  },
+  "avc_confirmation": {
+    "button_primary_upload": "Aufnahme hochladen",
+    "subtitle": "Ein Video von Ihrem Gesicht wurde erfolgreich aufgenommen",
+    "title": "Aufnahme abgeschlossen"
+  },
+  "avc_connection_error": {
+    "button_primary_reload": "Anweisungen neu laden",
+    "button_primary_retry_upload": "Upload wiederholen",
+    "button_secondary_restart_recording": "Aufnahme neu starten",
+    "subtitle": "Prüfen Sie, ob Ihre Internetverbindung stabil ist, und versuchen Sie es dann erneut",
+    "title": "Verbindungsfehler"
+  },
+  "avc_face_alignment": {
+    "feedback_move_back": "Gehen Sie zurück",
+    "feedback_move_closer": "Rücken Sie näher heran",
+    "feedback_no_face_detected": "Gesicht nicht erkannt",
+    "feedback_not_centered": "Gesicht nicht mittig",
+    "title": "Positionieren Sie Ihr Gesicht im Rahmen"
+  },
+  "avc_face_capture": {
+    "alert": {
+      "timeout_body": "Sie haben maximal 15 Sekunden Zeit, um die Aufnahme zu beenden",
+      "timeout_button_primary": "Wiederholen",
+      "timeout_title": "Leider muss die Aufnahme neu gestartet werden",
+      "too_fast_body": "Bitte versuchen Sie es erneut und drehen Sie Ihren Kopf langsamer",
+      "too_fast_button_primary": "Wiederholen",
+      "too_fast_title": "Sie haben Ihren Kopf zu schnell gedreht"
     },
-    "auth_cam_start": {
-        "loader": "Starten der Kamera"
+    "title": "Drehen Sie Ihren Kopf langsam nach beiden Seiten",
+    "title_completed": "Aufnahme abgeschlossen"
+  },
+  "avc_intro": {
+    "button_primary_ready": "Ich bin fertig",
+    "disclaimer": "Bitte beachten Sie, dass Ihr Gesicht und Ihr Hintergrund aufgenommen wird",
+    "list_item_one": "Positionieren Sie Ihr Gesicht zunächst im Rahmen",
+    "list_item_two": "Drehen Sie Ihren Kopf dann langsam nach beiden Seiten",
+    "subtitle": "Damit verifizieren wir, dass es sich bei Ihnen um eine reale Person handelt",
+    "title": "Video aufnehmen"
+  },
+  "avc_no_face_detected": {
+    "button_primary_restart": "Aufnahme neu starten",
+    "list_item_eyes": "Stellen Sie sicher, dass Ihre Augen deutlich sichtbar sind",
+    "list_item_face": "Zeigen Sie nur Ihr Gesicht, Ihr Ausweis wird nicht benötigt",
+    "list_item_lighting": "Stellen Sie sicher, dass Sie sich an einem Ort mit guter Beleuchtung befinden",
+    "list_item_mask": "Achten Sie darauf, dass Sie Gesichtsmasken oder andere Gegenstände, die Ihr Gesicht verdecken, abnehmen. Brillen sind zulässig",
+    "title": "Wir können Ihr Gesicht nicht erkennen"
+  },
+  "avc_uploading": {
+    "title": "Hochladen"
+  },
+  "country_select": {
+    "alert": {
+      "another_doc": "Dokumente aus diesem Land werden derzeit nicht unterstützt. <fallback>Versuchen Sie es mit einem anderen Dokumententyp</fallback>."
     },
-    "auth_capture_start": {
-        "body": "Positionieren Sie Ihr Gesicht innerhalb des ovalen Rahmens",
-        "button_primary": "Starten Sie mit dem Scannen des Gesichts",
-        "feedback": {
-            "center_face": "Positionieren Sie Ihr Gesicht im Rahmen",
-            "conditions_too_bright": "Suchen Sie eine weniger helle Umgebung auf",
-            "conditions_too_dark": "Suchen Sie eine hellere Umgebung auf",
-            "head_not_upright": "Halten Sie Ihren Kopf aufrecht",
-            "neutral_expression": "Behalten Sie einen neutralen Gesichtsausdruck",
-            "not_looking_straight": "Schauen Sie nach vorne",
-            "remove_sunglasses": "Nehmen Sie Ihre Sonnenbrille ab",
-            "steady_count_1": "Halten Sie still: 1",
-            "steady_count_2": "Halten Sie still: 2",
-            "steady_count_3": "Halten Sie still: 3"
-        },
-        "title": "Starten Sie mit dem Scannen des Gesichts"
+    "alert_dropdown": {
+      "country_not_found": "Land nicht gefunden"
     },
-    "auth_capture": {
-        "feedback": {
-            "center_face": "Positionieren Sie Ihr Gesicht im Rahmen",
-            "even_lighting": "Stellen Sie sicher, dass Ihre Beleuchtung gleichmäßig ist",
-            "eye_level": "Halten Sie Ihre Kamera auf Augenhöhe",
-            "face_not_found": "Stellen Sie sicher, dass Ihr Gesicht sichtbar ist",
-            "head_not_upright": "Halten Sie Ihren Kopf aufrecht",
-            "move_back": "Gehen sie jetzt zurück",
-            "move_close": "Rücken Sie jetzt näher heran",
-            "move_closer": "Rücken Sie näher heran",
-            "not_looking_straight": "Schauen Sie nach vorne",
-            "steady": "Halten Sie still"
-        }
+    "button_primary": "Dokument einreichen",
+    "poa_alert": {
+      "country_not_found": "Entschuldigen Sie bitte. Wir arbeiten an der Unterstützung von mehr Ländern.",
+      "intro": "Ihr Land ist nicht aufgeführt?"
     },
-    "auth_error": {
-        "cam_encryption": {
-            "body": "Diese App blockiert verdächtige Webcam-Konfigurationen. <fallback>Mehr erfahren<\/fallback>.",
-            "button_primary": "Erneut versuchen",
-            "button_primary_firefox": "Erneut versuchen",
-            "subtitle": "Dieses System kann aufgrund des Folgenden nicht überprüft werden:",
-            "table_header_1": "Mögliches Problem",
-            "table_header_2": "Behebung",
-            "table_row_1_cell_1": "Kamera wird bereits von einer anderen App verwendet.",
-            "table_row_1_cell_1_firefox": "Kameraberechtigungen werden in Firefox nicht gespeichert.",
-            "table_row_1_cell_2": "Die andere App schließen.",
-            "table_row_1_cell_2_firefox": "\"Berechtigungen speichern\" überprüfen.",
-            "table_row_2_cell_1": "Eine Drittanbieter-App modifiziert das Video.",
-            "table_row_2_cell_2": "Die andere App schließen\/deinstallieren.",
-            "table_row_3_cell_1": "Hardware kann nicht gesichert werden.",
-            "table_row_3_cell_2": "Anderes Gerät verwenden.",
-            "title": "<b>Problem bei der Verschlüsselung von Kameraaufnahmen<\/b>"
-        }
+    "search": {
+      "accessibility": "Land auswählen",
+      "input_placeholder": "z.B. Deutschland",
+      "label": "Suche nach Land"
     },
-    "auth_full_screen": {
-        "body": "Dadurch wird die Selfie-Erfassung im Vollbild-Modus gestartet",
-        "button_primary": "Als Vollbild öffnen",
-        "title": "Vollbild-Selfie-Modus"
+    "title": "Ausstellungsland auswählen"
+  },
+  "cross_device_checklist": {
+    "button_primary": "Bestätigung senden",
+    "info": "Tipps",
+    "list_item_doc_multiple": "Dokumente hochgeladen",
+    "list_item_doc_one": "Dokument hochgeladen",
+    "list_item_poa": "Adressnachweis",
+    "list_item_selfie": "Selfie hochgeladen",
+    "list_item_video": "Video hochgeladen",
+    "subtitle": "Hier ist alles, was Sie hochgeladen haben:",
+    "title": "Ein letzter Schritt"
+  },
+  "cross_device_error_desktop": {
+    "subtitle": "Der Link funktioniert nur auf mobilen Geräten",
+    "title": "Etwas ist schiefgelaufen"
+  },
+  "cross_device_error_restart": {
+    "subtitle": "Sie müssen Ihre Verifizierung auf Ihrem Computer neu starten",
+    "title": "Etwas ist schiefgelaufen"
+  },
+  "cross_device_intro": {
+    "button_primary": "Sicherheitslink erhalten",
+    "list_accessibility": "Erforderliche Schritte zur weiteren Verifizierung auf Ihrem Mobiltelefon",
+    "list_item_finish": "Überprüfen Sie alle Eingaben und Daten, um die Einreichung abzuschließen",
+    "list_item_open_link": "Öffnen Sie den Link und führen Sie die Aktionen aus",
+    "list_item_send_phone": "Senden Sie einen Sicherheitslink an Ihr Mobiltelefon",
+    "subtitle": "So geht’s:",
+    "title": "Fahren Sie mit Ihrem Mobiltelefon fort"
+  },
+  "cross_device_return": {
+    "body": "Die Aktualisierung Ihres Computers kann einige Sekunden dauern",
+    "subtitle": "Sie können nun zu Ihrem Computer zurückkehren, um fortzufahren",
+    "title": "Uploads erfolgreich!"
+  },
+  "cross_device_session_linked": {
+    "button_primary": "Fortfahren",
+    "info": "Überprüfen Sie bitte",
+    "list_item_desktop_open": "Ihr Desktop-Fenster bleibt geöffnet",
+    "list_item_sent_by_you": "Dieser Link wurde von Ihnen gesendet - lassen Sie sich beraten, wenn Sie glauben, dass es sich um einen Betrug handeln könnte",
+    "subtitle": "Fahren Sie mit der Überprüfung fort",
+    "title": "Mit Ihrem Computer verbunden"
+  },
+  "doc_capture": {
+    "button_primary": "Starten Sie mit dem Scannen des Dokuments",
+    "detail": {
+      "folded_doc_front": "Legen Sie Ihr Dokument flach hin, einschließlich aller Innenseiten (Ihr Foto muss enthalten sein)"
     },
-    "auth_permission_denied": {
-        "body_cam": "Um fortzufahren, müssen Sie die Kameraberechtigungen in Ihren Geräteeinstellungen aktivieren.",
-        "button_primary_cam": "Einstellungen starten"
+    "header_folded_doc_front": "Profilfotoseite",
+    "prompt": {
+      "button_card": "Plastikkarte",
+      "button_paper": "Papierdokument",
+      "title_id": "Welche Art von Personalausweis haben Sie?",
+      "title_license": "Welche Art von Führerschein haben Sie?"
+    }
+  },
+  "doc_confirmation": {
+    "alert": {
+      "blur_detail": "Stellen Sie sicher, dass alles klar ist",
+      "blur_title": "Unscharfes Foto erkannt",
+      "crop_detail": "Stellen Sie sicher, dass das vollständige Dokument zu sehen ist",
+      "crop_title": "Abgeschnittenes Bild erkannt",
+      "glare_detail": "Versuchen Sie, sich von direktem Licht zu entfernen",
+      "glare_title": "Spiegelung erkannt",
+      "no_doc_detail": "Stellen Sie sicher, dass das gesamte Dokument auf dem Foto zu sehen ist",
+      "no_doc_title": "Kein Dokument erkannt."
     },
-    "auth_permission": {
-        "body_cam": "Um fortzufahren, müssen Sie bei Aufforderung die Kameraberechtigungen aktivieren.",
-        "button_primary_cam": "Kamera aktivieren",
-        "title_cam": "Zugriff auf Kamera erlauben"
+    "body": "Überprüfen Sie, dass Sie die gesamte Dokumentseite hochgeladen haben, und dass man die Details ohne Unschärfen und blendfrei lesen kann",
+    "body_bank_statement": "Überprüfen Sie, dass Sie die gesamte Dokumentseite hochgeladen haben, und dass man die Details ohne Unschärfen und blendfrei lesen kann",
+    "body_benefits_letter": "Überprüfen Sie, dass Sie die gesamte Dokumentseite hochgeladen haben, und dass man die Details ohne Unschärfen und blendfrei lesen kann",
+    "body_bill": "Überprüfen Sie, dass Sie die gesamte Dokumentseite hochgeladen haben, und dass man die Details ohne Unschärfen und blendfrei lesen kann",
+    "body_id": "Die Reisepass-Details müssen deutlich lesbar sein, ohne Unschärfe oder Spiegelung",
+    "body_image_medium": "Es wird länger dauern, Sie zu verifizieren, wenn wir es nicht lesen können",
+    "body_image_poor": "Um Sie reibungslos zu verifizieren, benötigen wir ein besseres Foto",
+    "body_license": "Die Reisepass-Details müssen deutlich lesbar sein, ohne Unschärfe oder Spiegelung",
+    "body_passport": "Die Reisepass-Details müssen deutlich lesbar sein, ohne Unschärfe oder Spiegelung",
+    "body_permit": "Die Reisepass-Details müssen deutlich lesbar sein, ohne Unschärfe oder Spiegelung",
+    "body_tax_letter": "Überprüfen Sie, dass Sie die gesamte Dokumentseite hochgeladen haben, und dass man die Details ohne Unschärfen und blendfrei lesen kann",
+    "button_close": "Schließen",
+    "button_primary_redo": "Wiederholen",
+    "button_primary_upload": "Hochladen",
+    "button_primary_upload_anyway": "Trotzdem hochladen",
+    "button_secondary_redo": "Wiederholen",
+    "button_zoom": "Bild vergrößern",
+    "image_accessibility": "Foto Ihres Dokuments",
+    "title": "Überprüfen Sie Ihr Bild"
+  },
+  "doc_multi_frame_capture": {
+    "capture_progress_title": "Dokument wird gescannt",
+    "instructions_title_back": "Positionieren Sie die Rückseite Ihres Dokuments im Rahmen",
+    "instructions_title_front": "Positionieren Sie die Vorderseite Ihres Dokuments im Rahmen"
+  },
+  "doc_select": {
+    "button_bank_statement": "Bankauszug",
+    "button_bank_statement_non_uk": "Bankauszug",
+    "button_benefits_letter": "Sozialleistungsschreiben",
+    "button_benefits_letter_detail": "Von der Regierung autorisierte Sozialleistungen, wie z. B. Arbeitslosenhilfe, Wohngeld, Steuerermäßigung",
+    "button_bill": "Betriebskostenabrechnung",
+    "button_bill_detail": "Gas, Strom, Wasser, Festnetz oder Breitband-Internet",
+    "button_government_letter": "Staatliches Schreiben",
+    "button_government_letter_detail": "Jede Art vom Staat ausgestelltes Schreiben, z. B. Sozialleistungsschreiben, Wahlbenachrichtigung, Schreiben vom Finanzamt usw.",
+    "button_id": "Nationaler Personalausweis",
+    "button_id_detail": "Vorder- und Rückseite",
+    "button_license": "Führerschein",
+    "button_license_detail": "Vorder- und Rückseite",
+    "button_passport": "Reisepass",
+    "button_passport_detail": "Seite mit Foto",
+    "button_permit": "Karte der Aufenthaltsgenehmigung",
+    "button_permit_detail": "Vorder- und Rückseite",
+    "button_tax_letter": "Gemeindesteuerschreiben",
+    "extra_estatements_ok": "E-Auszüge werden akzeptiert",
+    "extra_no_mobile": "Entschuldigen Sie bitte, keine Mobiltelefonrechnungen",
+    "list_accessibility": "Dokumente, die Sie zur Überprüfung Ihrer Identität verwenden können",
+    "pill": "Schnellste",
+    "section": {
+      "header_country": "Ausstellendes Land",
+      "header_doc_type": "Akzeptierte Dokumente",
+      "input_country_not_found": "",
+      "input_placeholder_country": "Ausstellungsland auswählen"
     },
-    "auth_progress": {
-        "loader": "Hochladen"
+    "subtitle": "Es muss ein offizieller Lichtbildausweis sein",
+    "subtitle_country": "Wählen Sie das ausstellende Land aus, um zu sehen, welche Dokumente wir akzeptieren",
+    "subtitle_entire_page": "Ganze Seite",
+    "subtitle_front_back": "Vorne und Hinten",
+    "subtitle_photo_page": "Fotoseite",
+    "subtitle_poa": "Diese Dokumente zeigen wahrscheinlich Ihre aktuelle Wohnadresse:",
+    "title": "Dokument auswählen",
+    "title_poa": "Ein %{country}-Dokumente auswählen"
+  },
+  "doc_submit": {
+    "button_link_upload": "oder Foto hochladen – keine Scans oder Kopien",
+    "button_primary": "Weiter am Mobiltelefon",
+    "subtitle": "Machen Sie ein Foto mit Ihrem Mobiltelefon",
+    "title_bank_statement": "Auszug senden",
+    "title_benefits_letter": "Schreiben einreichen",
+    "title_bill": "Rechnung senden",
+    "title_government_letter": "Staatliches Schreiben",
+    "title_id_back": "Personalausweis einreichen (Rückseite)",
+    "title_id_front": "Personalausweis einreichen (Vorderseite)",
+    "title_license_back": "Führerschein einreichen (Rückseite)",
+    "title_license_front": "Führerschein einreichen (Vorderseite)",
+    "title_passport": "Passfoto-Seite einreichen",
+    "title_permit_back": "Aufenthaltsgenehmigung einreichen (Rückseite)",
+    "title_permit_front": "Aufenthaltsgenehmigung einreichen (Vorderseite)",
+    "title_tax_letter": "Schreiben einreichen"
+  },
+  "doc_video_capture": {
+    "button_primary_fallback": "Nächster Schritt",
+    "button_primary_fallback_end": "Aufnahme beenden",
+    "detail_step2": "Sorgen Sie dafür, dass stets das gesamte Dokument zu sehen ist",
+    "header": "Halten Sie die Lichtbild-Seite innerhalb des Rahmens, während Sie Ihr Dokument halten",
+    "header_paper_doc_step2": "Drehen Sie Ihr Dokument langsam um, sodass die äußeren Seiten zu sehen sind",
+    "header_passport": "Halten Sie die Lichtbild-Seite innerhalb des Rahmens, während Sie Ihren Reisepass halten",
+    "header_passport_progress": "Halten Sie still",
+    "header_step1": "Halten Sie nun still",
+    "header_step2": "Drehen Sie Ihr Dokument langsam um, sodass die Rückseite zu sehen ist",
+    "prompt": {
+      "detail_timeout": "Die Videoaufnahme ist auf <timeout></timeout> Sekunden beschränkt. <fallback>Nochmal beginnen</fallback>"
     },
-    "auth_retry": {
-        "body_blur": "Reinigen Sie Ihr Kameraobjektiv",
-        "body_neutral_expression": "Behalten Sie einen neutralen Gesichtsausdruck",
-        "body_too_bright": "Suchen Sie eine weniger helle Umgebung auf",
-        "button_primary": "Kamera starten",
-        "subtitle": "Wir konnten Ihr Gesicht nicht ordnungsgemäß erfassen",
-        "title": "Scannen Sie Ihr Gesicht erneut"
+    "stepper": "Schritt <step></step> von <total></total>",
+    "success_accessibility": "Erfolg"
+  },
+  "doc_video_confirmation": {
+    "button_secondary": "Video-Vorschau",
+    "title": "Selfie-Video prüfen"
+  },
+  "error_unsupported_browser": {
+    "subtitle_android": "Starten Sie den Prozess auf der neuesten Version von Google Chrome neu",
+    "subtitle_ios": "Starten Sie den Prozess mit der neuesten Version von Safari neu",
+    "title_android": "Nicht unterstützter Browser",
+    "title_ios": "Nicht unterstützter Browser"
+  },
+  "generic": {
+    "accessibility": {
+      "close_sdk_screen": "Bildschirm zur Identitätsprüfung schließen",
+      "dismiss_alert": "Alarm verwerfen"
     },
-    "auth_upload_pass": {
-        "body": "Hochladen erfolgreich"
+    "back": "zurück",
+    "close": "Schließen",
+    "errors": {
+      "expired_token": {
+        "instruction": "Bitte versuchen Sie es erneut",
+        "message": "Ihr Token ist abgelaufen"
+      },
+      "geoblocked_error": {
+        "instruction": "Es tut uns leid, wir können leider nicht fortfahren, da Ihr aktueller Standort nicht unterstützt wird.",
+        "message": "Service nicht verfügbar"
+      },
+      "interrupted_flow_error": {
+        "instruction": "Starten Sie den Prozess auf einem anderen Gerät neu",
+        "message": "Kamera nicht erkannt"
+      },
+      "invalid_size": {
+        "instruction": "Die Dateigröße muss unter 10 MB sein.",
+        "message": "Dateigröße überschritten."
+      },
+      "invalid_type": {
+        "instruction": "Versuchen Sie einen anderen Dateityp zu verwenden",
+        "message": "Datei nicht hochgeladen"
+      },
+      "lazy_loading": {
+        "message": "Beim Laden der Komponente ist ein Fehler aufgetreten"
+      },
+      "multiple_faces": {
+        "instruction": "Nur Ihr Gesicht kann im Selfie zu sehen sein",
+        "message": "Mehrere Gesichter gefunden"
+      },
+      "no_face": {
+        "instruction": "Stellen Sie sicher, dass Ihr Gesicht sichtbar ist",
+        "message": "Kein Gesicht gefunden"
+      },
+      "request_error": {
+        "instruction": "Bitte versuchen Sie es erneut",
+        "message": "Etwas ist schiefgelaufen"
+      },
+      "sms_failed": {
+        "instruction": "Kopieren Sie den Link auf Ihr Mobiltelefon",
+        "message": "Etwas ist schiefgelaufen"
+      },
+      "sms_overuse": {
+        "instruction": "Kopieren Sie den Link auf Ihr Mobiltelefon",
+        "message": "Zu viele fehlgeschlagene Versuche"
+      },
+      "unsupported_file": {
+        "instruction": "Versuchen Sie es mit einer JPG- oder PNG-Datei",
+        "message": "Dateityp nicht unterstützt"
+      }
     },
-    "avc_confirmation": {
-        "button_primary_upload": "Aufnahme hochladen",
-        "subtitle": "Ein Video von Ihrem Gesicht wurde erfolgreich aufgenommen",
-        "title": "Aufnahme abgeschlossen"
-    },
-    "avc_connection_error": {
-        "button_primary_reload": "Anweisungen neu laden",
-        "button_primary_retry_upload": "Upload wiederholen",
-        "button_secondary_restart_recording": "Aufnahme neu starten",
-        "subtitle": "Prüfen Sie, ob Ihre Internetverbindung stabil ist, und versuchen Sie es dann erneut",
-        "title": "Verbindungsfehler"
-    },
-    "avc_face_alignment": {
-        "feedback_move_back": "Gehen Sie zurück",
-        "feedback_move_closer": "Rücken Sie näher heran",
-        "feedback_no_face_detected": "Gesicht nicht erkannt",
-        "feedback_not_centered": "Gesicht nicht mittig",
-        "title": "Positionieren Sie Ihr Gesicht im Rahmen"
-    },
-    "avc_face_capture": {
-        "alert": {
-            "timeout_body": "Sie haben maximal 15 Sekunden Zeit, um die Aufnahme zu beenden",
-            "timeout_button_primary": "Wiederholen",
-            "timeout_title": "Leider muss die Aufnahme neu gestartet werden",
-            "too_fast_body": "Bitte versuchen Sie es erneut und drehen Sie Ihren Kopf langsamer",
-            "too_fast_button_primary": "Wiederholen",
-            "too_fast_title": "Sie haben Ihren Kopf zu schnell gedreht"
-        },
-        "title": "Drehen Sie Ihren Kopf langsam nach beiden Seiten",
-        "title_completed": "Aufnahme abgeschlossen"
-    },
-    "avc_intro": {
-        "button_primary_ready": "Ich bin fertig",
-        "disclaimer": "Bitte beachten Sie, dass Ihr Gesicht und Ihr Hintergrund aufgenommen wird",
-        "list_item_one": "Positionieren Sie Ihr Gesicht zunächst im Rahmen",
-        "list_item_two": "Drehen Sie Ihren Kopf dann langsam nach beiden Seiten",
-        "subtitle": "Damit verifizieren wir, dass es sich bei Ihnen um eine reale Person handelt",
-        "title": "Video aufnehmen"
-    },
-    "avc_no_face_detected": {
-        "button_primary_restart": "Aufnahme neu starten",
-        "list_item_eyes": "Stellen Sie sicher, dass Ihre Augen deutlich sichtbar sind",
-        "list_item_face": "Zeigen Sie nur Ihr Gesicht, Ihr Ausweis wird nicht benötigt",
-        "list_item_lighting": "Stellen Sie sicher, dass Sie sich an einem Ort mit guter Beleuchtung befinden",
-        "list_item_mask": "Achten Sie darauf, dass Sie Gesichtsmasken oder andere Gegenstände, die Ihr Gesicht verdecken, abnehmen. Brillen sind zulässig",
-        "title": "Wir können Ihr Gesicht nicht erkennen"
-    },
-    "avc_uploading": {
-        "title": "Hochladen"
-    },
-    "country_select": {
-        "alert": {
-            "another_doc": "Dokumente aus diesem Land werden derzeit nicht unterstützt. <fallback>Versuchen Sie es mit einem anderen Dokumententyp<\/fallback>."
-        },
-        "alert_dropdown": {
-            "country_not_found": "Land nicht gefunden"
-        },
-        "button_primary": "Dokument einreichen",
-        "poa_alert": {
-            "country_not_found": "Entschuldigen Sie bitte. Wir arbeiten an der Unterstützung von mehr Ländern.",
-            "intro": "Ihr Land ist nicht aufgeführt?"
-        },
-        "search": {
-            "accessibility": "Land auswählen",
-            "input_placeholder": "z.B. Deutschland",
-            "label": "Suche nach Land"
-        },
-        "title": "Ausstellungsland auswählen"
-    },
-    "cross_device_checklist": {
-        "button_primary": "Bestätigung senden",
-        "info": "Tipps",
-        "list_item_doc_multiple": "Dokumente hochgeladen",
-        "list_item_doc_one": "Dokument hochgeladen",
-        "list_item_poa": "Adressnachweis",
-        "list_item_selfie": "Selfie hochgeladen",
-        "list_item_video": "Video hochgeladen",
-        "subtitle": "Hier ist alles, was Sie hochgeladen haben:",
-        "title": "Ein letzter Schritt"
-    },
-    "cross_device_error_desktop": {
-        "subtitle": "Der Link funktioniert nur auf mobilen Geräten",
-        "title": "Etwas ist schiefgelaufen"
-    },
-    "cross_device_error_restart": {
-        "subtitle": "Sie müssen Ihre Verifizierung auf Ihrem Computer neu starten",
-        "title": "Etwas ist schiefgelaufen"
-    },
-    "cross_device_intro": {
-        "button_primary": "Sicherheitslink erhalten",
-        "list_accessibility": "Erforderliche Schritte zur weiteren Verifizierung auf Ihrem Mobiltelefon",
-        "list_item_finish": "Überprüfen Sie alle Eingaben und Daten, um die Einreichung abzuschließen",
-        "list_item_open_link": "Öffnen Sie den Link und führen Sie die Aktionen aus",
-        "list_item_send_phone": "Senden Sie einen Sicherheitslink an Ihr Mobiltelefon",
-        "subtitle": "So geht’s:",
-        "title": "Fahren Sie mit Ihrem Mobiltelefon fort"
-    },
-    "cross_device_return": {
-        "body": "Die Aktualisierung Ihres Computers kann einige Sekunden dauern",
-        "subtitle": "Sie können nun zu Ihrem Computer zurückkehren, um fortzufahren",
-        "title": "Uploads erfolgreich!"
-    },
-    "cross_device_session_linked": {
-        "button_primary": "Fortfahren",
-        "info": "Überprüfen Sie bitte",
-        "list_item_desktop_open": "Ihr Desktop-Fenster bleibt geöffnet",
-        "list_item_sent_by_you": "Dieser Link wurde von Ihnen gesendet - lassen Sie sich beraten, wenn Sie glauben, dass es sich um einen Betrug handeln könnte",
-        "subtitle": "Fahren Sie mit der Überprüfung fort",
-        "title": "Mit Ihrem Computer verbunden"
-    },
-    "doc_capture": {
-        "button_primary": "Starten Sie mit dem Scannen des Dokuments",
-        "detail": {
-            "folded_doc_front": "Legen Sie Ihr Dokument flach hin, einschließlich aller Innenseiten (Ihr Foto muss enthalten sein)"
-        },
-        "header_folded_doc_front": "Profilfotoseite",
-        "prompt": {
-            "button_card": "Plastikkarte",
-            "button_paper": "Papierdokument",
-            "title_id": "Welche Art von Personalausweis haben Sie?",
-            "title_license": "Welche Art von Führerschein haben Sie?"
-        }
-    },
-    "doc_confirmation": {
-        "alert": {
-            "blur_detail": "Stellen Sie sicher, dass alles klar ist",
-            "blur_title": "Unscharfes Foto erkannt",
-            "crop_detail": "Stellen Sie sicher, dass das vollständige Dokument zu sehen ist",
-            "crop_title": "Abgeschnittenes Bild erkannt",
-            "glare_detail": "Versuchen Sie, sich von direktem Licht zu entfernen",
-            "glare_title": "Spiegelung erkannt",
-            "no_doc_detail": "Stellen Sie sicher, dass das gesamte Dokument auf dem Foto zu sehen ist",
-            "no_doc_title": "Kein Dokument erkannt."
-        },
-        "body": "Überprüfen Sie, dass Sie die gesamte Dokumentseite hochgeladen haben, und dass man die Details ohne Unschärfen und blendfrei lesen kann",
-        "body_bank_statement": "Überprüfen Sie, dass Sie die gesamte Dokumentseite hochgeladen haben, und dass man die Details ohne Unschärfen und blendfrei lesen kann",
-        "body_benefits_letter": "Überprüfen Sie, dass Sie die gesamte Dokumentseite hochgeladen haben, und dass man die Details ohne Unschärfen und blendfrei lesen kann",
-        "body_bill": "Überprüfen Sie, dass Sie die gesamte Dokumentseite hochgeladen haben, und dass man die Details ohne Unschärfen und blendfrei lesen kann",
-        "body_id": "Die Reisepass-Details müssen deutlich lesbar sein, ohne Unschärfe oder Spiegelung",
-        "body_image_medium": "Es wird länger dauern, Sie zu verifizieren, wenn wir es nicht lesen können",
-        "body_image_poor": "Um Sie reibungslos zu verifizieren, benötigen wir ein besseres Foto",
-        "body_license": "Die Reisepass-Details müssen deutlich lesbar sein, ohne Unschärfe oder Spiegelung",
-        "body_passport": "Die Reisepass-Details müssen deutlich lesbar sein, ohne Unschärfe oder Spiegelung",
-        "body_permit": "Die Reisepass-Details müssen deutlich lesbar sein, ohne Unschärfe oder Spiegelung",
-        "body_tax_letter": "Überprüfen Sie, dass Sie die gesamte Dokumentseite hochgeladen haben, und dass man die Details ohne Unschärfen und blendfrei lesen kann",
-        "button_close": "Schließen",
-        "button_primary_redo": "Wiederholen",
-        "button_primary_upload": "Hochladen",
-        "button_primary_upload_anyway": "Trotzdem hochladen",
-        "button_secondary_redo": "Wiederholen",
-        "button_zoom": "Bild vergrößern",
-        "image_accessibility": "Foto Ihres Dokuments",
-        "title": "Überprüfen Sie Ihr Bild"
-    },
-    "doc_multi_frame_capture": {
-        "capture_progress_title": "Dokument wird gescannt",
-        "instructions_title_back": "Positionieren Sie die Rückseite Ihres Dokuments im Rahmen",
-        "instructions_title_front": "Positionieren Sie die Vorderseite Ihres Dokuments im Rahmen"
-    },
-    "doc_select": {
-        "button_bank_statement": "Bankauszug",
-        "button_bank_statement_non_uk": "Bankauszug",
-        "button_benefits_letter": "Sozialleistungsschreiben",
-        "button_benefits_letter_detail": "Von der Regierung autorisierte Sozialleistungen, wie z. B. Arbeitslosenhilfe, Wohngeld, Steuerermäßigung",
-        "button_bill": "Betriebskostenabrechnung",
-        "button_bill_detail": "Gas, Strom, Wasser, Festnetz oder Breitband-Internet",
-        "button_government_letter": "Staatliches Schreiben",
-        "button_government_letter_detail": "Jede Art vom Staat ausgestelltes Schreiben, z. B. Sozialleistungsschreiben, Wahlbenachrichtigung, Schreiben vom Finanzamt usw.",
-        "button_id": "Nationaler Personalausweis",
-        "button_id_detail": "Vorder- und Rückseite",
-        "button_license": "Führerschein",
-        "button_license_detail": "Vorder- und Rückseite",
-        "button_passport": "Reisepass",
-        "button_passport_detail": "Seite mit Foto",
-        "button_permit": "Karte der Aufenthaltsgenehmigung",
-        "button_permit_detail": "Vorder- und Rückseite",
-        "button_tax_letter": "Gemeindesteuerschreiben",
-        "extra_estatements_ok": "E-Auszüge werden akzeptiert",
-        "extra_no_mobile": "Entschuldigen Sie bitte, keine Mobiltelefonrechnungen",
-        "list_accessibility": "Dokumente, die Sie zur Überprüfung Ihrer Identität verwenden können",
-        "pill": "Schnellste",
-        "section": {
-            "header_country": "Ausstellendes Land",
-            "header_doc_type": "Akzeptierte Dokumente",
-            "input_country_not_found": "",
-            "input_placeholder_country": "Ausstellungsland auswählen"
-        },
-        "subtitle": "Es muss ein offizieller Lichtbildausweis sein",
-        "subtitle_country": "Wählen Sie das ausstellende Land aus, um zu sehen, welche Dokumente wir akzeptieren",
-        "subtitle_entire_page": "Ganze Seite",
-        "subtitle_front_back": "Vorne und Hinten",
-        "subtitle_photo_page": "Fotoseite",
-        "subtitle_poa": "Diese Dokumente zeigen wahrscheinlich Ihre aktuelle Wohnadresse:",
-        "title": "Dokument auswählen",
-        "title_poa": "Ein %{country}-Dokumente auswählen"
-    },
-    "doc_submit": {
-        "button_link_upload": "oder Foto hochladen – keine Scans oder Kopien",
-        "button_primary": "Weiter am Mobiltelefon",
-        "subtitle": "Machen Sie ein Foto mit Ihrem Mobiltelefon",
-        "title_bank_statement": "Auszug senden",
-        "title_benefits_letter": "Schreiben einreichen",
-        "title_bill": "Rechnung senden",
-        "title_government_letter": "Staatliches Schreiben",
-        "title_id_back": "Personalausweis einreichen (Rückseite)",
-        "title_id_front": "Personalausweis einreichen (Vorderseite)",
-        "title_license_back": "Führerschein einreichen (Rückseite)",
-        "title_license_front": "Führerschein einreichen (Vorderseite)",
-        "title_passport": "Passfoto-Seite einreichen",
-        "title_permit_back": "Aufenthaltsgenehmigung einreichen (Rückseite)",
-        "title_permit_front": "Aufenthaltsgenehmigung einreichen (Vorderseite)",
-        "title_tax_letter": "Schreiben einreichen"
-    },
-    "doc_video_capture": {
-        "button_primary_fallback": "Nächster Schritt",
-        "button_primary_fallback_end": "Aufnahme beenden",
-        "detail_step2": "Sorgen Sie dafür, dass stets das gesamte Dokument zu sehen ist",
-        "header": "Halten Sie die Lichtbild-Seite innerhalb des Rahmens, während Sie Ihr Dokument halten",
-        "header_paper_doc_step2": "Drehen Sie Ihr Dokument langsam um, sodass die äußeren Seiten zu sehen sind",
-        "header_passport": "Halten Sie die Lichtbild-Seite innerhalb des Rahmens, während Sie Ihren Reisepass halten",
-        "header_passport_progress": "Halten Sie still",
-        "header_step1": "Halten Sie nun still",
-        "header_step2": "Drehen Sie Ihr Dokument langsam um, sodass die Rückseite zu sehen ist",
-        "prompt": {
-            "detail_timeout": "Die Videoaufnahme ist auf <timeout><\/timeout> Sekunden beschränkt. <fallback>Nochmal beginnen<\/fallback>"
-        },
-        "stepper": "Schritt <step><\/step> von <total><\/total>",
-        "success_accessibility": "Erfolg"
-    },
-    "doc_video_confirmation": {
-        "button_secondary": "Video-Vorschau",
-        "title": "Selfie-Video prüfen"
-    },
-    "error_unsupported_browser": {
-        "subtitle_android": "Starten Sie den Prozess auf der neuesten Version von Google Chrome neu",
-        "subtitle_ios": "Starten Sie den Prozess mit der neuesten Version von Safari neu",
-        "title_android": "Nicht unterstützter Browser",
-        "title_ios": "Nicht unterstützter Browser"
-    },
-    "generic": {
-        "accessibility": {
-            "close_sdk_screen": "Bildschirm zur Identitätsprüfung schließen",
-            "dismiss_alert": "Alarm verwerfen"
-        },
-        "back": "zurück",
-        "close": "Schließen",
-        "errors": {
-            "expired_token": {
-                "instruction": "Bitte versuchen Sie es erneut",
-                "message": "Ihr Token ist abgelaufen"
-            },
-            "geoblocked_error": {
-                "instruction": "Es tut uns leid, wir können leider nicht fortfahren, da Ihr aktueller Standort nicht unterstützt wird.",
-                "message": "Service nicht verfügbar"
-            },
-            "interrupted_flow_error": {
-                "instruction": "Starten Sie den Prozess auf einem anderen Gerät neu",
-                "message": "Kamera nicht erkannt"
-            },
-            "invalid_size": {
-                "instruction": "Die Dateigröße muss unter 10 MB sein.",
-                "message": "Dateigröße überschritten."
-            },
-            "invalid_type": {
-                "instruction": "Versuchen Sie einen anderen Dateityp zu verwenden",
-                "message": "Datei nicht hochgeladen"
-            },
-            "lazy_loading": {
-                "message": "Beim Laden der Komponente ist ein Fehler aufgetreten"
-            },
-            "multiple_faces": {
-                "instruction": "Nur Ihr Gesicht kann im Selfie zu sehen sein",
-                "message": "Mehrere Gesichter gefunden"
-            },
-            "no_face": {
-                "instruction": "Stellen Sie sicher, dass Ihr Gesicht sichtbar ist",
-                "message": "Kein Gesicht gefunden"
-            },
-            "request_error": {
-                "instruction": "Bitte versuchen Sie es erneut",
-                "message": "Etwas ist schiefgelaufen"
-            },
-            "sms_failed": {
-                "instruction": "Kopieren Sie den Link auf Ihr Mobiltelefon",
-                "message": "Etwas ist schiefgelaufen"
-            },
-            "sms_overuse": {
-                "instruction": "Kopieren Sie den Link auf Ihr Mobiltelefon",
-                "message": "Zu viele fehlgeschlagene Versuche"
-            },
-            "unsupported_file": {
-                "instruction": "Versuchen Sie es mit einer JPG- oder PNG-Datei",
-                "message": "Dateityp nicht unterstützt"
-            }
-        },
-        "lazy_load_placeholder": "Wird geladen…",
-        "loading": "Wird geladen"
-    },
-    "get_link": {
-        "alert_wrong_number": "Überprüfen Sie, ob Ihre Nummer korrekt ist",
-        "button_copied": "Kopiert",
-        "button_copy": "Kopieren",
-        "button_submit": "Link senden",
-        "info_qr_how": "So scannen Sie einen QR-Code",
-        "info_qr_how_list_item_camera": "Richten Sie die Kamera Ihres Telefons auf den QR-Code",
-        "info_qr_how_list_item_download": "Wenn es nicht funktioniert, laden Sie einen QR-Code-Scanner von Google Play oder aus dem App Store herunter",
-        "link_divider": "oder wählen Sie eine alternative Methode",
-        "link_qr": "QR-Code scannen",
-        "link_sms": "Link per SMS erhalten",
-        "link_url": "Link kopieren",
-        "loader_sending": "Senden",
-        "number_field_input_placeholder": "Mobiltelefonnummer eingeben",
-        "number_field_label": "Geben Sie Ihre Mobiltelefonnummer ein:",
-        "subtitle_qr": "Scannen Sie den QR-Code mit Ihrem Mobiltelefon",
-        "subtitle_sms": "Öffnen Sie den Link auf Ihrem Mobiltelefon",
-        "subtitle_url": "Öffnen Sie den Link auf Ihrem Mobiltelefon",
-        "title": "Holen Sie sich Ihren Sicherheitslink",
-        "url_field_label": "Kopieren Sie den Link in Ihren mobilen Browser"
-    },
-    "livenessV2": {
-        "error_reload_instructions": "Anweisungen neu laden",
-        "intro_note_no1": "Positionieren Sie Ihr Gesicht zunächst im Rahmen",
-        "intro_note_no2": "Drehen Sie Ihren Kopf dann langsam nach beiden Seiten",
-        "intro_ready_button": "Bitte beachten Sie, dass wir Ihr Gesicht und Ihren Hintergrund aufnehmen",
-        "intro_subtitle": "Damit verifizieren wir, dass es sich bei Ihnen um eine reale Person handelt",
-        "intro_warning": "Bitte beachten Sie, dass wir Ihr Gesicht und Ihren Hintergrund aufnehmen",
-        "success_main_button": "Bestätigung senden",
-        "success_title": "Das ist alles, was wir benötigen, um mit Ihrer Identitätsprüfung zu beginnen"
-    },
-    "mobilePhrases": {
-        "photo_upload": {
-            "body_id_back": "Machen Sie ein Foto von der Rückseite Ihrer Karte",
-            "body_id_front": "Machen Sie ein Foto von der Vorderseite Ihrer Karte",
-            "body_license_back": "Machen Sie ein Foto von der Rückseite Ihres Führerscheins",
-            "body_license_front": "Machen Sie ein Foto von der Vorderseite Ihres Führerscheins",
-            "body_passport": "Machen Sie ein Foto von Ihrer Passfotoseite",
-            "body_selfie": "Machen Sie ein Selfie, das Ihr Gesicht zeigt"
-        },
-        "selfie_capture": {
-            "alert": {
-                "camera_inactive": {
-                    "detail": "Fotografieren Sie stattdessen mit dem <fallback>einfachen Kameramodus<\/fallback>"
-                },
-                "camera_not_working": {
-                    "detail": "Fotografieren Sie stattdessen mit dem <fallback>einfachen Kameramodus<\/fallback>"
-                }
-            }
-        },
-        "upload_guide": {
-            "button_primary": "Ein Foto machen",
-            "title": "Reisepass Foto-Seite"
-        }
-    },
-    "outro": {
-        "body": "Das ist alles, was wir benötigen, um mit Ihrer Identitätsprüfung zu beginnen",
-        "body_government_letter": "Für das beste Ergebnis die gesamte Dokumentseite abbilden",
-        "title": "Danke"
-    },
-    "permission": {
-        "body_both": "Wir können Sie nicht verifizieren, ohne auf Ihr Mikrofon und Ihre Kamera zuzugreifen",
-        "body_cam": "Wir können Sie nicht verifizieren, ohne Ihre Kamera zu benutzen",
-        "button_primary_both": "Beides aktivieren",
-        "button_primary_cam": "Kamera aktivieren",
-        "subtitle_both": "Wenn Sie dazu aufgefordert werden, müssen Sie den Zugriff auf beide Komponenten aktivieren, um fortzufahren",
-        "subtitle_cam": "Wenn Sie dazu aufgefordert werden, müssen Sie den Kamerazugriff aktivieren, um fortzufahren",
-        "title_both": "Zugriff auf Kamera und Mikrofon erlauben",
-        "title_cam": "Zugriff auf Kamera erlauben"
-    },
-    "permission_recovery": {
-        "button_primary": "Aktualisieren",
-        "info": "Wiederherstellen",
-        "list_header_both": "Befolgen Sie diese Schritte, um den Zugriff auf beides wiederherzustellen:",
-        "list_header_cam": "Befolgen Sie diese Schritte, um den Kamerazugriff wiederherzustellen:",
-        "list_item_action_cam": "Aktualisieren Sie diese Seite, um den Identitätsüberprüfungsprozess neu zu starten",
-        "list_item_how_to_both": "Gewähren Sie den Zugriff auf Ihre Kamera und Ihr Mikrofon über Ihre Browsereinstellungen",
-        "list_item_how_to_cam": "Gewähren Sie den Zugriff auf Ihre Kamera über Ihre Browsereinstellungen",
-        "subtitle_both": "Stellen Sie den Zugriff auf Kamera und Mikrofon wieder her, um ein Video aufzunehmen und den Überprüfungsprozess abzuschließen",
-        "subtitle_cam": "Kamerazugriff wiederherstellen, um Verifizierung fortzusetzen",
-        "subtitle_cam_old": "Kamerazugriff wiederherstellen, um Gesichtsverifizierung fortzusetzen",
-        "title_both": "Kamera- und Mikrofonzugriff verweigert",
-        "title_cam": "Kamerazugriff wird verweigert"
-    },
+    "lazy_load_placeholder": "Wird geladen…",
+    "loading": "Wird geladen"
+  },
+  "get_link": {
+    "alert_wrong_number": "Überprüfen Sie, ob Ihre Nummer korrekt ist",
+    "button_copied": "Kopiert",
+    "button_copy": "Kopieren",
+    "button_submit": "Link senden",
+    "info_qr_how": "So scannen Sie einen QR-Code",
+    "info_qr_how_list_item_camera": "Richten Sie die Kamera Ihres Telefons auf den QR-Code",
+    "info_qr_how_list_item_download": "Wenn es nicht funktioniert, laden Sie einen QR-Code-Scanner von Google Play oder aus dem App Store herunter",
+    "link_divider": "oder wählen Sie eine alternative Methode",
+    "link_qr": "QR-Code scannen",
+    "link_sms": "Link per SMS erhalten",
+    "link_url": "Link kopieren",
+    "loader_sending": "Senden",
+    "number_field_input_placeholder": "Mobiltelefonnummer eingeben",
+    "number_field_label": "Geben Sie Ihre Mobiltelefonnummer ein:",
+    "subtitle_qr": "Scannen Sie den QR-Code mit Ihrem Mobiltelefon",
+    "subtitle_sms": "Öffnen Sie den Link auf Ihrem Mobiltelefon",
+    "subtitle_url": "Öffnen Sie den Link auf Ihrem Mobiltelefon",
+    "title": "Holen Sie sich Ihren Sicherheitslink",
+    "url_field_label": "Kopieren Sie den Link in Ihren mobilen Browser"
+  },
+  "livenessV2": {
+    "error_reload_instructions": "Anweisungen neu laden",
+    "intro_note_no1": "Positionieren Sie Ihr Gesicht zunächst im Rahmen",
+    "intro_note_no2": "Drehen Sie Ihren Kopf dann langsam nach beiden Seiten",
+    "intro_ready_button": "Bitte beachten Sie, dass wir Ihr Gesicht und Ihren Hintergrund aufnehmen",
+    "intro_subtitle": "Damit verifizieren wir, dass es sich bei Ihnen um eine reale Person handelt",
+    "intro_warning": "Bitte beachten Sie, dass wir Ihr Gesicht und Ihren Hintergrund aufnehmen",
+    "success_main_button": "Bestätigung senden",
+    "success_title": "Das ist alles, was wir benötigen, um mit Ihrer Identitätsprüfung zu beginnen"
+  },
+  "mobilePhrases": {
     "photo_upload": {
-        "body_bank_statement": "Für das beste Ergebnis die gesamte Dokumentseite abbilden",
-        "body_benefits_letter": "Für das beste Ergebnis die gesamte Dokumentseite abbilden",
-        "body_bill": "Für das beste Ergebnis die gesamte Dokumentseite abbilden",
-        "body_id_back": "Kartenrückseite von Ihrem Computer hochladen",
-        "body_id_front": "Kartenvorderseite von Ihrem Computer hochladen",
-        "body_license_back": "Rückseite des Führerscheins von Ihrem Computer hochladen",
-        "body_license_front": "Vorderseite des Führerscheins von Ihrem Computer hochladen",
-        "body_passport": "Passfotoseite von Ihrem Computer hochladen",
-        "body_selfie": "Selfie von Ihrem Computer hochladen",
-        "body_tax_letter": "Für das beste Ergebnis die gesamte Dokumentseite abbilden",
-        "button_take_photo": "Foto machen",
-        "button_upload": "Hochladen",
-        "title_selfie": "Selfie"
-    },
-    "poa_cancel": "Abbrechen",
-    "poa_err_invalid_file": {
-        "message": "Bitte wählen Sie eine andere Datei.",
-        "ok": "OK",
-        "title": "Ungültige Datei"
-    },
-    "poa_guidance": {
-        "button_primary": "Fortfahren",
-        "instructions": {
-            "address": "Aktuelle Adresse",
-            "full_name": "Vollständiger Name",
-            "issue_date": "Ausgabedatum oder Abrechnungszeitraum",
-            "label": "Erfassen Sie das komplette Dokument und sorgen Sie dafür, dass es Folgendes klar zeigt:",
-            "logo": "Logo"
-        },
-        "subtitle_bank_statement": "Muss in den <strong>letzten 3 Monaten<\/strong> ausgestellt worden sein",
-        "subtitle_benefits_letter": "Muss in den <strong>letzten 12 Monaten<\/strong> ausgestellt worden sein",
-        "subtitle_bill": "Muss in den <strong>letzten 3 Monaten<\/strong> ausgestellt worden sein",
-        "subtitle_tax_letter": "Muss in den <strong>letzten 12 Monaten<\/strong> ausgestellt worden sein"
-    },
-    "poa_intro": {
-        "button_primary": "Bestätigung beginnen",
-        "list_matches_signup": "Der von Ihnen bei der Registrierung verwendeten Adresse <strong>entspricht<\/strong>",
-        "list_most_recent": "Ihr <strong>aktuellstes<\/strong> Dokument ist",
-        "list_shows_address": "Ihre  <strong>aktuelle<\/strong> Adresse zeigt",
-        "subtitle": "Sie brauchen ein Dokument, das:",
-        "title": "Bestätigen wir nun Ihre Adresse"
-    },
-    "profile_data": {
-        "address_title": "Fügen Sie Ihre Adresse hinzu",
-        "button_continue": "Weiter",
-        "components": {
-            "country_select": {
-                "placeholder": "Wählen Sie ein Land aus"
-            },
-            "nationality_select": {
-                "placeholder": "Wählen Sie ein Land aus"
-            },
-            "pan": {
-                "placeholder": "ABCDE1234F"
-            },
-            "ssn": {
-                "placeholder": "123-45-6789"
-            },
-            "state_select": {
-                "placeholder": "Wählen Sie ein Bundesland aus"
-            }
-        },
-        "country_of_residence_title": "Ihr Wohnsitzland",
-        "field_labels": {
-            "country": "Land",
-            "dob": "Geburtsdatum",
-            "email": "E-Mail-Adresse",
-            "first_name": "Vorname",
-            "gbr_specific": {
-                "postcode": "Postleitzahl",
-                "town": "Stadt"
-            },
-            "last_name": "Nachname",
-            "line1": "Adresszeile 1",
-            "line2": "Adresszeile 2",
-            "line3": "Adresszeile 3",
-            "mobile_number": "Mobiltelefonnummer",
-            "nationality": "Nationalität",
-            "pan": "Permanente Account-Nummer (PAN)",
-            "postcode": "Postleitzahl",
-            "ssn": "Sozialversicherungsnummer (SVN)",
-            "town": "Stadt",
-            "usa_specific": {
-                "line1_helper_text": "Straßenname, zum Beispiel: Abertstraße 200",
-                "line2_helper_text": "Wohnung, Suite, Einheit, etc.",
-                "postcode": "Zip code",
-                "state": "Staat"
-            }
-        },
-        "field_optional": "(optional)",
-        "field_validation": {
-            "gbr_specific": {
-                "required_postcode": "Bitte geben Sie Ihre Postleitzahl ein",
-                "too_long_postcode": "Die Postleitzahl ist zu lang",
-                "too_short_postcode": "Die Postleitzahl ist zu kurz"
-            },
-            "invalid": "Bitte auf ungültige Zeichen oder Symbole überprüfen",
-            "invalid_dob": "Bitte geben Sie ein gültiges Geburtsdatum ein",
-            "required_country": "Bitte wählen Sie ein Land aus",
-            "required_dob": "Bitte geben Sie Ihr Geburtsdatum ein",
-            "required_email": "Bitte geben Sie Ihre E-Mail-Adresse ein",
-            "required_first_name": "",
-            "required_last_name": "Bitte geben Sie Ihren Nachnamen ein",
-            "required_line1": "Bitte geben Sie Ihre Adresse ein",
-            "required_mobile_number": "Bitte geben Sie Ihre Mobiltelefonnummer ein",
-            "required_nationality": "Bitte wählen Sie ein Land aus",
-            "required_pan": "Bitte geben Sie Ihre PAN ein",
-            "required_postcode": "Bitte geben Sie Ihre Postleitzahl ein",
-            "required_ssn": "Bitte geben Sie Ihre SVN ein",
-            "too_long__line1": "Die Adresszeile ist zu lang",
-            "too_long_first_name": "Der Vorname ist zu lang",
-            "too_long_last_name": "Der Nachname ist zu lang",
-            "too_long_postcode": "Die Postleitzahl ist zu lang",
-            "too_long_town": "",
-            "too_short_first_name": "Der Vorname ist zu kurz",
-            "too_short_last_name": "Der Nachname ist zu kurz",
-            "too_short_postcode": "Die Postleitzahl ist zu kurz",
-            "usa_specific": {
-                "required_state": "Bitte wählen Sie einen Staat aus"
-            },
-            "valid_email": "Bitte geben Sie eine gültige E-Mail-Adresse ein",
-            "valid_mobile_number": "Bitte geben Sie eine gültige Mobiltelefonnummer ein",
-            "valid_pan": "Bitte geben Sie eine gültige PAN ein",
-            "valid_ssn": "Bitte geben Sie eine gültige SVN ein"
-        },
-        "personal_information_title": "Fügen Sie Ihre persönlichen Informationen hinzu",
-        "prompt": {
-            "details_timeout": "Erneut starten",
-            "header_timeout": "Sieht aus, als hätten Sie zu lange gebraucht"
-        }
-    },
-    "retry_feedback": {
-        "button_primary": "Versuchen Sie es erneut."
-    },
-    "retry_feedback_id_expired": {
-        "subtitle": "Versuchen Sie es mit einem gültigen Lichtbildausweis erneut und stellen Sie sicher, dass die Angaben zu Ihrer Person gut sichtbar sind",
-        "title": "Ihr Ausweis ist ungültig"
-    },
-    "retry_feedback_id_generic": {
-        "subtitle": "Versuchen Sie es mit einem gültigen Lichtbildausweis erneut und stellen Sie sicher, dass die Angaben zu Ihrer Person gut sichtbar sind",
-        "title": "Es gab ein Problem mit Ihrem Ausweis"
-    },
-    "retry_feedback_id_unaccepted": {
-        "subtitle": "Versuchen Sie es mit einem gültigen Lichtbildausweis erneut und stellen Sie sicher, dass die Angaben zu Ihrer Person gut sichtbar sind",
-        "title": "Ausweis wird nicht akzeptiert"
-    },
-    "retry_feedback_selfie_generic": {
-        "subtitle": "Versuchen Sie es erneut und stellen Sie sicher, dass Ihr Gesicht sichtbar und gut beleuchtet ist",
-        "title": "Es gab ein Problem mit Ihrem Selfie"
+      "body_id_back": "Machen Sie ein Foto von der Rückseite Ihrer Karte",
+      "body_id_front": "Machen Sie ein Foto von der Vorderseite Ihrer Karte",
+      "body_license_back": "Machen Sie ein Foto von der Rückseite Ihres Führerscheins",
+      "body_license_front": "Machen Sie ein Foto von der Vorderseite Ihres Führerscheins",
+      "body_passport": "Machen Sie ein Foto von Ihrer Passfotoseite",
+      "body_selfie": "Machen Sie ein Selfie, das Ihr Gesicht zeigt"
     },
     "selfie_capture": {
-        "alert": {
-            "camera_inactive": {
-                "detail": "Überprüfen Sie, ob die Kamera verbunden und funktionsfähig ist. Sie können <fallback>die Überprüfung auch auf Ihrem Telefon fortsetzen.<\/fallback>",
-                "detail_no_fallback": "Stellen Sie sicher, dass Ihr Gerät über eine funktionierende Kamera verfügt",
-                "title": "Kamera funktioniert nicht?"
-            },
-            "camera_not_working": {
-                "detail": "Die Verbindung kann unterbrochen werden. <fallback>Versuchen Sie stattdessen, Ihr Telefon zu benutzen<\/fallback>.",
-                "detail_no_fallback": "Stellen Sie sicher, dass die Kamera Ihres Geräts funktioniert",
-                "title": "Kamera funktioniert nicht"
-            },
-            "timeout": {
-                "detail": "Denken Sie daran, die Taste zu drücken, wenn Sie fertig sind. <fallback>Video-Aktionen wiederholen<\/fallback>.",
-                "title": "Sieht aus, als hätten Sie zu lange gebraucht"
-            }
+      "alert": {
+        "camera_inactive": {
+          "detail": "Fotografieren Sie stattdessen mit dem <fallback>einfachen Kameramodus</fallback>"
         },
-        "body": "Positionieren Sie Ihr Gesicht im angezeigten Oval",
-        "button_accessibility": "Ein Foto machen",
-        "button_primary": "Starten Sie mit dem Scannen des Gesichts",
-        "frame_accessibility": "Ansicht von der Kamera",
-        "title": "Positionieren Sie Ihr Gesicht im angezeigten Oval"
-    },
-    "selfie_confirmation": {
-        "image_accessibility": "Foto von Ihrem Gesicht",
-        "subtitle": "Stellen Sie sicher, dass Ihr Selfie Ihr Gesicht deutlich zeigt",
-        "title": "Selfie prüfen"
-    },
-    "selfie_intro": {
-        "button_primary": "Fortfahren",
-        "list_accessibility": "Tipps für ein gutes Selfie",
-        "list_item_face_forward": "Schauen Sie nach vorne und stellen Sie sicher, dass Ihre Augen deutlich sichtbar sind",
-        "list_item_no_glasses": "Nehmen Sie Ihre Brille ab, falls erforderlich",
-        "subtitle": "Wir werden dies mit Ihrem Dokument vergleichen",
-        "title": "Ein Selfie aufnehmen"
-    },
-    "sms_sent": {
-        "info": "Tipps",
-        "info_link_expire": "Ihr Link läuft in einer Stunde ab",
-        "info_link_window": "Lassen Sie dieses Fenster geöffnet, während Sie Ihr Mobiltelefon bedienen",
-        "link": "Link erneut senden",
-        "subtitle": "Wir haben einen sicheren Link an %{number} gesendet",
-        "subtitle_minutes": "Dieser Vorgang kann einige Minuten dauern",
-        "title": "Überprüfen Sie Ihr Mobiltelefon"
-    },
-    "switch_phone": {
-        "info": "Tipps",
-        "info_link_expire": "Ihr mobiler Link läuft in einer Stunde ab",
-        "info_link_refresh": "Diese Seite nicht aktualisieren",
-        "info_link_window": "Lassen Sie dieses Fenster geöffnet, während Sie Ihr Mobiltelefon bedienen",
-        "link": "Abbrechen",
-        "subtitle": "Wenn Sie fertig sind, gelangen Sie zum nächsten Schritt",
-        "title": "Mit Ihrem Mobiltelefon verbunden"
+        "camera_not_working": {
+          "detail": "Fotografieren Sie stattdessen mit dem <fallback>einfachen Kameramodus</fallback>"
+        }
+      }
     },
     "upload_guide": {
-        "button_primary": "Foto hochladen",
-        "image_detail_blur_alt": "Beispiel eines verschwommenen Dokuments",
-        "image_detail_blur_label": "Alle Details müssen klar sein - nichts verschwommen",
-        "image_detail_cutoff_label": "Alle Details anzeigen - einschließlich der unteren 2 Zeilen",
-        "image_detail_glare_label": "Entfernen Sie sich von direktem Licht - keine Blendung",
-        "image_detail_good_label": "Das Foto sollte Ihr Dokument deutlich zeigen",
-        "subtitle": "Scans und Fotokopien werden nicht akzeptiert",
-        "title": "Fotoseite des Reisepasses hochladen"
-    },
-    "user_consent": {
-        "button_primary": "Accept",
-        "button_secondary": "Do not accept",
-        "prompt": {
-            "button_primary": "Review again",
-            "button_secondary": "Yes, don’t verify me",
-            "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
-            "no_consent_title": "Are you sure?"
-        }
-    },
-    "user_consent_load_fail": {
-        "button_primary": "Reload screen",
-        "detail": "Check that your connection is stable, then try again",
-        "title": "Content failed to load"
-    },
-    "video_capture": {
-        "body": "Positionieren Sie Ihr Gesicht im angezeigten Oval",
-        "body_record": "Drücken Sie die Taste, wenn Sie bereit sind",
-        "body_stop": "Drücken Sie \"Stopp\", wenn Sie fertig sind",
-        "button_primary_finish": "Aufnahme beenden",
-        "button_primary_next": "Nächster Schritt",
-        "button_primary_start": "Aufnahme starten",
-        "button_record_accessibility": "Aufnahme starten",
-        "frame_accessibility": "Ansicht von der Kamera",
-        "header": {
-            "challenge_digit_instructions": "Sprechen Sie jede Ziffer laut aus",
-            "challenge_turn_forward": "dann nach vorne schauen",
-            "challenge_turn_left": "Kopf nach links drehen",
-            "challenge_turn_right": "Kopf nach rechts drehen"
-        },
-        "prompt": {
-            "header_timeout": "Sieht aus, als hätten Sie zu lange gebraucht"
-        }
-    },
-    "video_confirmation": {
-        "body": "Ihr Video wurde aufgezeichnet",
-        "button_primary": "Video senden",
-        "button_secondary": "Video erneut aufnehmen",
-        "title": "Selfie-Video prüfen",
-        "video_accessibility": "Wiedergeben Ihres aufgezeichneten Videos"
-    },
-    "video_intro": {
-        "button_primary": "Fortfahren",
-        "list_accessibility": "Aktionen zum Aufzeichnen eines Selfie-Videos",
-        "list_item_actions": "Beenden Sie Aktionen in weniger als 20 Sekunden",
-        "list_item_speak": "Befolgen Sie die Anweisungen zur Bewegung oder zum Sprechen",
-        "title": "Selfie-Video aufnehmen"
-    },
-    "welcome": {
-        "doc_video_subtitle": "Es dauert nur wenige Minuten",
-        "list_header_doc_video": "Nutzen Sie Ihr Gerät um Folgendes aufzunehmen:",
-        "list_header_webcam": "Verwenden Sie Ihre Webcam oder Ihr Telefon zum Fotografieren:",
-        "list_item_doc": "Ihr Ausweisdokument",
-        "list_item_doc_video_timeout": "Die Aufnahme ist auf <timeout><\/timeout> Sekunden beschränkt",
-        "list_item_poa": "Ihr Adressnachweis",
-        "list_item_selfie": "Ihr Gesicht",
-        "next_button": "Dokument auswählen",
-        "start_workflow_button": "Verifizierung beginnen",
-        "subtitle": "Es dauert nur wenige Minuten",
-        "title": "Identität überprüfen"
-    },
-    "workflow_complete": {
-        "pass": {
-            "description": "",
-            "title": ""
-        },
-        "reject": {
-            "description": "",
-            "title": ""
-        }
-    },
-    "workflow_erros": {
-        "generic_title": "",
-        "no_workflow_run_id": "",
-        "reload_app": "",
-        "task_not_completed": "",
-        "task_not_retrieved": "",
-        "task_not_supported": ""
+      "button_primary": "Ein Foto machen",
+      "title": "Reisepass Foto-Seite"
     }
+  },
+  "outro": {
+    "body": "Das ist alles, was wir benötigen, um mit Ihrer Identitätsprüfung zu beginnen",
+    "body_government_letter": "Für das beste Ergebnis die gesamte Dokumentseite abbilden",
+    "title": "Danke"
+  },
+  "permission": {
+    "body_both": "Wir können Sie nicht verifizieren, ohne auf Ihr Mikrofon und Ihre Kamera zuzugreifen",
+    "body_cam": "Wir können Sie nicht verifizieren, ohne Ihre Kamera zu benutzen",
+    "button_primary_both": "Beides aktivieren",
+    "button_primary_cam": "Kamera aktivieren",
+    "subtitle_both": "Wenn Sie dazu aufgefordert werden, müssen Sie den Zugriff auf beide Komponenten aktivieren, um fortzufahren",
+    "subtitle_cam": "Wenn Sie dazu aufgefordert werden, müssen Sie den Kamerazugriff aktivieren, um fortzufahren",
+    "title_both": "Zugriff auf Kamera und Mikrofon erlauben",
+    "title_cam": "Zugriff auf Kamera erlauben"
+  },
+  "permission_recovery": {
+    "button_primary": "Aktualisieren",
+    "info": "Wiederherstellen",
+    "list_header_both": "Befolgen Sie diese Schritte, um den Zugriff auf beides wiederherzustellen:",
+    "list_header_cam": "Befolgen Sie diese Schritte, um den Kamerazugriff wiederherzustellen:",
+    "list_item_action_cam": "Aktualisieren Sie diese Seite, um den Identitätsüberprüfungsprozess neu zu starten",
+    "list_item_how_to_both": "Gewähren Sie den Zugriff auf Ihre Kamera und Ihr Mikrofon über Ihre Browsereinstellungen",
+    "list_item_how_to_cam": "Gewähren Sie den Zugriff auf Ihre Kamera über Ihre Browsereinstellungen",
+    "subtitle_both": "Stellen Sie den Zugriff auf Kamera und Mikrofon wieder her, um ein Video aufzunehmen und den Überprüfungsprozess abzuschließen",
+    "subtitle_cam": "Kamerazugriff wiederherstellen, um Verifizierung fortzusetzen",
+    "subtitle_cam_old": "Kamerazugriff wiederherstellen, um Gesichtsverifizierung fortzusetzen",
+    "title_both": "Kamera- und Mikrofonzugriff verweigert",
+    "title_cam": "Kamerazugriff wird verweigert"
+  },
+  "photo_upload": {
+    "body_bank_statement": "Für das beste Ergebnis die gesamte Dokumentseite abbilden",
+    "body_benefits_letter": "Für das beste Ergebnis die gesamte Dokumentseite abbilden",
+    "body_bill": "Für das beste Ergebnis die gesamte Dokumentseite abbilden",
+    "body_id_back": "Kartenrückseite von Ihrem Computer hochladen",
+    "body_id_front": "Kartenvorderseite von Ihrem Computer hochladen",
+    "body_license_back": "Rückseite des Führerscheins von Ihrem Computer hochladen",
+    "body_license_front": "Vorderseite des Führerscheins von Ihrem Computer hochladen",
+    "body_passport": "Passfotoseite von Ihrem Computer hochladen",
+    "body_selfie": "Selfie von Ihrem Computer hochladen",
+    "body_tax_letter": "Für das beste Ergebnis die gesamte Dokumentseite abbilden",
+    "button_take_photo": "Foto machen",
+    "button_upload": "Hochladen",
+    "title_selfie": "Selfie"
+  },
+  "poa_cancel": "Abbrechen",
+  "poa_err_invalid_file": {
+    "message": "Bitte wählen Sie eine andere Datei.",
+    "ok": "OK",
+    "title": "Ungültige Datei"
+  },
+  "poa_guidance": {
+    "button_primary": "Fortfahren",
+    "instructions": {
+      "address": "Aktuelle Adresse",
+      "full_name": "Vollständiger Name",
+      "issue_date": "Ausgabedatum oder Abrechnungszeitraum",
+      "label": "Erfassen Sie das komplette Dokument und sorgen Sie dafür, dass es Folgendes klar zeigt:",
+      "logo": "Logo"
+    },
+    "subtitle_bank_statement": "Muss in den <strong>letzten 3 Monaten</strong> ausgestellt worden sein",
+    "subtitle_benefits_letter": "Muss in den <strong>letzten 12 Monaten</strong> ausgestellt worden sein",
+    "subtitle_bill": "Muss in den <strong>letzten 3 Monaten</strong> ausgestellt worden sein",
+    "subtitle_tax_letter": "Muss in den <strong>letzten 12 Monaten</strong> ausgestellt worden sein"
+  },
+  "poa_intro": {
+    "button_primary": "Bestätigung beginnen",
+    "list_matches_signup": "Der von Ihnen bei der Registrierung verwendeten Adresse <strong>entspricht</strong>",
+    "list_most_recent": "Ihr <strong>aktuellstes</strong> Dokument ist",
+    "list_shows_address": "Ihre  <strong>aktuelle</strong> Adresse zeigt",
+    "subtitle": "Sie brauchen ein Dokument, das:",
+    "title": "Bestätigen wir nun Ihre Adresse"
+  },
+  "profile_data": {
+    "address_title": "Fügen Sie Ihre Adresse hinzu",
+    "button_continue": "Weiter",
+    "components": {
+      "country_select": {
+        "placeholder": "Wählen Sie ein Land aus"
+      },
+      "nationality_select": {
+        "placeholder": "Wählen Sie ein Land aus"
+      },
+      "pan": {
+        "placeholder": "ABCDE1234F"
+      },
+      "ssn": {
+        "placeholder": "123-45-6789"
+      },
+      "state_select": {
+        "placeholder": "Wählen Sie ein Bundesland aus"
+      }
+    },
+    "country_of_residence_title": "Ihr Wohnsitzland",
+    "field_labels": {
+      "country": "Land",
+      "dob": "Geburtsdatum",
+      "email": "E-Mail-Adresse",
+      "first_name": "Vorname",
+      "gbr_specific": {
+        "postcode": "Postleitzahl",
+        "town": "Stadt"
+      },
+      "last_name": "Nachname",
+      "line1": "Adresszeile 1",
+      "line2": "Adresszeile 2",
+      "line3": "Adresszeile 3",
+      "mobile_number": "Mobiltelefonnummer",
+      "nationality": "Nationalität",
+      "pan": "Permanente Account-Nummer (PAN)",
+      "postcode": "Postleitzahl",
+      "ssn": "Sozialversicherungsnummer (SVN)",
+      "town": "Stadt",
+      "usa_specific": {
+        "line1_helper_text": "Straßenname, zum Beispiel: Abertstraße 200",
+        "line2_helper_text": "Wohnung, Suite, Einheit, etc.",
+        "postcode": "Zip code",
+        "state": "Staat"
+      }
+    },
+    "field_optional": "(optional)",
+    "field_validation": {
+      "gbr_specific": {
+        "required_postcode": "Bitte geben Sie Ihre Postleitzahl ein",
+        "too_long_postcode": "Die Postleitzahl ist zu lang",
+        "too_short_postcode": "Die Postleitzahl ist zu kurz"
+      },
+      "invalid": "Bitte auf ungültige Zeichen oder Symbole überprüfen",
+      "invalid_dob": "Bitte geben Sie ein gültiges Geburtsdatum ein",
+      "required_country": "Bitte wählen Sie ein Land aus",
+      "required_dob": "Bitte geben Sie Ihr Geburtsdatum ein",
+      "required_email": "Bitte geben Sie Ihre E-Mail-Adresse ein",
+      "required_first_name": "",
+      "required_last_name": "Bitte geben Sie Ihren Nachnamen ein",
+      "required_line1": "Bitte geben Sie Ihre Adresse ein",
+      "required_mobile_number": "Bitte geben Sie Ihre Mobiltelefonnummer ein",
+      "required_nationality": "Bitte wählen Sie ein Land aus",
+      "required_pan": "Bitte geben Sie Ihre PAN ein",
+      "required_postcode": "Bitte geben Sie Ihre Postleitzahl ein",
+      "required_ssn": "Bitte geben Sie Ihre SVN ein",
+      "too_long__line1": "Die Adresszeile ist zu lang",
+      "too_long_first_name": "Der Vorname ist zu lang",
+      "too_long_last_name": "Der Nachname ist zu lang",
+      "too_long_postcode": "Die Postleitzahl ist zu lang",
+      "too_long_town": "",
+      "too_short_first_name": "Der Vorname ist zu kurz",
+      "too_short_last_name": "Der Nachname ist zu kurz",
+      "too_short_postcode": "Die Postleitzahl ist zu kurz",
+      "usa_specific": {
+        "required_state": "Bitte wählen Sie einen Staat aus"
+      },
+      "valid_email": "Bitte geben Sie eine gültige E-Mail-Adresse ein",
+      "valid_mobile_number": "Bitte geben Sie eine gültige Mobiltelefonnummer ein",
+      "valid_pan": "Bitte geben Sie eine gültige PAN ein",
+      "valid_ssn": "Bitte geben Sie eine gültige SVN ein"
+    },
+    "personal_information_title": "Fügen Sie Ihre persönlichen Informationen hinzu",
+    "prompt": {
+      "details_timeout": "Erneut starten",
+      "header_timeout": "Sieht aus, als hätten Sie zu lange gebraucht"
+    }
+  },
+  "retry_feedback": {
+    "button_primary": "Versuchen Sie es erneut."
+  },
+  "retry_feedback_id_expired": {
+    "subtitle": "Versuchen Sie es mit einem gültigen Lichtbildausweis erneut und stellen Sie sicher, dass die Angaben zu Ihrer Person gut sichtbar sind",
+    "title": "Ihr Ausweis ist ungültig"
+  },
+  "retry_feedback_id_generic": {
+    "subtitle": "Versuchen Sie es mit einem gültigen Lichtbildausweis erneut und stellen Sie sicher, dass die Angaben zu Ihrer Person gut sichtbar sind",
+    "title": "Es gab ein Problem mit Ihrem Ausweis"
+  },
+  "retry_feedback_id_unaccepted": {
+    "subtitle": "Versuchen Sie es mit einem gültigen Lichtbildausweis erneut und stellen Sie sicher, dass die Angaben zu Ihrer Person gut sichtbar sind",
+    "title": "Ausweis wird nicht akzeptiert"
+  },
+  "retry_feedback_selfie_generic": {
+    "subtitle": "Versuchen Sie es erneut und stellen Sie sicher, dass Ihr Gesicht sichtbar und gut beleuchtet ist",
+    "title": "Es gab ein Problem mit Ihrem Selfie"
+  },
+  "selfie_capture": {
+    "alert": {
+      "camera_inactive": {
+        "detail": "Überprüfen Sie, ob die Kamera verbunden und funktionsfähig ist. Sie können <fallback>die Überprüfung auch auf Ihrem Telefon fortsetzen.</fallback>",
+        "detail_no_fallback": "Stellen Sie sicher, dass Ihr Gerät über eine funktionierende Kamera verfügt",
+        "title": "Kamera funktioniert nicht?"
+      },
+      "camera_not_working": {
+        "detail": "Die Verbindung kann unterbrochen werden. <fallback>Versuchen Sie stattdessen, Ihr Telefon zu benutzen</fallback>.",
+        "detail_no_fallback": "Stellen Sie sicher, dass die Kamera Ihres Geräts funktioniert",
+        "title": "Kamera funktioniert nicht"
+      },
+      "timeout": {
+        "detail": "Denken Sie daran, die Taste zu drücken, wenn Sie fertig sind. <fallback>Video-Aktionen wiederholen</fallback>.",
+        "title": "Sieht aus, als hätten Sie zu lange gebraucht"
+      }
+    },
+    "body": "Positionieren Sie Ihr Gesicht im angezeigten Oval",
+    "button_accessibility": "Ein Foto machen",
+    "button_primary": "Starten Sie mit dem Scannen des Gesichts",
+    "frame_accessibility": "Ansicht von der Kamera",
+    "title": "Positionieren Sie Ihr Gesicht im angezeigten Oval"
+  },
+  "selfie_confirmation": {
+    "image_accessibility": "Foto von Ihrem Gesicht",
+    "subtitle": "Stellen Sie sicher, dass Ihr Selfie Ihr Gesicht deutlich zeigt",
+    "title": "Selfie prüfen"
+  },
+  "selfie_intro": {
+    "button_primary": "Fortfahren",
+    "list_accessibility": "Tipps für ein gutes Selfie",
+    "list_item_face_forward": "Schauen Sie nach vorne und stellen Sie sicher, dass Ihre Augen deutlich sichtbar sind",
+    "list_item_no_glasses": "Nehmen Sie Ihre Brille ab, falls erforderlich",
+    "subtitle": "Wir werden dies mit Ihrem Dokument vergleichen",
+    "title": "Ein Selfie aufnehmen"
+  },
+  "sms_sent": {
+    "info": "Tipps",
+    "info_link_expire": "Ihr Link läuft in einer Stunde ab",
+    "info_link_window": "Lassen Sie dieses Fenster geöffnet, während Sie Ihr Mobiltelefon bedienen",
+    "link": "Link erneut senden",
+    "subtitle": "Wir haben einen sicheren Link an %{number} gesendet",
+    "subtitle_minutes": "Dieser Vorgang kann einige Minuten dauern",
+    "title": "Überprüfen Sie Ihr Mobiltelefon"
+  },
+  "switch_phone": {
+    "info": "Tipps",
+    "info_link_expire": "Ihr mobiler Link läuft in einer Stunde ab",
+    "info_link_refresh": "Diese Seite nicht aktualisieren",
+    "info_link_window": "Lassen Sie dieses Fenster geöffnet, während Sie Ihr Mobiltelefon bedienen",
+    "link": "Abbrechen",
+    "subtitle": "Wenn Sie fertig sind, gelangen Sie zum nächsten Schritt",
+    "title": "Mit Ihrem Mobiltelefon verbunden"
+  },
+  "upload_guide": {
+    "button_primary": "Foto hochladen",
+    "image_detail_blur_alt": "Beispiel eines verschwommenen Dokuments",
+    "image_detail_blur_label": "Alle Details müssen klar sein - nichts verschwommen",
+    "image_detail_cutoff_label": "Alle Details anzeigen - einschließlich der unteren 2 Zeilen",
+    "image_detail_glare_label": "Entfernen Sie sich von direktem Licht - keine Blendung",
+    "image_detail_good_label": "Das Foto sollte Ihr Dokument deutlich zeigen",
+    "subtitle": "Scans und Fotokopien werden nicht akzeptiert",
+    "title": "Fotoseite des Reisepasses hochladen"
+  },
+  "user_consent": {
+    "button_primary": "Accept",
+    "button_secondary": "Do not accept",
+    "prompt": {
+      "button_primary": "Review again",
+      "button_secondary": "Yes, don’t verify me",
+      "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
+      "no_consent_title": "Are you sure?"
+    }
+  },
+  "user_consent_load_fail": {
+    "button_primary": "Reload screen",
+    "detail": "Check that your connection is stable, then try again",
+    "title": "Content failed to load"
+  },
+  "video_capture": {
+    "body": "Positionieren Sie Ihr Gesicht im angezeigten Oval",
+    "body_record": "Drücken Sie die Taste, wenn Sie bereit sind",
+    "body_stop": "Drücken Sie \"Stopp\", wenn Sie fertig sind",
+    "button_primary_finish": "Aufnahme beenden",
+    "button_primary_next": "Nächster Schritt",
+    "button_primary_start": "Aufnahme starten",
+    "button_record_accessibility": "Aufnahme starten",
+    "frame_accessibility": "Ansicht von der Kamera",
+    "header": {
+      "challenge_digit_instructions": "Sprechen Sie jede Ziffer laut aus",
+      "challenge_turn_forward": "dann nach vorne schauen",
+      "challenge_turn_left": "Kopf nach links drehen",
+      "challenge_turn_right": "Kopf nach rechts drehen"
+    },
+    "prompt": {
+      "header_timeout": "Sieht aus, als hätten Sie zu lange gebraucht"
+    }
+  },
+  "video_confirmation": {
+    "body": "Ihr Video wurde aufgezeichnet",
+    "button_primary": "Video senden",
+    "button_secondary": "Video erneut aufnehmen",
+    "title": "Selfie-Video prüfen",
+    "video_accessibility": "Wiedergeben Ihres aufgezeichneten Videos"
+  },
+  "video_intro": {
+    "button_primary": "Fortfahren",
+    "list_accessibility": "Aktionen zum Aufzeichnen eines Selfie-Videos",
+    "list_item_actions": "Beenden Sie Aktionen in weniger als 20 Sekunden",
+    "list_item_speak": "Befolgen Sie die Anweisungen zur Bewegung oder zum Sprechen",
+    "title": "Selfie-Video aufnehmen"
+  },
+  "welcome": {
+    "doc_video_subtitle": "Es dauert nur wenige Minuten",
+    "list_header_doc_video": "Nutzen Sie Ihr Gerät um Folgendes aufzunehmen:",
+    "list_header_webcam": "Verwenden Sie Ihre Webcam oder Ihr Telefon zum Fotografieren:",
+    "list_item_doc": "Ihr Ausweisdokument",
+    "list_item_doc_video_timeout": "Die Aufnahme ist auf <timeout></timeout> Sekunden beschränkt",
+    "list_item_poa": "Ihr Adressnachweis",
+    "list_item_selfie": "Ihr Gesicht",
+    "next_button": "Dokument auswählen",
+    "start_workflow_button": "Verifizierung beginnen",
+    "subtitle": "Es dauert nur wenige Minuten",
+    "title": "Identität überprüfen"
+  },
+  "workflow_complete": {
+    "pass": {
+      "description": "",
+      "title": ""
+    },
+    "reject": {
+      "description": "",
+      "title": ""
+    }
+  },
+  "workflow_erros": {
+    "generic_title": "",
+    "no_workflow_run_id": "",
+    "reload_app": "",
+    "task_not_completed": "",
+    "task_not_retrieved": "",
+    "task_not_supported": ""
+  }
 }

--- a/src/locales/en_US/en_US.json
+++ b/src/locales/en_US/en_US.json
@@ -1,765 +1,765 @@
 {
-    "auth_accessibility": {
-        "back_button": "Cancel"
+  "auth_accessibility": {
+    "back_button": "Cancel"
+  },
+  "auth_cam_encrypt": {
+    "loader": "Encrypting camera feed"
+  },
+  "auth_cam_start": {
+    "loader": "Starting camera"
+  },
+  "auth_capture_start": {
+    "body": "Fit your face within the oval frame",
+    "button_primary": "Start face scan",
+    "feedback": {
+      "center_face": "Frame your face",
+      "conditions_too_bright": "Find a less bright environment",
+      "conditions_too_dark": "Find a brighter environment",
+      "head_not_upright": "Keep your head upright",
+      "neutral_expression": "Keep a neutral expression",
+      "not_looking_straight": "Look forward",
+      "remove_sunglasses": "Remove your sunglasses",
+      "steady_count_1": "Keep still: 1",
+      "steady_count_2": "Keep still: 2",
+      "steady_count_3": "Keep still: 3"
     },
-    "auth_cam_encrypt": {
-        "loader": "Encrypting camera feed"
+    "title": "Start face scan"
+  },
+  "auth_capture": {
+    "feedback": {
+      "center_face": "Frame your face",
+      "even_lighting": "Make sure your lighting is even",
+      "eye_level": "Keep your camera at eye level",
+      "face_not_found": "Make sure your face is visible",
+      "head_not_upright": "Keep your head upright",
+      "move_back": "Now move back",
+      "move_close": "Now move in closer",
+      "move_closer": "Move in closer",
+      "not_looking_straight": "Look forward",
+      "steady": "Keep still"
+    }
+  },
+  "auth_error": {
+    "cam_encryption": {
+      "body": "This app blocks suspicious webcam configurations. <fallback>Learn more</fallback>.",
+      "button_primary": "Try again",
+      "button_primary_firefox": "Try again",
+      "subtitle": "This system cannot be verified due to the following:",
+      "table_header_1": "Possible issue",
+      "table_header_2": "Fix",
+      "table_row_1_cell_1": "Camera already in use by another app.",
+      "table_row_1_cell_1_firefox": "Camera permissions not remembered in Firefox.",
+      "table_row_1_cell_2": "Close the other app.",
+      "table_row_1_cell_2_firefox": "Check Remember Permissions.",
+      "table_row_2_cell_1": "A 3rd-party app is modifying the video.",
+      "table_row_2_cell_2": "Close/Uninstall the other app.",
+      "table_row_3_cell_1": "Hardware not capable of being secured.",
+      "table_row_3_cell_2": "Use a different device.",
+      "title": "<b>Issue Encrypting Camera Feed</b>"
+    }
+  },
+  "auth_full_screen": {
+    "body": "This will start the selfie capture in full screen mode",
+    "button_primary": "Open in full screen",
+    "title": "Full screen selfie mode"
+  },
+  "auth_permission_denied": {
+    "body_cam": "To continue, you must enable camera permissions in your device settings.",
+    "button_primary_cam": "Launch settings"
+  },
+  "auth_permission": {
+    "body_cam": "To continue, you must enable camera permissions when prompted.",
+    "button_primary_cam": "Enable camera",
+    "title_cam": "Allow camera access"
+  },
+  "auth_progress": {
+    "loader": "Uploading"
+  },
+  "auth_retry": {
+    "body_blur": "Clean your camera lens",
+    "body_neutral_expression": "Keep a neutral expression",
+    "body_too_bright": "Find a less bright environment",
+    "button_primary": "Start camera",
+    "subtitle": "We weren’t able to capture your face properly",
+    "title": "Scan your face again"
+  },
+  "auth_upload_pass": {
+    "body": "Upload successful"
+  },
+  "avc_confirmation": {
+    "button_primary_upload": "Upload recording",
+    "subtitle": "A video of your face has been recorded successfully",
+    "title": "Recording complete"
+  },
+  "avc_connection_error": {
+    "button_primary_reload": "Reload instructions",
+    "button_primary_retry_upload": "Retry upload",
+    "button_secondary_restart_recording": "Restart recording",
+    "subtitle": "Check that your connection is stable, then try again",
+    "title": "Connection error"
+  },
+  "avc_face_alignment": {
+    "feedback_move_back": "Move back",
+    "feedback_move_closer": "Move closer",
+    "feedback_no_face_detected": "Face not detected",
+    "feedback_not_centered": "Face not centered",
+    "title": "Position your face in the frame"
+  },
+  "avc_face_capture": {
+    "alert": {
+      "timeout_body": "You have up to 15 seconds to complete the recording",
+      "timeout_button_primary": "Retry",
+      "timeout_title": "Sorry, we have to restart the recording",
+      "too_fast_body": "Please retry and turn your head slower",
+      "too_fast_button_primary": "Retry",
+      "too_fast_title": "You turned your head too fast"
     },
-    "auth_cam_start": {
-        "loader": "Starting camera"
+    "title": "Turn your head slowly to both sides",
+    "title_completed": "Recording complete"
+  },
+  "avc_intro": {
+    "button_primary_ready": "I'm ready",
+    "disclaimer": "Please be mindful that we'll record your face and your background",
+    "list_item_one": "First, position your face in the frame",
+    "list_item_two": "Then, turn your head slowly to both sides",
+    "subtitle": "This is to verify that you’re a real person",
+    "title": "Record a video"
+  },
+  "avc_no_face_detected": {
+    "button_primary_restart": "Restart recording",
+    "list_item_eyes": "Make sure your eyes are clearly visible",
+    "list_item_face": "Make sure to only show your face, we don’t need to see your ID",
+    "list_item_lighting": "Make sure to be in a place with good lighting",
+    "list_item_mask": "Make sure to remove masks or other items that cover your face. Eyeglasses are okay",
+    "title": "We can't detect your face"
+  },
+  "avc_uploading": {
+    "title": "Uploading"
+  },
+  "country_select": {
+    "alert": {
+      "another_doc": "Documents from that country are not currently supported — <fallback>try another document type</fallback>"
     },
-    "auth_capture_start": {
-        "body": "Fit your face within the oval frame",
-        "button_primary": "Start face scan",
-        "feedback": {
-            "center_face": "Frame your face",
-            "conditions_too_bright": "Find a less bright environment",
-            "conditions_too_dark": "Find a brighter environment",
-            "head_not_upright": "Keep your head upright",
-            "neutral_expression": "Keep a neutral expression",
-            "not_looking_straight": "Look forward",
-            "remove_sunglasses": "Remove your sunglasses",
-            "steady_count_1": "Keep still: 1",
-            "steady_count_2": "Keep still: 2",
-            "steady_count_3": "Keep still: 3"
-        },
-        "title": "Start face scan"
+    "alert_dropdown": {
+      "country_not_found": "Country not found"
     },
-    "auth_capture": {
-        "feedback": {
-            "center_face": "Frame your face",
-            "even_lighting": "Make sure your lighting is even",
-            "eye_level": "Keep your camera at eye level",
-            "face_not_found": "Make sure your face is visible",
-            "head_not_upright": "Keep your head upright",
-            "move_back": "Now move back",
-            "move_close": "Now move in closer",
-            "move_closer": "Move in closer",
-            "not_looking_straight": "Look forward",
-            "steady": "Keep still"
-        }
+    "button_primary": "Submit document",
+    "poa_alert": {
+      "country_not_found": "Sorry about that. We are working on supporting more countries.",
+      "intro": "Can’t find your country?"
     },
-    "auth_error": {
-        "cam_encryption": {
-            "body": "This app blocks suspicious webcam configurations. <fallback>Learn more<\/fallback>.",
-            "button_primary": "Try again",
-            "button_primary_firefox": "Try again",
-            "subtitle": "This system cannot be verified due to the following:",
-            "table_header_1": "Possible issue",
-            "table_header_2": "Fix",
-            "table_row_1_cell_1": "Camera already in use by another app.",
-            "table_row_1_cell_1_firefox": "Camera permissions not remembered in Firefox.",
-            "table_row_1_cell_2": "Close the other app.",
-            "table_row_1_cell_2_firefox": "Check Remember Permissions.",
-            "table_row_2_cell_1": "A 3rd-party app is modifying the video.",
-            "table_row_2_cell_2": "Close\/Uninstall the other app.",
-            "table_row_3_cell_1": "Hardware not capable of being secured.",
-            "table_row_3_cell_2": "Use a different device.",
-            "title": "<b>Issue Encrypting Camera Feed<\/b>"
-        }
+    "search": {
+      "accessibility": "Select country",
+      "input_placeholder": "e.g. United States",
+      "label": "Search for country"
     },
-    "auth_full_screen": {
-        "body": "This will start the selfie capture in full screen mode",
-        "button_primary": "Open in full screen",
-        "title": "Full screen selfie mode"
+    "title": "Select issuing country"
+  },
+  "cross_device_checklist": {
+    "button_primary": "Submit verification",
+    "info": "Tips",
+    "list_item_doc_multiple": "Documents",
+    "list_item_doc_one": "Document",
+    "list_item_poa": "Proof of address",
+    "list_item_selfie": "Selfie",
+    "list_item_video": "Video",
+    "subtitle": "Here’s everything you’ve uploaded:",
+    "title": "One final step"
+  },
+  "cross_device_error_desktop": {
+    "subtitle": "The link only works on mobile devices",
+    "title": "Something’s gone wrong"
+  },
+  "cross_device_error_restart": {
+    "subtitle": "You’ll need to restart your verification on your computer",
+    "title": "Something’s gone wrong"
+  },
+  "cross_device_intro": {
+    "button_primary": "Get secure link",
+    "list_accessibility": "Steps required to continue verification on your mobile",
+    "list_item_finish": "Check back here to finish the submission",
+    "list_item_open_link": "Open the link and complete the tasks",
+    "list_item_send_phone": "Send a secure link to your phone",
+    "subtitle": "Here’s how to do it:",
+    "title": "Continue on your phone"
+  },
+  "cross_device_return": {
+    "body": "Your computer may take a few seconds to update",
+    "subtitle": "You can now return to your computer to continue",
+    "title": "Uploads successful"
+  },
+  "cross_device_session_linked": {
+    "button_primary": "Continue",
+    "info": "Double-check",
+    "list_item_desktop_open": "Your desktop window remains open",
+    "list_item_sent_by_you": "This link was sent by you — seek advice if you think this could be a scam",
+    "subtitle": "Continue with the verification",
+    "title": "Mobile session linked to your computer"
+  },
+  "doc_capture": {
+    "button_primary": "Start document scan",
+    "detail": {
+      "folded_doc_front": "Lay your document flat, include all inner pages (must contain your photo)"
     },
-    "auth_permission_denied": {
-        "body_cam": "To continue, you must enable camera permissions in your device settings.",
-        "button_primary_cam": "Launch settings"
+    "header_folded_doc_front": "Profile photo side",
+    "prompt": {
+      "button_card": "Plastic card",
+      "button_paper": "Paper document",
+      "title_id": "What type of identity card do you have?",
+      "title_license": "What type of license do you have?"
+    }
+  },
+  "doc_confirmation": {
+    "alert": {
+      "blur_detail": "Make sure everything is clear",
+      "blur_title": "Blurry photo detected",
+      "crop_detail": "Make sure full document is visible",
+      "crop_title": "Cut-off image detected",
+      "glare_detail": "Move away from direct light",
+      "glare_title": "Glare detected",
+      "no_doc_detail": "Make sure it’s fully in the frame",
+      "no_doc_title": "Document not detected"
     },
-    "auth_permission": {
-        "body_cam": "To continue, you must enable camera permissions when prompted.",
-        "button_primary_cam": "Enable camera",
-        "title_cam": "Allow camera access"
+    "body": "Make sure you have uploaded the entire document page, and details are clear to read with no blur or glare",
+    "body_bank_statement": "Make sure you have uploaded the entire document page, and details are clear to read with no blur or glare",
+    "body_benefits_letter": "Make sure you have uploaded the entire document page, and details are clear to read with no blur or glare",
+    "body_bill": "Make sure you have uploaded the entire document page, and details are clear to read with no blur or glare",
+    "body_id": "Make sure your details are clear and unobstructed",
+    "body_image_medium": "It’ll take longer to verify you if we can’t read it",
+    "body_image_poor": "To smoothly verify you, we need a better photo",
+    "body_license": "Make sure your details are clear and unobstructed",
+    "body_passport": "Make sure your details are clear and unobstructed",
+    "body_permit": "Make sure your details are clear and unobstructed",
+    "body_tax_letter": "Make sure you have uploaded the entire document page, and details are clear to read with no blur or glare",
+    "button_close": "Close",
+    "button_primary_redo": "Redo",
+    "button_primary_upload": "Upload",
+    "button_primary_upload_anyway": "Upload anyway",
+    "button_secondary_redo": "Redo",
+    "button_zoom": "Enlarge image",
+    "image_accessibility": "Photo of your document",
+    "title": "Check your image"
+  },
+  "doc_multi_frame_capture": {
+    "capture_progress_title": "Scanning document",
+    "instructions_title_back": "Position the back of your document in the frame",
+    "instructions_title_front": "Position the front of your document in the frame"
+  },
+  "doc_select": {
+    "button_bank_statement": "Bank or building society statement",
+    "button_bank_statement_non_uk": "Bank statement",
+    "button_benefits_letter": "Benefits Letter",
+    "button_benefits_letter_detail": "Government authorised household benefits eg. Jobseeker allowance, Housing benefit, Tax credits",
+    "button_bill": "Utility Bill",
+    "button_bill_detail": "Gas, electricity, water, landline, or broadband",
+    "button_government_letter": "Government Letter",
+    "button_government_letter_detail": "Any government issued letter eg. Benefits entitlement, Voting letters, Tax letters, etc",
+    "button_id": "Identity card",
+    "button_id_detail": "Front and back",
+    "button_license": "Driver’s license",
+    "button_license_detail": "Front and back",
+    "button_passport": "Passport",
+    "button_passport_detail": "Photo page",
+    "button_permit": "Residence permit",
+    "button_permit_detail": "Front and back",
+    "button_tax_letter": "Council Tax Letter",
+    "extra_estatements_ok": "e-statements accepted",
+    "extra_no_mobile": "Sorry, no mobile phone bills",
+    "list_accessibility": "Documents you can use to verify your identity",
+    "pill": "fastest",
+    "section": {
+      "header_country": "Issuing country",
+      "header_doc_type": "Accepted documents",
+      "input_country_not_found": "No Results",
+      "input_placeholder_country": "Select issuing country"
     },
-    "auth_progress": {
-        "loader": "Uploading"
+    "subtitle": "It must be an official photo ID",
+    "subtitle_country": "Select issuing country to see which documents we accept",
+    "subtitle_entire_page": "Entire page",
+    "subtitle_front_back": "Front and back",
+    "subtitle_photo_page": "Photo page",
+    "subtitle_poa": "These are the documents most likely to show your current home address",
+    "title": "Choose your document",
+    "title_poa": "Select a %{country} document"
+  },
+  "doc_submit": {
+    "button_link_upload": "or upload photo – no scans or photocopies",
+    "button_primary": "Continue on phone",
+    "subtitle": "Take a photo with your phone",
+    "title_bank_statement": "Submit statement",
+    "title_benefits_letter": "Submit letter",
+    "title_bill": "Submit bill",
+    "title_government_letter": "Government Letter",
+    "title_id_back": "Submit identity card (back)",
+    "title_id_front": "Submit identity card (front)",
+    "title_license_back": "Submit license (back)",
+    "title_license_front": "Submit license (front)",
+    "title_passport": "Submit passport photo page",
+    "title_permit_back": "Submit residence permit (back)",
+    "title_permit_front": "Submit residence permit (front)",
+    "title_tax_letter": "Submit letter"
+  },
+  "doc_video_capture": {
+    "button_primary_fallback": "Next step",
+    "button_primary_fallback_end": "Finish recording",
+    "detail_step2": "Keep the document in full view at all times",
+    "header": "While holding your document, keep the front side within the frame",
+    "header_paper_doc_step2": "Slowly turn your document around to show the outer pages",
+    "header_passport": "While holding your passport, keep the photo page within the frame",
+    "header_passport_progress": "Hold still",
+    "header_step1": "Now, keep still",
+    "header_step2": "Slowly turn your document around to show the back",
+    "prompt": {
+      "detail_timeout": "Video recording is limited to <timeout></timeout> seconds. <fallback>Start again</fallback>"
     },
-    "auth_retry": {
-        "body_blur": "Clean your camera lens",
-        "body_neutral_expression": "Keep a neutral expression",
-        "body_too_bright": "Find a less bright environment",
-        "button_primary": "Start camera",
-        "subtitle": "We weren’t able to capture your face properly",
-        "title": "Scan your face again"
+    "stepper": "Step <step></step> of <total></total>",
+    "success_accessibility": "Success"
+  },
+  "doc_video_confirmation": {
+    "button_secondary": "Preview video",
+    "title": "Check your video"
+  },
+  "error_unsupported_browser": {
+    "subtitle_android": "Restart the process on the latest version of Google Chrome",
+    "subtitle_ios": "Restart the process on the latest version of Safari",
+    "title_android": "Unsupported browser",
+    "title_ios": "Unsupported browser"
+  },
+  "generic": {
+    "accessibility": {
+      "close_sdk_screen": "Close identity verification screen",
+      "dismiss_alert": "Dismiss alert"
     },
-    "auth_upload_pass": {
-        "body": "Upload successful"
+    "back": "back",
+    "close": "close",
+    "errors": {
+      "expired_token": {
+        "instruction": "Please try again",
+        "message": "Your token has expired"
+      },
+      "geoblocked_error": {
+        "instruction": "We’re sorry, seems like we can’t proceed further as your current location is not supported",
+        "message": "Service unavailable"
+      },
+      "interrupted_flow_error": {
+        "instruction": "Restart process on a different device",
+        "message": "Camera not detected"
+      },
+      "invalid_size": {
+        "instruction": "Must be under 10MB.",
+        "message": "File size exceeded."
+      },
+      "invalid_type": {
+        "instruction": "Try using another file type.",
+        "message": "File not uploaded."
+      },
+      "lazy_loading": {
+        "message": "An error occurred while loading the component"
+      },
+      "multiple_faces": {
+        "instruction": "Only your face can be in the selfie",
+        "message": "Multiple faces found"
+      },
+      "no_face": {
+        "instruction": "Make sure your face is visible",
+        "message": "Face not detected"
+      },
+      "request_error": {
+        "instruction": "Please try again",
+        "message": "Something’s gone wrong"
+      },
+      "sms_failed": {
+        "instruction": "Copy the link to your phone",
+        "message": "Something’s gone wrong"
+      },
+      "sms_overuse": {
+        "instruction": "Copy the link to your phone",
+        "message": "Too many failed attempts"
+      },
+      "unsupported_file": {
+        "instruction": "Try using a JPG or PNG file",
+        "message": "File type not supported"
+      }
     },
-    "avc_confirmation": {
-        "button_primary_upload": "Upload recording",
-        "subtitle": "A video of your face has been recorded successfully",
-        "title": "Recording complete"
-    },
-    "avc_connection_error": {
-        "button_primary_reload": "Reload instructions",
-        "button_primary_retry_upload": "Retry upload",
-        "button_secondary_restart_recording": "Restart recording",
-        "subtitle": "Check that your connection is stable, then try again",
-        "title": "Connection error"
-    },
-    "avc_face_alignment": {
-        "feedback_move_back": "Move back",
-        "feedback_move_closer": "Move closer",
-        "feedback_no_face_detected": "Face not detected",
-        "feedback_not_centered": "Face not centered",
-        "title": "Position your face in the frame"
-    },
-    "avc_face_capture": {
-        "alert": {
-            "timeout_body": "You have up to 15 seconds to complete the recording",
-            "timeout_button_primary": "Retry",
-            "timeout_title": "Sorry, we have to restart the recording",
-            "too_fast_body": "Please retry and turn your head slower",
-            "too_fast_button_primary": "Retry",
-            "too_fast_title": "You turned your head too fast"
-        },
-        "title": "Turn your head slowly to both sides",
-        "title_completed": "Recording complete"
-    },
-    "avc_intro": {
-        "button_primary_ready": "I'm ready",
-        "disclaimer": "Please be mindful that we'll record your face and your background",
-        "list_item_one": "First, position your face in the frame",
-        "list_item_two": "Then, turn your head slowly to both sides",
-        "subtitle": "This is to verify that you’re a real person",
-        "title": "Record a video"
-    },
-    "avc_no_face_detected": {
-        "button_primary_restart": "Restart recording",
-        "list_item_eyes": "Make sure your eyes are clearly visible",
-        "list_item_face": "Make sure to only show your face, we don’t need to see your ID",
-        "list_item_lighting": "Make sure to be in a place with good lighting",
-        "list_item_mask": "Make sure to remove masks or other items that cover your face. Eyeglasses are okay",
-        "title": "We can't detect your face"
-    },
-    "avc_uploading": {
-        "title": "Uploading"
-    },
-    "country_select": {
-        "alert": {
-            "another_doc": "Documents from that country are not currently supported — <fallback>try another document type<\/fallback>"
-        },
-        "alert_dropdown": {
-            "country_not_found": "Country not found"
-        },
-        "button_primary": "Submit document",
-        "poa_alert": {
-            "country_not_found": "Sorry about that. We are working on supporting more countries.",
-            "intro": "Can’t find your country?"
-        },
-        "search": {
-            "accessibility": "Select country",
-            "input_placeholder": "e.g. United States",
-            "label": "Search for country"
-        },
-        "title": "Select issuing country"
-    },
-    "cross_device_checklist": {
-        "button_primary": "Submit verification",
-        "info": "Tips",
-        "list_item_doc_multiple": "Documents",
-        "list_item_doc_one": "Document",
-        "list_item_poa": "Proof of address",
-        "list_item_selfie": "Selfie",
-        "list_item_video": "Video",
-        "subtitle": "Here’s everything you’ve uploaded:",
-        "title": "One final step"
-    },
-    "cross_device_error_desktop": {
-        "subtitle": "The link only works on mobile devices",
-        "title": "Something’s gone wrong"
-    },
-    "cross_device_error_restart": {
-        "subtitle": "You’ll need to restart your verification on your computer",
-        "title": "Something’s gone wrong"
-    },
-    "cross_device_intro": {
-        "button_primary": "Get secure link",
-        "list_accessibility": "Steps required to continue verification on your mobile",
-        "list_item_finish": "Check back here to finish the submission",
-        "list_item_open_link": "Open the link and complete the tasks",
-        "list_item_send_phone": "Send a secure link to your phone",
-        "subtitle": "Here’s how to do it:",
-        "title": "Continue on your phone"
-    },
-    "cross_device_return": {
-        "body": "Your computer may take a few seconds to update",
-        "subtitle": "You can now return to your computer to continue",
-        "title": "Uploads successful"
-    },
-    "cross_device_session_linked": {
-        "button_primary": "Continue",
-        "info": "Double-check",
-        "list_item_desktop_open": "Your desktop window remains open",
-        "list_item_sent_by_you": "This link was sent by you — seek advice if you think this could be a scam",
-        "subtitle": "Continue with the verification",
-        "title": "Mobile session linked to your computer"
-    },
-    "doc_capture": {
-        "button_primary": "Start document scan",
-        "detail": {
-            "folded_doc_front": "Lay your document flat, include all inner pages (must contain your photo)"
-        },
-        "header_folded_doc_front": "Profile photo side",
-        "prompt": {
-            "button_card": "Plastic card",
-            "button_paper": "Paper document",
-            "title_id": "What type of identity card do you have?",
-            "title_license": "What type of license do you have?"
-        }
-    },
-    "doc_confirmation": {
-        "alert": {
-            "blur_detail": "Make sure everything is clear",
-            "blur_title": "Blurry photo detected",
-            "crop_detail": "Make sure full document is visible",
-            "crop_title": "Cut-off image detected",
-            "glare_detail": "Move away from direct light",
-            "glare_title": "Glare detected",
-            "no_doc_detail": "Make sure it’s fully in the frame",
-            "no_doc_title": "Document not detected"
-        },
-        "body": "Make sure you have uploaded the entire document page, and details are clear to read with no blur or glare",
-        "body_bank_statement": "Make sure you have uploaded the entire document page, and details are clear to read with no blur or glare",
-        "body_benefits_letter": "Make sure you have uploaded the entire document page, and details are clear to read with no blur or glare",
-        "body_bill": "Make sure you have uploaded the entire document page, and details are clear to read with no blur or glare",
-        "body_id": "Make sure your details are clear and unobstructed",
-        "body_image_medium": "It’ll take longer to verify you if we can’t read it",
-        "body_image_poor": "To smoothly verify you, we need a better photo",
-        "body_license": "Make sure your details are clear and unobstructed",
-        "body_passport": "Make sure your details are clear and unobstructed",
-        "body_permit": "Make sure your details are clear and unobstructed",
-        "body_tax_letter": "Make sure you have uploaded the entire document page, and details are clear to read with no blur or glare",
-        "button_close": "Close",
-        "button_primary_redo": "Redo",
-        "button_primary_upload": "Upload",
-        "button_primary_upload_anyway": "Upload anyway",
-        "button_secondary_redo": "Redo",
-        "button_zoom": "Enlarge image",
-        "image_accessibility": "Photo of your document",
-        "title": "Check your image"
-    },
-    "doc_multi_frame_capture": {
-        "capture_progress_title": "Scanning document",
-        "instructions_title_back": "Position the back of your document in the frame",
-        "instructions_title_front": "Position the front of your document in the frame"
-    },
-    "doc_select": {
-        "button_bank_statement": "Bank or building society statement",
-        "button_bank_statement_non_uk": "Bank statement",
-        "button_benefits_letter": "Benefits Letter",
-        "button_benefits_letter_detail": "Government authorised household benefits eg. Jobseeker allowance, Housing benefit, Tax credits",
-        "button_bill": "Utility Bill",
-        "button_bill_detail": "Gas, electricity, water, landline, or broadband",
-        "button_government_letter": "Government Letter",
-        "button_government_letter_detail": "Any government issued letter eg. Benefits entitlement, Voting letters, Tax letters, etc",
-        "button_id": "Identity card",
-        "button_id_detail": "Front and back",
-        "button_license": "Driver’s license",
-        "button_license_detail": "Front and back",
-        "button_passport": "Passport",
-        "button_passport_detail": "Photo page",
-        "button_permit": "Residence permit",
-        "button_permit_detail": "Front and back",
-        "button_tax_letter": "Council Tax Letter",
-        "extra_estatements_ok": "e-statements accepted",
-        "extra_no_mobile": "Sorry, no mobile phone bills",
-        "list_accessibility": "Documents you can use to verify your identity",
-        "pill": "fastest",
-        "section": {
-            "header_country": "Issuing country",
-            "header_doc_type": "Accepted documents",
-            "input_country_not_found": "No Results",
-            "input_placeholder_country": "Select issuing country"
-        },
-        "subtitle": "It must be an official photo ID",
-        "subtitle_country": "Select issuing country to see which documents we accept",
-        "subtitle_entire_page": "Entire page",
-        "subtitle_front_back": "Front and back",
-        "subtitle_photo_page": "Photo page",
-        "subtitle_poa": "These are the documents most likely to show your current home address",
-        "title": "Choose your document",
-        "title_poa": "Select a %{country} document"
-    },
-    "doc_submit": {
-        "button_link_upload": "or upload photo – no scans or photocopies",
-        "button_primary": "Continue on phone",
-        "subtitle": "Take a photo with your phone",
-        "title_bank_statement": "Submit statement",
-        "title_benefits_letter": "Submit letter",
-        "title_bill": "Submit bill",
-        "title_government_letter": "Government Letter",
-        "title_id_back": "Submit identity card (back)",
-        "title_id_front": "Submit identity card (front)",
-        "title_license_back": "Submit license (back)",
-        "title_license_front": "Submit license (front)",
-        "title_passport": "Submit passport photo page",
-        "title_permit_back": "Submit residence permit (back)",
-        "title_permit_front": "Submit residence permit (front)",
-        "title_tax_letter": "Submit letter"
-    },
-    "doc_video_capture": {
-        "button_primary_fallback": "Next step",
-        "button_primary_fallback_end": "Finish recording",
-        "detail_step2": "Keep the document in full view at all times",
-        "header": "While holding your document, keep the front side within the frame",
-        "header_paper_doc_step2": "Slowly turn your document around to show the outer pages",
-        "header_passport": "While holding your passport, keep the photo page within the frame",
-        "header_passport_progress": "Hold still",
-        "header_step1": "Now, keep still",
-        "header_step2": "Slowly turn your document around to show the back",
-        "prompt": {
-            "detail_timeout": "Video recording is limited to <timeout><\/timeout> seconds. <fallback>Start again<\/fallback>"
-        },
-        "stepper": "Step <step><\/step> of <total><\/total>",
-        "success_accessibility": "Success"
-    },
-    "doc_video_confirmation": {
-        "button_secondary": "Preview video",
-        "title": "Check your video"
-    },
-    "error_unsupported_browser": {
-        "subtitle_android": "Restart the process on the latest version of Google Chrome",
-        "subtitle_ios": "Restart the process on the latest version of Safari",
-        "title_android": "Unsupported browser",
-        "title_ios": "Unsupported browser"
-    },
-    "generic": {
-        "accessibility": {
-            "close_sdk_screen": "Close identity verification screen",
-            "dismiss_alert": "Dismiss alert"
-        },
-        "back": "back",
-        "close": "close",
-        "errors": {
-            "expired_token": {
-                "instruction": "Please try again",
-                "message": "Your token has expired"
-            },
-            "geoblocked_error": {
-                "instruction": "We’re sorry, seems like we can’t proceed further as your current location is not supported",
-                "message": "Service unavailable"
-            },
-            "interrupted_flow_error": {
-                "instruction": "Restart process on a different device",
-                "message": "Camera not detected"
-            },
-            "invalid_size": {
-                "instruction": "Must be under 10MB.",
-                "message": "File size exceeded."
-            },
-            "invalid_type": {
-                "instruction": "Try using another file type.",
-                "message": "File not uploaded."
-            },
-            "lazy_loading": {
-                "message": "An error occurred while loading the component"
-            },
-            "multiple_faces": {
-                "instruction": "Only your face can be in the selfie",
-                "message": "Multiple faces found"
-            },
-            "no_face": {
-                "instruction": "Make sure your face is visible",
-                "message": "Face not detected"
-            },
-            "request_error": {
-                "instruction": "Please try again",
-                "message": "Something’s gone wrong"
-            },
-            "sms_failed": {
-                "instruction": "Copy the link to your phone",
-                "message": "Something’s gone wrong"
-            },
-            "sms_overuse": {
-                "instruction": "Copy the link to your phone",
-                "message": "Too many failed attempts"
-            },
-            "unsupported_file": {
-                "instruction": "Try using a JPG or PNG file",
-                "message": "File type not supported"
-            }
-        },
-        "lazy_load_placeholder": "Loading...",
-        "loading": "Loading"
-    },
-    "get_link": {
-        "alert_wrong_number": "Check that your number is correct",
-        "button_copied": "Copied",
-        "button_copy": "Copy",
-        "button_submit": "Send link",
-        "info_qr_how": "How to scan a QR code",
-        "info_qr_how_list_item_camera": "Point your phone’s camera at the QR code",
-        "info_qr_how_list_item_download": "If it doesn’t work, download a QR code scanner from Google Play or the App Store",
-        "link_divider": "or choose an alternative method",
-        "link_qr": "Scan QR code",
-        "link_sms": "Get link via SMS",
-        "link_url": "Copy link",
-        "loader_sending": "Sending",
-        "number_field_input_placeholder": "Enter mobile number",
-        "number_field_label": "Enter your mobile number:",
-        "subtitle_qr": "Scan the QR code with your phone",
-        "subtitle_sms": "Send this one-time link to your phone",
-        "subtitle_url": "Send this one-time link to your phone",
-        "title": "Get your secure link",
-        "url_field_label": "Copy the link to your mobile browser"
-    },
-    "livenessV2": {
-        "error_reload_instructions": "Reload instructions",
-        "intro_note_no1": "First, position your face in the frame",
-        "intro_note_no2": "Then, turn your head slowly to both sides",
-        "intro_ready_button": "Please be mindful that we’ll record your face and your background",
-        "intro_subtitle": "This is to verify that you’re a real person",
-        "intro_warning": "Please be mindful that we’ll record your face and your background",
-        "success_main_button": "Submit verification",
-        "success_title": "That’s all we need to start verifying your identity"
-    },
-    "mobilePhrases": {
-        "photo_upload": {
-            "body_id_back": "Take a photo of the back of your card",
-            "body_id_front": "Take a photo of the front of your card",
-            "body_license_back": "Take a photo of the back of your license",
-            "body_license_front": "Take a photo of the front of your license",
-            "body_passport": "Take a photo of your passport photo page",
-            "body_selfie": "Take a selfie showing your face"
-        },
-        "selfie_capture": {
-            "alert": {
-                "camera_inactive": {
-                    "detail": "Take a photo using the <fallback>basic camera mode<\/fallback> instead"
-                },
-                "camera_not_working": {
-                    "detail": "Take a photo using the <fallback>basic camera mode<\/fallback> instead"
-                }
-            }
-        },
-        "upload_guide": {
-            "button_primary": "Take a photo",
-            "title": "Passport photo page"
-        }
-    },
-    "outro": {
-        "body": "That’s all we need to start verifying your identity",
-        "body_government_letter": "Provide the whole document page for best results",
-        "title": "Thank you"
-    },
-    "permission": {
-        "body_both": "We can’t verify you without using both your camera and microphone",
-        "body_cam": "We can’t verify you without your camera",
-        "button_primary_both": "Enable both",
-        "button_primary_cam": "Enable camera",
-        "subtitle_both": "When prompted, you must enable access for both to continue",
-        "subtitle_cam": "When prompted, you must enable camera access to continue",
-        "title_both": "Allow camera and microphone access",
-        "title_cam": "Allow camera access"
-    },
-    "permission_recovery": {
-        "button_primary": "Refresh",
-        "info": "Recovery",
-        "list_header_both": "Follow these steps to recover access for both:",
-        "list_header_cam": "Follow these steps to recover camera access:",
-        "list_item_action_cam": "Refresh this page to restart the identity verification process",
-        "list_item_how_to_both": "Grant access to your camera and microphone from your browser settings",
-        "list_item_how_to_cam": "Grant access to your camera from your browser settings",
-        "subtitle_both": "Recover camera and microphone access to take a video and complete the verification process",
-        "subtitle_cam": "Recover camera access to continue your verification",
-        "subtitle_cam_old": "Recover camera access to continue face verification",
-        "title_both": "Camera and microphone access denied",
-        "title_cam": "Camera access is denied"
-    },
+    "lazy_load_placeholder": "Loading...",
+    "loading": "Loading"
+  },
+  "get_link": {
+    "alert_wrong_number": "Check that your number is correct",
+    "button_copied": "Copied",
+    "button_copy": "Copy",
+    "button_submit": "Send link",
+    "info_qr_how": "How to scan a QR code",
+    "info_qr_how_list_item_camera": "Point your phone’s camera at the QR code",
+    "info_qr_how_list_item_download": "If it doesn’t work, download a QR code scanner from Google Play or the App Store",
+    "link_divider": "or choose an alternative method",
+    "link_qr": "Scan QR code",
+    "link_sms": "Get link via SMS",
+    "link_url": "Copy link",
+    "loader_sending": "Sending",
+    "number_field_input_placeholder": "Enter mobile number",
+    "number_field_label": "Enter your mobile number:",
+    "subtitle_qr": "Scan the QR code with your phone",
+    "subtitle_sms": "Send this one-time link to your phone",
+    "subtitle_url": "Send this one-time link to your phone",
+    "title": "Get your secure link",
+    "url_field_label": "Copy the link to your mobile browser"
+  },
+  "livenessV2": {
+    "error_reload_instructions": "Reload instructions",
+    "intro_note_no1": "First, position your face in the frame",
+    "intro_note_no2": "Then, turn your head slowly to both sides",
+    "intro_ready_button": "Please be mindful that we’ll record your face and your background",
+    "intro_subtitle": "This is to verify that you’re a real person",
+    "intro_warning": "Please be mindful that we’ll record your face and your background",
+    "success_main_button": "Submit verification",
+    "success_title": "That’s all we need to start verifying your identity"
+  },
+  "mobilePhrases": {
     "photo_upload": {
-        "body_bank_statement": "Provide the whole document page for best results",
-        "body_benefits_letter": "Provide the whole document page for best results",
-        "body_bill": "Provide the whole document page for best results",
-        "body_id_back": "Upload back of card from your computer",
-        "body_id_front": "Upload front of card from your computer",
-        "body_license_back": "Upload back of license from your computer",
-        "body_license_front": "Upload front of license from your computer",
-        "body_passport": "Upload passport photo page from your computer",
-        "body_selfie": "Upload a selfie from your computer",
-        "body_tax_letter": "Provide the whole document page for best results",
-        "button_take_photo": "Take photo",
-        "button_upload": "Upload",
-        "title_selfie": "Selfie"
-    },
-    "poa_cancel": "Cancel",
-    "poa_err_invalid_file": {
-        "message": "Please choose a different file.",
-        "ok": "OK",
-        "title": "Invalid File"
-    },
-    "poa_guidance": {
-        "button_primary": "Continue",
-        "instructions": {
-            "address": "Current address",
-            "full_name": "Full name",
-            "issue_date": "Issue date or summary period",
-            "label": "Capture the entire document and make sure it clearly shows:",
-            "logo": "Logo"
-        },
-        "subtitle_bank_statement": "Must be issued in the <strong>last 3 months<\/strong>",
-        "subtitle_benefits_letter": "Must be issued in the <strong>last 12 months<\/strong>",
-        "subtitle_bill": "Must have been issued in the <strong>last 3 months<\/strong>",
-        "subtitle_tax_letter": "Must be issued in the <strong>last 12 months<\/strong>"
-    },
-    "poa_intro": {
-        "button_primary": "Start verification",
-        "list_matches_signup": "<strong>Matches<\/strong> the address you used on sign up",
-        "list_most_recent": "Is your most <strong>recent<\/strong> document",
-        "list_shows_address": "Shows your <strong>current<\/strong> address",
-        "subtitle": "You’ll need a document that:",
-        "title": "Let’s verify your address"
-    },
-    "profile_data": {
-        "address_title": "Add your address",
-        "button_continue": "Continue",
-        "components": {
-            "country_select": {
-                "placeholder": "Select a country"
-            },
-            "nationality_select": {
-                "placeholder": "Select a country"
-            },
-            "pan": {
-                "placeholder": "ABCDE1234F"
-            },
-            "ssn": {
-                "placeholder": "123-45-6789"
-            },
-            "state_select": {
-                "placeholder": "Select a state"
-            }
-        },
-        "country_of_residence_title": "Your country of residence",
-        "field_labels": {
-            "country": "Country",
-            "dob": "Date of birth",
-            "email": "Email",
-            "first_name": "First name",
-            "gbr_specific": {
-                "postcode": "Postcode",
-                "town": "City\/Town"
-            },
-            "last_name": "Last name",
-            "line1": "Address line 1",
-            "line2": "Address line 2",
-            "line3": "Address line 3",
-            "mobile_number": "Mobile number",
-            "nationality": "Nationality",
-            "pan": "Permanent account number (PAN)",
-            "postcode": "Postal code",
-            "ssn": "Social Security number (SSN)",
-            "town": "Town",
-            "usa_specific": {
-                "line1_helper_text": "Street address, for example: 200 Albert Street",
-                "line2_helper_text": "Apartment, suite, unit, etc.",
-                "postcode": "Zip code",
-                "state": "State"
-            }
-        },
-        "field_optional": "(optional)",
-        "field_validation": {
-            "gbr_specific": {
-                "required_postcode": "Please enter your postcode",
-                "too_long_postcode": "Postcode is too long",
-                "too_short_postcode": "Postcode is too short"
-            },
-            "invalid": "Please check for invalid characters or symbols",
-            "invalid_dob": "Please enter a valid date of birth",
-            "required_country": "Please select a country",
-            "required_dob": "Please enter your date of birth",
-            "required_email": "Please enter your email",
-            "required_first_name": "Please enter your first name",
-            "required_last_name": "Please enter your last name",
-            "required_line1": "Please enter your address",
-            "required_mobile_number": "Please enter your mobile number",
-            "required_nationality": "Please select a country",
-            "required_pan": "Please enter your PAN",
-            "required_postcode": "Please enter your postal code",
-            "required_ssn": "Please enter your SSN",
-            "too_long__line1": "Address line is too long",
-            "too_long_first_name": "First name is too long",
-            "too_long_last_name": "Last name is too long",
-            "too_long_postcode": "Postal code is too long",
-            "too_long_town": "Town is too long",
-            "too_short_first_name": "First name is too short",
-            "too_short_last_name": "Last name is too short",
-            "too_short_postcode": "Postal code is too short",
-            "usa_specific": {
-                "required_state": "Please select a state"
-            },
-            "valid_email": "Please enter a valid email",
-            "valid_mobile_number": "Please enter a valid mobile number",
-            "valid_pan": "Please enter a valid PAN",
-            "valid_ssn": "Please enter a valid SSN"
-        },
-        "personal_information_title": "Add your personal information",
-        "prompt": {
-            "details_timeout": "Start again",
-            "header_timeout": "Looks like you took too long"
-        }
-    },
-    "retry_feedback": {
-        "button_primary": "Try again"
-    },
-    "retry_feedback_id_expired": {
-        "subtitle": "Please try again with a valid photo ID and make sure your information is clearly visible",
-        "title": "Your document has expired"
-    },
-    "retry_feedback_id_generic": {
-        "subtitle": "Please try again with a valid photo ID and make sure your information is clearly visible",
-        "title": "There was a problem with your document"
-    },
-    "retry_feedback_id_unaccepted": {
-        "subtitle": "Please try again with a valid photo ID and make sure your information is clearly visible",
-        "title": "Unaccepted document"
-    },
-    "retry_feedback_selfie_generic": {
-        "subtitle": "Please try again, and make sure your face is visible and well lit",
-        "title": "There was a problem with your selfie"
+      "body_id_back": "Take a photo of the back of your card",
+      "body_id_front": "Take a photo of the front of your card",
+      "body_license_back": "Take a photo of the back of your license",
+      "body_license_front": "Take a photo of the front of your license",
+      "body_passport": "Take a photo of your passport photo page",
+      "body_selfie": "Take a selfie showing your face"
     },
     "selfie_capture": {
-        "alert": {
-            "camera_inactive": {
-                "detail": "Check that it is connected and functional. You can also <fallback>continue verification on your phone<\/fallback>",
-                "detail_no_fallback": "Make sure your device has a working camera",
-                "title": "Camera not working?"
-            },
-            "camera_not_working": {
-                "detail": "It may be disconnected. <fallback>Try using your phone instead<\/fallback>.",
-                "detail_no_fallback": "Make sure your device’s camera works",
-                "title": "Camera not working"
-            },
-            "timeout": {
-                "detail": "Remember to press the button when you’re done. <fallback>Redo video actions<\/fallback>",
-                "title": "Looks like you took too long"
-            }
+      "alert": {
+        "camera_inactive": {
+          "detail": "Take a photo using the <fallback>basic camera mode</fallback> instead"
         },
-        "body": "Keep your face within the oval",
-        "button_accessibility": "Take a photo",
-        "button_primary": "Start face scan",
-        "frame_accessibility": "View from camera",
-        "title": "Keep your face within the oval"
-    },
-    "selfie_confirmation": {
-        "image_accessibility": "Photo of your face",
-        "subtitle": "Make sure your entire face is visible",
-        "title": "Check your selfie"
-    },
-    "selfie_intro": {
-        "button_primary": "Continue",
-        "list_accessibility": "Tips to take a good selfie",
-        "list_item_face_forward": "Face forward and make sure your eyes are clearly visible",
-        "list_item_no_glasses": "Remove your glasses, if necessary",
-        "subtitle": "We’ll compare this with your document",
-        "title": "Take a selfie"
-    },
-    "sms_sent": {
-        "info": "Tips",
-        "info_link_expire": "Your link will expire in one hour",
-        "info_link_window": "Keep this window open while using your mobile",
-        "link": "Resend link",
-        "subtitle": "We’ve sent a secure link to %{number}",
-        "subtitle_minutes": "It may take a few minutes to arrive",
-        "title": "Check your mobile"
-    },
-    "switch_phone": {
-        "info": "Tips",
-        "info_link_expire": "Your mobile link will expire in one hour",
-        "info_link_refresh": "Don’t refresh this page",
-        "info_link_window": "Keep this window open while using your mobile",
-        "link": "Cancel",
-        "subtitle": "Once you’ve finished we’ll take you to the next step",
-        "title": "Connected to your mobile"
+        "camera_not_working": {
+          "detail": "Take a photo using the <fallback>basic camera mode</fallback> instead"
+        }
+      }
     },
     "upload_guide": {
-        "button_primary": "Upload photo",
-        "image_detail_blur_alt": "Example of a blurry document",
-        "image_detail_blur_label": "All details must be clear — nothing blurry",
-        "image_detail_cutoff_label": "Show all details — including the bottom 2 lines",
-        "image_detail_glare_label": "Move away from direct light — no glare",
-        "image_detail_good_label": "The photo should clearly show your document",
-        "subtitle": "Scans and photocopies are not accepted",
-        "title": "Upload passport photo page"
-    },
-    "user_consent": {
-        "button_primary": "Accept",
-        "button_secondary": "Do not accept",
-        "prompt": {
-            "button_primary": "Review again",
-            "button_secondary": "Yes, don’t verify me",
-            "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
-            "no_consent_title": "Are you sure?"
-        }
-    },
-    "user_consent_load_fail": {
-        "button_primary": "Reload screen",
-        "detail": "Check that your connection is stable, then try again",
-        "title": "Content failed to load"
-    },
-    "video_capture": {
-        "body": "Keep your face within the oval",
-        "body_record": "Press the button when you’re ready",
-        "body_stop": "Press stop when you’re done",
-        "button_primary_finish": "Finish recording",
-        "button_primary_next": "Next step",
-        "button_primary_start": "Start recording",
-        "button_record_accessibility": "Start recording",
-        "frame_accessibility": "View from camera",
-        "header": {
-            "challenge_digit_instructions": "Say each digit out loud",
-            "challenge_turn_forward": "then face forward",
-            "challenge_turn_left": "Turn your head left",
-            "challenge_turn_right": "Turn your head right"
-        },
-        "prompt": {
-            "header_timeout": "Looks like you took too long"
-        }
-    },
-    "video_confirmation": {
-        "body": "Your video has been recorded",
-        "button_primary": "Upload video",
-        "button_secondary": "Retake video",
-        "title": "Check your video",
-        "video_accessibility": "Replay your recorded video"
-    },
-    "video_intro": {
-        "button_primary": "Record video",
-        "list_accessibility": "Actions to record a selfie video",
-        "list_item_actions": "You have 20 seconds to finish",
-        "list_item_speak": "Follow the instructions to move or speak",
-        "title": "Record a video"
-    },
-    "welcome": {
-        "doc_video_subtitle": "It should take a few minutes",
-        "list_header_doc_video": "Use your device to record:",
-        "list_header_webcam": "Use your webcam or phone to photograph:",
-        "list_item_doc": "your identity document",
-        "list_item_doc_video_timeout": "Recording is limited to <timeout><\/timeout> seconds",
-        "list_item_poa": "your proof of address",
-        "list_item_selfie": "your face",
-        "next_button": "Choose document",
-        "start_workflow_button": "Start verfication",
-        "subtitle": "It should take a few minutes",
-        "title": "Verify your identity"
-    },
-    "workflow_complete": {
-        "pass": {
-            "description": "We have been able to verify your identity",
-            "title": "Passed"
-        },
-        "reject": {
-            "description": "We haven't been able to verify your identity",
-            "title": "Rejected"
-        }
-    },
-    "workflow_erros": {
-        "generic_title": "There was a server error!",
-        "no_workflow_run_id": "Workflow run ID is not set.",
-        "reload_app": "Please try reloading the app, and try again.",
-        "task_not_completed": "Could not complete workflow task.",
-        "task_not_retrieved": "Could not retrieve workflow task.",
-        "task_not_supported": "Task is currently not supported"
+      "button_primary": "Take a photo",
+      "title": "Passport photo page"
     }
+  },
+  "outro": {
+    "body": "That’s all we need to start verifying your identity",
+    "body_government_letter": "Provide the whole document page for best results",
+    "title": "Thank you"
+  },
+  "permission": {
+    "body_both": "We can’t verify you without using both your camera and microphone",
+    "body_cam": "We can’t verify you without your camera",
+    "button_primary_both": "Enable both",
+    "button_primary_cam": "Enable camera",
+    "subtitle_both": "When prompted, you must enable access for both to continue",
+    "subtitle_cam": "When prompted, you must enable camera access to continue",
+    "title_both": "Allow camera and microphone access",
+    "title_cam": "Allow camera access"
+  },
+  "permission_recovery": {
+    "button_primary": "Refresh",
+    "info": "Recovery",
+    "list_header_both": "Follow these steps to recover access for both:",
+    "list_header_cam": "Follow these steps to recover camera access:",
+    "list_item_action_cam": "Refresh this page to restart the identity verification process",
+    "list_item_how_to_both": "Grant access to your camera and microphone from your browser settings",
+    "list_item_how_to_cam": "Grant access to your camera from your browser settings",
+    "subtitle_both": "Recover camera and microphone access to take a video and complete the verification process",
+    "subtitle_cam": "Recover camera access to continue your verification",
+    "subtitle_cam_old": "Recover camera access to continue face verification",
+    "title_both": "Camera and microphone access denied",
+    "title_cam": "Camera access is denied"
+  },
+  "photo_upload": {
+    "body_bank_statement": "Provide the whole document page for best results",
+    "body_benefits_letter": "Provide the whole document page for best results",
+    "body_bill": "Provide the whole document page for best results",
+    "body_id_back": "Upload back of card from your computer",
+    "body_id_front": "Upload front of card from your computer",
+    "body_license_back": "Upload back of license from your computer",
+    "body_license_front": "Upload front of license from your computer",
+    "body_passport": "Upload passport photo page from your computer",
+    "body_selfie": "Upload a selfie from your computer",
+    "body_tax_letter": "Provide the whole document page for best results",
+    "button_take_photo": "Take photo",
+    "button_upload": "Upload",
+    "title_selfie": "Selfie"
+  },
+  "poa_cancel": "Cancel",
+  "poa_err_invalid_file": {
+    "message": "Please choose a different file.",
+    "ok": "OK",
+    "title": "Invalid File"
+  },
+  "poa_guidance": {
+    "button_primary": "Continue",
+    "instructions": {
+      "address": "Current address",
+      "full_name": "Full name",
+      "issue_date": "Issue date or summary period",
+      "label": "Capture the entire document and make sure it clearly shows:",
+      "logo": "Logo"
+    },
+    "subtitle_bank_statement": "Must be issued in the <strong>last 3 months</strong>",
+    "subtitle_benefits_letter": "Must be issued in the <strong>last 12 months</strong>",
+    "subtitle_bill": "Must have been issued in the <strong>last 3 months</strong>",
+    "subtitle_tax_letter": "Must be issued in the <strong>last 12 months</strong>"
+  },
+  "poa_intro": {
+    "button_primary": "Start verification",
+    "list_matches_signup": "<strong>Matches</strong> the address you used on sign up",
+    "list_most_recent": "Is your most <strong>recent</strong> document",
+    "list_shows_address": "Shows your <strong>current</strong> address",
+    "subtitle": "You’ll need a document that:",
+    "title": "Let’s verify your address"
+  },
+  "profile_data": {
+    "address_title": "Add your address",
+    "button_continue": "Continue",
+    "components": {
+      "country_select": {
+        "placeholder": "Select a country"
+      },
+      "nationality_select": {
+        "placeholder": "Select a country"
+      },
+      "pan": {
+        "placeholder": "ABCDE1234F"
+      },
+      "ssn": {
+        "placeholder": "123-45-6789"
+      },
+      "state_select": {
+        "placeholder": "Select a state"
+      }
+    },
+    "country_of_residence_title": "Your country of residence",
+    "field_labels": {
+      "country": "Country",
+      "dob": "Date of birth",
+      "email": "Email",
+      "first_name": "First name",
+      "gbr_specific": {
+        "postcode": "Postcode",
+        "town": "City/Town"
+      },
+      "last_name": "Last name",
+      "line1": "Address line 1",
+      "line2": "Address line 2",
+      "line3": "Address line 3",
+      "mobile_number": "Mobile number",
+      "nationality": "Nationality",
+      "pan": "Permanent account number (PAN)",
+      "postcode": "Postal code",
+      "ssn": "Social Security number (SSN)",
+      "town": "Town",
+      "usa_specific": {
+        "line1_helper_text": "Street address, for example: 200 Albert Street",
+        "line2_helper_text": "Apartment, suite, unit, etc.",
+        "postcode": "Zip code",
+        "state": "State"
+      }
+    },
+    "field_optional": "(optional)",
+    "field_validation": {
+      "gbr_specific": {
+        "required_postcode": "Please enter your postcode",
+        "too_long_postcode": "Postcode is too long",
+        "too_short_postcode": "Postcode is too short"
+      },
+      "invalid": "Please check for invalid characters or symbols",
+      "invalid_dob": "Please enter a valid date of birth",
+      "required_country": "Please select a country",
+      "required_dob": "Please enter your date of birth",
+      "required_email": "Please enter your email",
+      "required_first_name": "Please enter your first name",
+      "required_last_name": "Please enter your last name",
+      "required_line1": "Please enter your address",
+      "required_mobile_number": "Please enter your mobile number",
+      "required_nationality": "Please select a country",
+      "required_pan": "Please enter your PAN",
+      "required_postcode": "Please enter your postal code",
+      "required_ssn": "Please enter your SSN",
+      "too_long__line1": "Address line is too long",
+      "too_long_first_name": "First name is too long",
+      "too_long_last_name": "Last name is too long",
+      "too_long_postcode": "Postal code is too long",
+      "too_long_town": "Town is too long",
+      "too_short_first_name": "First name is too short",
+      "too_short_last_name": "Last name is too short",
+      "too_short_postcode": "Postal code is too short",
+      "usa_specific": {
+        "required_state": "Please select a state"
+      },
+      "valid_email": "Please enter a valid email",
+      "valid_mobile_number": "Please enter a valid mobile number",
+      "valid_pan": "Please enter a valid PAN",
+      "valid_ssn": "Please enter a valid SSN"
+    },
+    "personal_information_title": "Add your personal information",
+    "prompt": {
+      "details_timeout": "Start again",
+      "header_timeout": "Looks like you took too long"
+    }
+  },
+  "retry_feedback": {
+    "button_primary": "Try again"
+  },
+  "retry_feedback_id_expired": {
+    "subtitle": "Please try again with a valid photo ID and make sure your information is clearly visible",
+    "title": "Your document has expired"
+  },
+  "retry_feedback_id_generic": {
+    "subtitle": "Please try again with a valid photo ID and make sure your information is clearly visible",
+    "title": "There was a problem with your document"
+  },
+  "retry_feedback_id_unaccepted": {
+    "subtitle": "Please try again with a valid photo ID and make sure your information is clearly visible",
+    "title": "Unaccepted document"
+  },
+  "retry_feedback_selfie_generic": {
+    "subtitle": "Please try again, and make sure your face is visible and well lit",
+    "title": "There was a problem with your selfie"
+  },
+  "selfie_capture": {
+    "alert": {
+      "camera_inactive": {
+        "detail": "Check that it is connected and functional. You can also <fallback>continue verification on your phone</fallback>",
+        "detail_no_fallback": "Make sure your device has a working camera",
+        "title": "Camera not working?"
+      },
+      "camera_not_working": {
+        "detail": "It may be disconnected. <fallback>Try using your phone instead</fallback>.",
+        "detail_no_fallback": "Make sure your device’s camera works",
+        "title": "Camera not working"
+      },
+      "timeout": {
+        "detail": "Remember to press the button when you’re done. <fallback>Redo video actions</fallback>",
+        "title": "Looks like you took too long"
+      }
+    },
+    "body": "Keep your face within the oval",
+    "button_accessibility": "Take a photo",
+    "button_primary": "Start face scan",
+    "frame_accessibility": "View from camera",
+    "title": "Keep your face within the oval"
+  },
+  "selfie_confirmation": {
+    "image_accessibility": "Photo of your face",
+    "subtitle": "Make sure your entire face is visible",
+    "title": "Check your selfie"
+  },
+  "selfie_intro": {
+    "button_primary": "Continue",
+    "list_accessibility": "Tips to take a good selfie",
+    "list_item_face_forward": "Face forward and make sure your eyes are clearly visible",
+    "list_item_no_glasses": "Remove your glasses, if necessary",
+    "subtitle": "We’ll compare this with your document",
+    "title": "Take a selfie"
+  },
+  "sms_sent": {
+    "info": "Tips",
+    "info_link_expire": "Your link will expire in one hour",
+    "info_link_window": "Keep this window open while using your mobile",
+    "link": "Resend link",
+    "subtitle": "We’ve sent a secure link to %{number}",
+    "subtitle_minutes": "It may take a few minutes to arrive",
+    "title": "Check your mobile"
+  },
+  "switch_phone": {
+    "info": "Tips",
+    "info_link_expire": "Your mobile link will expire in one hour",
+    "info_link_refresh": "Don’t refresh this page",
+    "info_link_window": "Keep this window open while using your mobile",
+    "link": "Cancel",
+    "subtitle": "Once you’ve finished we’ll take you to the next step",
+    "title": "Connected to your mobile"
+  },
+  "upload_guide": {
+    "button_primary": "Upload photo",
+    "image_detail_blur_alt": "Example of a blurry document",
+    "image_detail_blur_label": "All details must be clear — nothing blurry",
+    "image_detail_cutoff_label": "Show all details — including the bottom 2 lines",
+    "image_detail_glare_label": "Move away from direct light — no glare",
+    "image_detail_good_label": "The photo should clearly show your document",
+    "subtitle": "Scans and photocopies are not accepted",
+    "title": "Upload passport photo page"
+  },
+  "user_consent": {
+    "button_primary": "Accept",
+    "button_secondary": "Do not accept",
+    "prompt": {
+      "button_primary": "Review again",
+      "button_secondary": "Yes, don’t verify me",
+      "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
+      "no_consent_title": "Are you sure?"
+    }
+  },
+  "user_consent_load_fail": {
+    "button_primary": "Reload screen",
+    "detail": "Check that your connection is stable, then try again",
+    "title": "Content failed to load"
+  },
+  "video_capture": {
+    "body": "Keep your face within the oval",
+    "body_record": "Press the button when you’re ready",
+    "body_stop": "Press stop when you’re done",
+    "button_primary_finish": "Finish recording",
+    "button_primary_next": "Next step",
+    "button_primary_start": "Start recording",
+    "button_record_accessibility": "Start recording",
+    "frame_accessibility": "View from camera",
+    "header": {
+      "challenge_digit_instructions": "Say each digit out loud",
+      "challenge_turn_forward": "then face forward",
+      "challenge_turn_left": "Turn your head left",
+      "challenge_turn_right": "Turn your head right"
+    },
+    "prompt": {
+      "header_timeout": "Looks like you took too long"
+    }
+  },
+  "video_confirmation": {
+    "body": "Your video has been recorded",
+    "button_primary": "Upload video",
+    "button_secondary": "Retake video",
+    "title": "Check your video",
+    "video_accessibility": "Replay your recorded video"
+  },
+  "video_intro": {
+    "button_primary": "Record video",
+    "list_accessibility": "Actions to record a selfie video",
+    "list_item_actions": "You have 20 seconds to finish",
+    "list_item_speak": "Follow the instructions to move or speak",
+    "title": "Record a video"
+  },
+  "welcome": {
+    "doc_video_subtitle": "It should take a few minutes",
+    "list_header_doc_video": "Use your device to record:",
+    "list_header_webcam": "Use your webcam or phone to photograph:",
+    "list_item_doc": "your identity document",
+    "list_item_doc_video_timeout": "Recording is limited to <timeout></timeout> seconds",
+    "list_item_poa": "your proof of address",
+    "list_item_selfie": "your face",
+    "next_button": "Choose document",
+    "start_workflow_button": "Start verfication",
+    "subtitle": "It should take a few minutes",
+    "title": "Verify your identity"
+  },
+  "workflow_complete": {
+    "pass": {
+      "description": "We have been able to verify your identity",
+      "title": "Passed"
+    },
+    "reject": {
+      "description": "We haven't been able to verify your identity",
+      "title": "Rejected"
+    }
+  },
+  "workflow_erros": {
+    "generic_title": "There was a server error!",
+    "no_workflow_run_id": "Workflow run ID is not set.",
+    "reload_app": "Please try reloading the app, and try again.",
+    "task_not_completed": "Could not complete workflow task.",
+    "task_not_retrieved": "Could not retrieve workflow task.",
+    "task_not_supported": "Task is currently not supported"
+  }
 }

--- a/src/locales/es_ES/es_ES.json
+++ b/src/locales/es_ES/es_ES.json
@@ -1,765 +1,765 @@
 {
-    "auth_accessibility": {
-        "back_button": "Cancelar"
+  "auth_accessibility": {
+    "back_button": "Cancelar"
+  },
+  "auth_cam_encrypt": {
+    "loader": "Cifrado de transmisión de la cámara"
+  },
+  "auth_cam_start": {
+    "loader": "Iniciando cámara"
+  },
+  "auth_capture_start": {
+    "body": "Coloque su rostro dentro del marco ovalado",
+    "button_primary": "Iniciar escaneo del rostro",
+    "feedback": {
+      "center_face": "Coloque su rostro en el marco",
+      "conditions_too_bright": "Busque un entorno con menos luz",
+      "conditions_too_dark": "Busque un entorno con más luz",
+      "head_not_upright": "Mantenga la cabeza erguida",
+      "neutral_expression": "Mantenga una expresión neutra",
+      "not_looking_straight": "Mire hacia adelante",
+      "remove_sunglasses": "Quítese las gafas de sol",
+      "steady_count_1": "No se mueva: 1",
+      "steady_count_2": "No se mueva: 2",
+      "steady_count_3": "No se mueva: 3"
     },
-    "auth_cam_encrypt": {
-        "loader": "Cifrado de transmisión de la cámara"
+    "title": "Iniciar escaneo del rostro"
+  },
+  "auth_capture": {
+    "feedback": {
+      "center_face": "Coloque su rostro en el marco",
+      "even_lighting": "Asegúrese de que la iluminación sea uniforme",
+      "eye_level": "Mantenga la cámara a la altura de los ojos",
+      "face_not_found": "Asegúrese que su cara sea visible",
+      "head_not_upright": "Mantenga la cabeza erguida",
+      "move_back": "Ahora muévase hacia atrás",
+      "move_close": "Ahora acérquese",
+      "move_closer": "Acérquese",
+      "not_looking_straight": "Mire hacia adelante",
+      "steady": "No se mueva"
+    }
+  },
+  "auth_error": {
+    "cam_encryption": {
+      "body": "Esta aplicación bloquea las configuraciones sospechosas de las cámaras web. <fallback>Más información</fallback>.",
+      "button_primary": "Intentar otra vez",
+      "button_primary_firefox": "Intentar otra vez",
+      "subtitle": "Este sistema no se puede verificar debido a lo siguiente:",
+      "table_header_1": "Posible problema",
+      "table_header_2": "Solución",
+      "table_row_1_cell_1": "La cámara ya está siendo utilizada por otra app.",
+      "table_row_1_cell_1_firefox": "Permisos de la cámara no recordados en Firefox.",
+      "table_row_1_cell_2": "Cierre la otra app.",
+      "table_row_1_cell_2_firefox": "Revise Recordar permisos.",
+      "table_row_2_cell_1": "Una app de terceros está modificando el vídeo.",
+      "table_row_2_cell_2": "Cierre/desinstale la otra app.",
+      "table_row_3_cell_1": "No es posible asegurar el hardware.",
+      "table_row_3_cell_2": "Utilice un dispositivo diferente.",
+      "title": "<b>Problema de cifrado de transmisión de la cámara</b>"
+    }
+  },
+  "auth_full_screen": {
+    "body": "Esto iniciará la captura de selfies en modo de pantalla completa.",
+    "button_primary": "Abrir en pantalla completa",
+    "title": "Modo selfie en pantalla completa"
+  },
+  "auth_permission_denied": {
+    "body_cam": "Para continuar, deberá conceder acceso a la cámara desde la configuración de su móvil.",
+    "button_primary_cam": "Acceder a la configuración"
+  },
+  "auth_permission": {
+    "body_cam": "Para continuar, deberá conceder acceso a la cámara cuando se le solicite.",
+    "button_primary_cam": "Conceder acceso a la cámara",
+    "title_cam": "Permitir acceso a la cámara"
+  },
+  "auth_progress": {
+    "loader": "Cargando"
+  },
+  "auth_retry": {
+    "body_blur": "Limpie el objetivo de su cámara",
+    "body_neutral_expression": "Mantenga una expresión neutra",
+    "body_too_bright": "Busque un entorno con menos luz",
+    "button_primary": "Iniciar cámara",
+    "subtitle": "No hemos podido capturar su rostro correctamente",
+    "title": "Vuelva a escanear su rostro"
+  },
+  "auth_upload_pass": {
+    "body": "Carga realizada correctamente"
+  },
+  "avc_confirmation": {
+    "button_primary_upload": "Subiendo grabación",
+    "subtitle": "Se ha registrado correctamente un vídeo de su cara",
+    "title": "Grabación completada"
+  },
+  "avc_connection_error": {
+    "button_primary_reload": "Volver a cargar las instrucciones",
+    "button_primary_retry_upload": "Reintentar la subida",
+    "button_secondary_restart_recording": "Reiniciar la grabación",
+    "subtitle": "Compruebe que la conexión sea estable e inténtelo de nuevo",
+    "title": "Error de conexión"
+  },
+  "avc_face_alignment": {
+    "feedback_move_back": "Muévase hacia atrás",
+    "feedback_move_closer": "Acérquese",
+    "feedback_no_face_detected": "Cara no detectada",
+    "feedback_not_centered": "La cara no está centrada",
+    "title": "Coloque la cara dentro el marco"
+  },
+  "avc_face_capture": {
+    "alert": {
+      "timeout_body": "Dispone de 15 segundos para completar la grabación",
+      "timeout_button_primary": "Reintentar",
+      "timeout_title": "Lo sentimos, debemos reiniciar la grabación",
+      "too_fast_body": "Vuelva a intentarlo y gire la cabeza más despacio",
+      "too_fast_button_primary": "Reintentar",
+      "too_fast_title": "Ha girado la cabeza demasiado rápido"
     },
-    "auth_cam_start": {
-        "loader": "Iniciando cámara"
+    "title": "Gire la cabeza despacio hacia ambos lados",
+    "title_completed": "Grabación completada"
+  },
+  "avc_intro": {
+    "button_primary_ready": "Estoy listo",
+    "disclaimer": "Tenga en cuenta que grabaremos un vídeo del rostro y el fondo",
+    "list_item_one": "Primero, coloque la cara dentro del marco",
+    "list_item_two": "Luego, gire la cabeza despacio hacia ambos lados",
+    "subtitle": "Esto es para verificar que es una persona real",
+    "title": "Grábese en un vídeo"
+  },
+  "avc_no_face_detected": {
+    "button_primary_restart": "Reiniciar la grabación",
+    "list_item_eyes": "Asegúrese de que los ojos se vean con claridad",
+    "list_item_face": "Asegúrese de mostrar únicamente la cara. No necesitamos ver el documento de identidad",
+    "list_item_lighting": "Asegúrese de estar en un lugar con buena iluminación",
+    "list_item_mask": "Asegúrese de retirar mascarillas o cualquier otro objeto que le cubra el rostro. Puede llevar gafas para ver",
+    "title": "No podemos detectar su cara"
+  },
+  "avc_uploading": {
+    "title": "Cargando"
+  },
+  "country_select": {
+    "alert": {
+      "another_doc": "Actualmente no se admiten documentos de ese país: <fallback> pruebe con otro tipo de documento </fallback>"
     },
-    "auth_capture_start": {
-        "body": "Coloque su rostro dentro del marco ovalado",
-        "button_primary": "Iniciar escaneo del rostro",
-        "feedback": {
-            "center_face": "Coloque su rostro en el marco",
-            "conditions_too_bright": "Busque un entorno con menos luz",
-            "conditions_too_dark": "Busque un entorno con más luz",
-            "head_not_upright": "Mantenga la cabeza erguida",
-            "neutral_expression": "Mantenga una expresión neutra",
-            "not_looking_straight": "Mire hacia adelante",
-            "remove_sunglasses": "Quítese las gafas de sol",
-            "steady_count_1": "No se mueva: 1",
-            "steady_count_2": "No se mueva: 2",
-            "steady_count_3": "No se mueva: 3"
-        },
-        "title": "Iniciar escaneo del rostro"
+    "alert_dropdown": {
+      "country_not_found": "País no encontrado"
     },
-    "auth_capture": {
-        "feedback": {
-            "center_face": "Coloque su rostro en el marco",
-            "even_lighting": "Asegúrese de que la iluminación sea uniforme",
-            "eye_level": "Mantenga la cámara a la altura de los ojos",
-            "face_not_found": "Asegúrese que su cara sea visible",
-            "head_not_upright": "Mantenga la cabeza erguida",
-            "move_back": "Ahora muévase hacia atrás",
-            "move_close": "Ahora acérquese",
-            "move_closer": "Acérquese",
-            "not_looking_straight": "Mire hacia adelante",
-            "steady": "No se mueva"
-        }
+    "button_primary": "Enviar documento",
+    "poa_alert": {
+      "country_not_found": "Lo sentimos. Estamos trabajando para ampliar los países de servicio.",
+      "intro": "¿No puede encontrar su país?"
     },
-    "auth_error": {
-        "cam_encryption": {
-            "body": "Esta aplicación bloquea las configuraciones sospechosas de las cámaras web. <fallback>Más información<\/fallback>.",
-            "button_primary": "Intentar otra vez",
-            "button_primary_firefox": "Intentar otra vez",
-            "subtitle": "Este sistema no se puede verificar debido a lo siguiente:",
-            "table_header_1": "Posible problema",
-            "table_header_2": "Solución",
-            "table_row_1_cell_1": "La cámara ya está siendo utilizada por otra app.",
-            "table_row_1_cell_1_firefox": "Permisos de la cámara no recordados en Firefox.",
-            "table_row_1_cell_2": "Cierre la otra app.",
-            "table_row_1_cell_2_firefox": "Revise Recordar permisos.",
-            "table_row_2_cell_1": "Una app de terceros está modificando el vídeo.",
-            "table_row_2_cell_2": "Cierre\/desinstale la otra app.",
-            "table_row_3_cell_1": "No es posible asegurar el hardware.",
-            "table_row_3_cell_2": "Utilice un dispositivo diferente.",
-            "title": "<b>Problema de cifrado de transmisión de la cámara<\/b>"
-        }
+    "search": {
+      "accessibility": "Seleccione el país",
+      "input_placeholder": "por ejemplo, España",
+      "label": "Buscar país"
     },
-    "auth_full_screen": {
-        "body": "Esto iniciará la captura de selfies en modo de pantalla completa.",
-        "button_primary": "Abrir en pantalla completa",
-        "title": "Modo selfie en pantalla completa"
+    "title": "Seleccione el país emisor"
+  },
+  "cross_device_checklist": {
+    "button_primary": "Enviar verificación",
+    "info": "Recomendaciones",
+    "list_item_doc_multiple": "Documentos cargados",
+    "list_item_doc_one": "Documento cargado",
+    "list_item_poa": "Prueba de dirección",
+    "list_item_selfie": "Selfie cargado",
+    "list_item_video": "Video cargado",
+    "subtitle": "Aquí tiene todo lo que ha subido:",
+    "title": "Un último paso"
+  },
+  "cross_device_error_desktop": {
+    "subtitle": "Debe abrir este enlace en un dispositivo móvil",
+    "title": "Algo salió mal"
+  },
+  "cross_device_error_restart": {
+    "subtitle": "Deberá reiniciar su verificación en su computadora",
+    "title": "Algo salió mal"
+  },
+  "cross_device_intro": {
+    "button_primary": "Obtener enlace seguro",
+    "list_accessibility": "Pasos requeridos para continuar con la verificación en su móvil",
+    "list_item_finish": "Vuelva aquí para finalizar el envío",
+    "list_item_open_link": "Abra el enlace y complete las acciones",
+    "list_item_send_phone": "Envíe el enlace seguro a su teléfono móvil",
+    "subtitle": "Siga estas instrucciones:",
+    "title": "Continúe en su teléfono móvil"
+  },
+  "cross_device_return": {
+    "body": "Su computadora puede tardar unos segundos en actualizarse",
+    "subtitle": "Ahora puede volver a su computadora para continuar",
+    "title": "Carga completa"
+  },
+  "cross_device_session_linked": {
+    "button_primary": "Continuar",
+    "info": "Verificación doble",
+    "list_item_desktop_open": "La ventana del escritorio sigue abierta",
+    "list_item_sent_by_you": "Usted envío este enlace. Pida ayuda si cree que podría ser peligroso",
+    "subtitle": "Continúe con la verificación",
+    "title": "Vinculado a su ordenador"
+  },
+  "doc_capture": {
+    "button_primary": "Iniciar escaneo del documento",
+    "detail": {
+      "folded_doc_front": "Asegúrese que su documento este completamente abierto (debe incluir su foto)"
     },
-    "auth_permission_denied": {
-        "body_cam": "Para continuar, deberá conceder acceso a la cámara desde la configuración de su móvil.",
-        "button_primary_cam": "Acceder a la configuración"
+    "header_folded_doc_front": "Lado con su foto",
+    "prompt": {
+      "button_card": "Tarjeta de plastico",
+      "button_paper": "Documento en papel",
+      "title_id": "Que tipo de carnet tiene?",
+      "title_license": "Que tipo de licencia tiene?"
+    }
+  },
+  "doc_confirmation": {
+    "alert": {
+      "blur_detail": "Asegúrese de que todo se vea nítido",
+      "blur_title": "La imagen no es nítida",
+      "crop_detail": "Asegúrese que su documento sea completamente visible",
+      "crop_title": "Se ha detectado una imagen recortada",
+      "glare_detail": "Intente alejarse de la luz directa",
+      "glare_title": "Brillo detectado",
+      "no_doc_detail": "Asegúrese de que todo el documento esté en la foto",
+      "no_doc_title": "Documento no detectado"
     },
-    "auth_permission": {
-        "body_cam": "Para continuar, deberá conceder acceso a la cámara cuando se le solicite.",
-        "button_primary_cam": "Conceder acceso a la cámara",
-        "title_cam": "Permitir acceso a la cámara"
+    "body": "Asegúrese de haber subido la página completa del documento y de que pueda leerse con claridad, sin destellos ni partes borrosas",
+    "body_bank_statement": "Asegúrese de haber subido la página completa del documento y de que pueda leerse con claridad, sin destellos ni partes borrosas",
+    "body_benefits_letter": "Asegúrese de haber subido la página completa del documento y de que pueda leerse con claridad, sin destellos ni partes borrosas",
+    "body_bill": "Asegúrese de haber subido la página completa del documento y de que pueda leerse con claridad, sin destellos ni partes borrosas",
+    "body_id": "Asegúrese de que los datos sean claros y no estén ocultos",
+    "body_image_medium": "Nos llevará más tiempo verificarle si no podemos leerla",
+    "body_image_poor": "Para poder verificar que es usted, necesitamos una foto de mejor calidad",
+    "body_license": "Asegúrese de que los datos sean claros y no estén ocultos",
+    "body_passport": "Asegúrese de que los datos sean claros y no estén ocultos",
+    "body_permit": "Asegúrese de que los datos sean claros y no estén ocultos",
+    "body_tax_letter": "Asegúrese de haber subido la página completa del documento y de que pueda leerse con claridad, sin destellos ni partes borrosas",
+    "button_close": "Cerrar",
+    "button_primary_redo": "Reintentar",
+    "button_primary_upload": "Subir",
+    "button_primary_upload_anyway": "Subir igualmente",
+    "button_secondary_redo": "Reintentar",
+    "button_zoom": "Ampliar imagen",
+    "image_accessibility": "Foto de su documento",
+    "title": "Compruebe su imagen"
+  },
+  "doc_multi_frame_capture": {
+    "capture_progress_title": "Escaneando documento",
+    "instructions_title_back": "Ponga la parte trasera de su documento en el marco",
+    "instructions_title_front": "Ponga la parte delantera de su documento en el marco"
+  },
+  "doc_select": {
+    "button_bank_statement": "Extracto bancario o de una sociedad de crédito",
+    "button_bank_statement_non_uk": "Extracto bancario",
+    "button_benefits_letter": "Carta de prestación",
+    "button_benefits_letter_detail": "Prestaciones estatales, por ejemplo, créditos fiscales, ayudas por desempleo, subsidios de vivienda",
+    "button_bill": "Factura de servicios",
+    "button_bill_detail": "Gas, electricidad, agua, telefonía fija o internet doméstico",
+    "button_government_letter": "Carta del Gobierno",
+    "button_government_letter_detail": "Cualquier carta emitida por el gobierno, por ejemplo, derecho a prestaciones, cartas electorales, cartas de impuestos, etc",
+    "button_id": "Documento Nacional de Identidad",
+    "button_id_detail": "Frente y reverso",
+    "button_license": "Licencia de conducir",
+    "button_license_detail": "Frente y reverso",
+    "button_passport": "Pasaporte",
+    "button_passport_detail": "Página del pasaporte con su foto",
+    "button_permit": "Permiso de Residencia",
+    "button_permit_detail": "Frente y reverso",
+    "button_tax_letter": "Carta del impuesto sobre bienes inmuebles",
+    "extra_estatements_ok": "Se aceptan extractos electrónicos",
+    "extra_no_mobile": "Lo sentimos. Factura de teléfonos móviles no",
+    "list_accessibility": "Documentos que puede utilizar para verificar su identidad",
+    "pill": "más rápida",
+    "section": {
+      "header_country": "País emisor",
+      "header_doc_type": "Documentos aceptados",
+      "input_country_not_found": "Sin resultados",
+      "input_placeholder_country": "Seleccione el país emisor"
     },
-    "auth_progress": {
-        "loader": "Cargando"
+    "subtitle": "Debe ser un documento de identidad oficial con fotografía",
+    "subtitle_country": "Seleccione el país emisor para ver qué documentos aceptamos",
+    "subtitle_entire_page": "Página completa",
+    "subtitle_front_back": "Frente y detrás",
+    "subtitle_photo_page": "página de fotos",
+    "subtitle_poa": "Estos son los documentos en los que es más probable que se muestre la dirección de su hogar",
+    "title": "Seleccione un documento",
+    "title_poa": "Seleccione un documento de %{country}"
+  },
+  "doc_submit": {
+    "button_link_upload": "o subir foto - no escaneos o fotocopias",
+    "button_primary": "Continuar en el teléfono",
+    "subtitle": "Tome una foto con su teléfono",
+    "title_bank_statement": "Enviar extracto",
+    "title_benefits_letter": "Enviar carta",
+    "title_bill": "Enviar factura",
+    "title_government_letter": "Carta del Gobierno",
+    "title_id_back": "Reverso de la tarjeta de identificación",
+    "title_id_front": "Frente de la tarjeta de identificación",
+    "title_license_back": "Reverso de la licencia de conducir",
+    "title_license_front": "Frente de la licencia de conducir",
+    "title_passport": "Página del pasaporte con su foto",
+    "title_permit_back": "Enviar permiso de residencia (reverso)",
+    "title_permit_front": "Enviar permiso de residencia (anverso)",
+    "title_tax_letter": "Enviar carta"
+  },
+  "doc_video_capture": {
+    "button_primary_fallback": "Siguiente paso",
+    "button_primary_fallback_end": "Finalizar grabación",
+    "detail_step2": "Mantenga el documento a la vista en todo momento",
+    "header": "Mientras sostiene el documento, mantenga la parte frontal dentro del marco",
+    "header_paper_doc_step2": "Gire lentamente el documento para mostrar las páginas exteriores",
+    "header_passport": "Mientras sostiene su pasaporte, mantenga la página de la foto dentro del marco",
+    "header_passport_progress": "No se mueva",
+    "header_step1": "Ahora, no se mueva",
+    "header_step2": "Gire lentamente el documento para mostrar el reverso",
+    "prompt": {
+      "detail_timeout": "La grabación de vídeo tiene un límite de <timeout></timeout> segundos. <fallback>Empezar de nuevo</fallback>"
     },
-    "auth_retry": {
-        "body_blur": "Limpie el objetivo de su cámara",
-        "body_neutral_expression": "Mantenga una expresión neutra",
-        "body_too_bright": "Busque un entorno con menos luz",
-        "button_primary": "Iniciar cámara",
-        "subtitle": "No hemos podido capturar su rostro correctamente",
-        "title": "Vuelva a escanear su rostro"
+    "stepper": "Paso <step></step> de <total></total>",
+    "success_accessibility": "Se ha realizado correctamente"
+  },
+  "doc_video_confirmation": {
+    "button_secondary": "Vista previa del vídeo",
+    "title": "Verifique video"
+  },
+  "error_unsupported_browser": {
+    "subtitle_android": "Reinicie el proceso en la versión más reciente de Google Chrome",
+    "subtitle_ios": "Reinicie el proceso en la versión más reciente de Safari",
+    "title_android": "Browser no soportado",
+    "title_ios": "Browser no soportado"
+  },
+  "generic": {
+    "accessibility": {
+      "close_sdk_screen": "Cerrar pantalla de verificación",
+      "dismiss_alert": "Cerrar alerta"
     },
-    "auth_upload_pass": {
-        "body": "Carga realizada correctamente"
+    "back": "atrás",
+    "close": "cerrar",
+    "errors": {
+      "expired_token": {
+        "instruction": "Inténtelo de nuevo",
+        "message": "Su token ha caducado"
+      },
+      "geoblocked_error": {
+        "instruction": "Lo sentimos, parece que no podemos seguir adelante ya que su ubicación actual no es compatible",
+        "message": "Servicio no disponible"
+      },
+      "interrupted_flow_error": {
+        "instruction": "Reinicie el proceso con un dispositivo diferente",
+        "message": "Cámara no detectada"
+      },
+      "invalid_size": {
+        "instruction": "El tamaño debe ser menos de 10MB.",
+        "message": "El tamaño de archivo excede el limite."
+      },
+      "invalid_type": {
+        "instruction": "Intenta usar otro tipo de archivo.",
+        "message": "Archivo no cargado."
+      },
+      "lazy_loading": {
+        "message": "Se produjo un error al cargar el componente"
+      },
+      "multiple_faces": {
+        "instruction": "Solo su cara puede estar en la selfie",
+        "message": "Múltiples caras encontradas"
+      },
+      "no_face": {
+        "instruction": "Asegúrese que su cara sea visible",
+        "message": "Cara no encontrada"
+      },
+      "request_error": {
+        "instruction": "Inténtalo de nuevo",
+        "message": "Algo salió mal"
+      },
+      "sms_failed": {
+        "instruction": "Copie el enlace a continuación en su dispositivo móvil",
+        "message": "Algo salió mal"
+      },
+      "sms_overuse": {
+        "instruction": "Copie el enlace a continuación en su dispositivo móvil",
+        "message": "Demasiados intentos de reenvío"
+      },
+      "unsupported_file": {
+        "instruction": "Intente usar un archivo .jpg o .png",
+        "message": "Tipo de archivo no admitido"
+      }
     },
-    "avc_confirmation": {
-        "button_primary_upload": "Subiendo grabación",
-        "subtitle": "Se ha registrado correctamente un vídeo de su cara",
-        "title": "Grabación completada"
-    },
-    "avc_connection_error": {
-        "button_primary_reload": "Volver a cargar las instrucciones",
-        "button_primary_retry_upload": "Reintentar la subida",
-        "button_secondary_restart_recording": "Reiniciar la grabación",
-        "subtitle": "Compruebe que la conexión sea estable e inténtelo de nuevo",
-        "title": "Error de conexión"
-    },
-    "avc_face_alignment": {
-        "feedback_move_back": "Muévase hacia atrás",
-        "feedback_move_closer": "Acérquese",
-        "feedback_no_face_detected": "Cara no detectada",
-        "feedback_not_centered": "La cara no está centrada",
-        "title": "Coloque la cara dentro el marco"
-    },
-    "avc_face_capture": {
-        "alert": {
-            "timeout_body": "Dispone de 15 segundos para completar la grabación",
-            "timeout_button_primary": "Reintentar",
-            "timeout_title": "Lo sentimos, debemos reiniciar la grabación",
-            "too_fast_body": "Vuelva a intentarlo y gire la cabeza más despacio",
-            "too_fast_button_primary": "Reintentar",
-            "too_fast_title": "Ha girado la cabeza demasiado rápido"
-        },
-        "title": "Gire la cabeza despacio hacia ambos lados",
-        "title_completed": "Grabación completada"
-    },
-    "avc_intro": {
-        "button_primary_ready": "Estoy listo",
-        "disclaimer": "Tenga en cuenta que grabaremos un vídeo del rostro y el fondo",
-        "list_item_one": "Primero, coloque la cara dentro del marco",
-        "list_item_two": "Luego, gire la cabeza despacio hacia ambos lados",
-        "subtitle": "Esto es para verificar que es una persona real",
-        "title": "Grábese en un vídeo"
-    },
-    "avc_no_face_detected": {
-        "button_primary_restart": "Reiniciar la grabación",
-        "list_item_eyes": "Asegúrese de que los ojos se vean con claridad",
-        "list_item_face": "Asegúrese de mostrar únicamente la cara. No necesitamos ver el documento de identidad",
-        "list_item_lighting": "Asegúrese de estar en un lugar con buena iluminación",
-        "list_item_mask": "Asegúrese de retirar mascarillas o cualquier otro objeto que le cubra el rostro. Puede llevar gafas para ver",
-        "title": "No podemos detectar su cara"
-    },
-    "avc_uploading": {
-        "title": "Cargando"
-    },
-    "country_select": {
-        "alert": {
-            "another_doc": "Actualmente no se admiten documentos de ese país: <fallback> pruebe con otro tipo de documento <\/fallback>"
-        },
-        "alert_dropdown": {
-            "country_not_found": "País no encontrado"
-        },
-        "button_primary": "Enviar documento",
-        "poa_alert": {
-            "country_not_found": "Lo sentimos. Estamos trabajando para ampliar los países de servicio.",
-            "intro": "¿No puede encontrar su país?"
-        },
-        "search": {
-            "accessibility": "Seleccione el país",
-            "input_placeholder": "por ejemplo, España",
-            "label": "Buscar país"
-        },
-        "title": "Seleccione el país emisor"
-    },
-    "cross_device_checklist": {
-        "button_primary": "Enviar verificación",
-        "info": "Recomendaciones",
-        "list_item_doc_multiple": "Documentos cargados",
-        "list_item_doc_one": "Documento cargado",
-        "list_item_poa": "Prueba de dirección",
-        "list_item_selfie": "Selfie cargado",
-        "list_item_video": "Video cargado",
-        "subtitle": "Aquí tiene todo lo que ha subido:",
-        "title": "Un último paso"
-    },
-    "cross_device_error_desktop": {
-        "subtitle": "Debe abrir este enlace en un dispositivo móvil",
-        "title": "Algo salió mal"
-    },
-    "cross_device_error_restart": {
-        "subtitle": "Deberá reiniciar su verificación en su computadora",
-        "title": "Algo salió mal"
-    },
-    "cross_device_intro": {
-        "button_primary": "Obtener enlace seguro",
-        "list_accessibility": "Pasos requeridos para continuar con la verificación en su móvil",
-        "list_item_finish": "Vuelva aquí para finalizar el envío",
-        "list_item_open_link": "Abra el enlace y complete las acciones",
-        "list_item_send_phone": "Envíe el enlace seguro a su teléfono móvil",
-        "subtitle": "Siga estas instrucciones:",
-        "title": "Continúe en su teléfono móvil"
-    },
-    "cross_device_return": {
-        "body": "Su computadora puede tardar unos segundos en actualizarse",
-        "subtitle": "Ahora puede volver a su computadora para continuar",
-        "title": "Carga completa"
-    },
-    "cross_device_session_linked": {
-        "button_primary": "Continuar",
-        "info": "Verificación doble",
-        "list_item_desktop_open": "La ventana del escritorio sigue abierta",
-        "list_item_sent_by_you": "Usted envío este enlace. Pida ayuda si cree que podría ser peligroso",
-        "subtitle": "Continúe con la verificación",
-        "title": "Vinculado a su ordenador"
-    },
-    "doc_capture": {
-        "button_primary": "Iniciar escaneo del documento",
-        "detail": {
-            "folded_doc_front": "Asegúrese que su documento este completamente abierto (debe incluir su foto)"
-        },
-        "header_folded_doc_front": "Lado con su foto",
-        "prompt": {
-            "button_card": "Tarjeta de plastico",
-            "button_paper": "Documento en papel",
-            "title_id": "Que tipo de carnet tiene?",
-            "title_license": "Que tipo de licencia tiene?"
-        }
-    },
-    "doc_confirmation": {
-        "alert": {
-            "blur_detail": "Asegúrese de que todo se vea nítido",
-            "blur_title": "La imagen no es nítida",
-            "crop_detail": "Asegúrese que su documento sea completamente visible",
-            "crop_title": "Se ha detectado una imagen recortada",
-            "glare_detail": "Intente alejarse de la luz directa",
-            "glare_title": "Brillo detectado",
-            "no_doc_detail": "Asegúrese de que todo el documento esté en la foto",
-            "no_doc_title": "Documento no detectado"
-        },
-        "body": "Asegúrese de haber subido la página completa del documento y de que pueda leerse con claridad, sin destellos ni partes borrosas",
-        "body_bank_statement": "Asegúrese de haber subido la página completa del documento y de que pueda leerse con claridad, sin destellos ni partes borrosas",
-        "body_benefits_letter": "Asegúrese de haber subido la página completa del documento y de que pueda leerse con claridad, sin destellos ni partes borrosas",
-        "body_bill": "Asegúrese de haber subido la página completa del documento y de que pueda leerse con claridad, sin destellos ni partes borrosas",
-        "body_id": "Asegúrese de que los datos sean claros y no estén ocultos",
-        "body_image_medium": "Nos llevará más tiempo verificarle si no podemos leerla",
-        "body_image_poor": "Para poder verificar que es usted, necesitamos una foto de mejor calidad",
-        "body_license": "Asegúrese de que los datos sean claros y no estén ocultos",
-        "body_passport": "Asegúrese de que los datos sean claros y no estén ocultos",
-        "body_permit": "Asegúrese de que los datos sean claros y no estén ocultos",
-        "body_tax_letter": "Asegúrese de haber subido la página completa del documento y de que pueda leerse con claridad, sin destellos ni partes borrosas",
-        "button_close": "Cerrar",
-        "button_primary_redo": "Reintentar",
-        "button_primary_upload": "Subir",
-        "button_primary_upload_anyway": "Subir igualmente",
-        "button_secondary_redo": "Reintentar",
-        "button_zoom": "Ampliar imagen",
-        "image_accessibility": "Foto de su documento",
-        "title": "Compruebe su imagen"
-    },
-    "doc_multi_frame_capture": {
-        "capture_progress_title": "Escaneando documento",
-        "instructions_title_back": "Ponga la parte trasera de su documento en el marco",
-        "instructions_title_front": "Ponga la parte delantera de su documento en el marco"
-    },
-    "doc_select": {
-        "button_bank_statement": "Extracto bancario o de una sociedad de crédito",
-        "button_bank_statement_non_uk": "Extracto bancario",
-        "button_benefits_letter": "Carta de prestación",
-        "button_benefits_letter_detail": "Prestaciones estatales, por ejemplo, créditos fiscales, ayudas por desempleo, subsidios de vivienda",
-        "button_bill": "Factura de servicios",
-        "button_bill_detail": "Gas, electricidad, agua, telefonía fija o internet doméstico",
-        "button_government_letter": "Carta del Gobierno",
-        "button_government_letter_detail": "Cualquier carta emitida por el gobierno, por ejemplo, derecho a prestaciones, cartas electorales, cartas de impuestos, etc",
-        "button_id": "Documento Nacional de Identidad",
-        "button_id_detail": "Frente y reverso",
-        "button_license": "Licencia de conducir",
-        "button_license_detail": "Frente y reverso",
-        "button_passport": "Pasaporte",
-        "button_passport_detail": "Página del pasaporte con su foto",
-        "button_permit": "Permiso de Residencia",
-        "button_permit_detail": "Frente y reverso",
-        "button_tax_letter": "Carta del impuesto sobre bienes inmuebles",
-        "extra_estatements_ok": "Se aceptan extractos electrónicos",
-        "extra_no_mobile": "Lo sentimos. Factura de teléfonos móviles no",
-        "list_accessibility": "Documentos que puede utilizar para verificar su identidad",
-        "pill": "más rápida",
-        "section": {
-            "header_country": "País emisor",
-            "header_doc_type": "Documentos aceptados",
-            "input_country_not_found": "Sin resultados",
-            "input_placeholder_country": "Seleccione el país emisor"
-        },
-        "subtitle": "Debe ser un documento de identidad oficial con fotografía",
-        "subtitle_country": "Seleccione el país emisor para ver qué documentos aceptamos",
-        "subtitle_entire_page": "Página completa",
-        "subtitle_front_back": "Frente y detrás",
-        "subtitle_photo_page": "página de fotos",
-        "subtitle_poa": "Estos son los documentos en los que es más probable que se muestre la dirección de su hogar",
-        "title": "Seleccione un documento",
-        "title_poa": "Seleccione un documento de %{country}"
-    },
-    "doc_submit": {
-        "button_link_upload": "o subir foto - no escaneos o fotocopias",
-        "button_primary": "Continuar en el teléfono",
-        "subtitle": "Tome una foto con su teléfono",
-        "title_bank_statement": "Enviar extracto",
-        "title_benefits_letter": "Enviar carta",
-        "title_bill": "Enviar factura",
-        "title_government_letter": "Carta del Gobierno",
-        "title_id_back": "Reverso de la tarjeta de identificación",
-        "title_id_front": "Frente de la tarjeta de identificación",
-        "title_license_back": "Reverso de la licencia de conducir",
-        "title_license_front": "Frente de la licencia de conducir",
-        "title_passport": "Página del pasaporte con su foto",
-        "title_permit_back": "Enviar permiso de residencia (reverso)",
-        "title_permit_front": "Enviar permiso de residencia (anverso)",
-        "title_tax_letter": "Enviar carta"
-    },
-    "doc_video_capture": {
-        "button_primary_fallback": "Siguiente paso",
-        "button_primary_fallback_end": "Finalizar grabación",
-        "detail_step2": "Mantenga el documento a la vista en todo momento",
-        "header": "Mientras sostiene el documento, mantenga la parte frontal dentro del marco",
-        "header_paper_doc_step2": "Gire lentamente el documento para mostrar las páginas exteriores",
-        "header_passport": "Mientras sostiene su pasaporte, mantenga la página de la foto dentro del marco",
-        "header_passport_progress": "No se mueva",
-        "header_step1": "Ahora, no se mueva",
-        "header_step2": "Gire lentamente el documento para mostrar el reverso",
-        "prompt": {
-            "detail_timeout": "La grabación de vídeo tiene un límite de <timeout><\/timeout> segundos. <fallback>Empezar de nuevo<\/fallback>"
-        },
-        "stepper": "Paso <step><\/step> de <total><\/total>",
-        "success_accessibility": "Se ha realizado correctamente"
-    },
-    "doc_video_confirmation": {
-        "button_secondary": "Vista previa del vídeo",
-        "title": "Verifique video"
-    },
-    "error_unsupported_browser": {
-        "subtitle_android": "Reinicie el proceso en la versión más reciente de Google Chrome",
-        "subtitle_ios": "Reinicie el proceso en la versión más reciente de Safari",
-        "title_android": "Browser no soportado",
-        "title_ios": "Browser no soportado"
-    },
-    "generic": {
-        "accessibility": {
-            "close_sdk_screen": "Cerrar pantalla de verificación",
-            "dismiss_alert": "Cerrar alerta"
-        },
-        "back": "atrás",
-        "close": "cerrar",
-        "errors": {
-            "expired_token": {
-                "instruction": "Inténtelo de nuevo",
-                "message": "Su token ha caducado"
-            },
-            "geoblocked_error": {
-                "instruction": "Lo sentimos, parece que no podemos seguir adelante ya que su ubicación actual no es compatible",
-                "message": "Servicio no disponible"
-            },
-            "interrupted_flow_error": {
-                "instruction": "Reinicie el proceso con un dispositivo diferente",
-                "message": "Cámara no detectada"
-            },
-            "invalid_size": {
-                "instruction": "El tamaño debe ser menos de 10MB.",
-                "message": "El tamaño de archivo excede el limite."
-            },
-            "invalid_type": {
-                "instruction": "Intenta usar otro tipo de archivo.",
-                "message": "Archivo no cargado."
-            },
-            "lazy_loading": {
-                "message": "Se produjo un error al cargar el componente"
-            },
-            "multiple_faces": {
-                "instruction": "Solo su cara puede estar en la selfie",
-                "message": "Múltiples caras encontradas"
-            },
-            "no_face": {
-                "instruction": "Asegúrese que su cara sea visible",
-                "message": "Cara no encontrada"
-            },
-            "request_error": {
-                "instruction": "Inténtalo de nuevo",
-                "message": "Algo salió mal"
-            },
-            "sms_failed": {
-                "instruction": "Copie el enlace a continuación en su dispositivo móvil",
-                "message": "Algo salió mal"
-            },
-            "sms_overuse": {
-                "instruction": "Copie el enlace a continuación en su dispositivo móvil",
-                "message": "Demasiados intentos de reenvío"
-            },
-            "unsupported_file": {
-                "instruction": "Intente usar un archivo .jpg o .png",
-                "message": "Tipo de archivo no admitido"
-            }
-        },
-        "lazy_load_placeholder": "Cargando...",
-        "loading": "Cargando"
-    },
-    "get_link": {
-        "alert_wrong_number": "Compruebe que su número de móvil sea correcto",
-        "button_copied": "Copiado",
-        "button_copy": "Copiar",
-        "button_submit": "Enviar enlace",
-        "info_qr_how": "Cómo escanear un código QR",
-        "info_qr_how_list_item_camera": "Apunte la cámara de su teléfono al código QR",
-        "info_qr_how_list_item_download": "Si esto no funciona, descargue una aplicación para escanear códigos QR desde Google Play o Apple Store",
-        "link_divider": "o elige un método alternativo",
-        "link_qr": "Escanear código QR",
-        "link_sms": "Obtener enlace via mensaje de texto",
-        "link_url": "Copiar enlace",
-        "loader_sending": "Enviando",
-        "number_field_input_placeholder": "Introduzca su número de móvil",
-        "number_field_label": "Ingrese su número de teléfono móvil:",
-        "subtitle_qr": "Escanear el código QR con su teléfono",
-        "subtitle_sms": "Abrir el enlace en su teléfono",
-        "subtitle_url": "Abrir el enlace en su teléfono",
-        "title": "Obtener enlace seguro",
-        "url_field_label": "Copie el enlace al navegador de internet de su teléfono"
-    },
-    "livenessV2": {
-        "error_reload_instructions": "Volver a cargar instrucciones",
-        "intro_note_no1": "Primero, coloque su cara en el marco",
-        "intro_note_no2": "Luego, gire la cabeza despacio hacia ambos lados",
-        "intro_ready_button": "Tenga en cuenta que podemos registrar su rostro y el fondo",
-        "intro_subtitle": "Esto es para verificar que es una persona real",
-        "intro_warning": "Tenga en cuenta que registraremos su rostro y el fondo",
-        "success_main_button": "Enviar verificación",
-        "success_title": "Es todo lo que necesitamos para empezar a verificar su identidad"
-    },
-    "mobilePhrases": {
-        "photo_upload": {
-            "body_id_back": "Tome una foto del reverso de su tarjeta",
-            "body_id_front": "Tome una foto del frente de su tarjeta",
-            "body_license_back": "Tome una foto del reverso de su licencia",
-            "body_license_front": "Tome una foto del frente de su licencia",
-            "body_passport": "Tome una foto de la página del pasaporte que incluye su fotografía",
-            "body_selfie": "Tome una selfie que muestre su cara"
-        },
-        "selfie_capture": {
-            "alert": {
-                "camera_inactive": {
-                    "detail": "Tome una foto usando el <fallback>modo de cámara básica<\/fallback> en su lugar"
-                },
-                "camera_not_working": {
-                    "detail": "Tome una foto usando el <fallback>modo de cámara básica<\/fallback> en su lugar"
-                }
-            }
-        },
-        "upload_guide": {
-            "button_primary": "Tomar foto",
-            "title": "Página del pasaporte con su foto"
-        }
-    },
-    "outro": {
-        "body": "Eso es todo lo que necesitamos para comenzar a verificar su identidad",
-        "body_government_letter": "Facilite la página completa del documento para obtener mejores resultados",
-        "title": "Gracias"
-    },
-    "permission": {
-        "body_both": "No lo podemos verificar sin acceso a su cámara y micrófono",
-        "body_cam": "No le podemos verificar sin usar su cámara",
-        "button_primary_both": "Conceder acceso a ambos",
-        "button_primary_cam": "Activar cámara",
-        "subtitle_both": "Deberá conceder acceso a ambos para continuar",
-        "subtitle_cam": "Deberá activar la cámara para continuar",
-        "title_both": "Permitir acceso a la cámara y al micrófono",
-        "title_cam": "Permitir acceso a la cámara"
-    },
-    "permission_recovery": {
-        "button_primary": "Actualizar",
-        "info": "Recuperación",
-        "list_header_both": "Siga estos pasos para recuperar acceso a ambos:",
-        "list_header_cam": "Siga estos pasos para recuperar acceso a la cámara:",
-        "list_item_action_cam": "Actualice esta página para reiniciar el proceso de verificación",
-        "list_item_how_to_both": "Autorice acceso a la cámara y el micrófono desde los ajustes del navegador",
-        "list_item_how_to_cam": "Autorice acceso a su cámara desde los ajustes del navegador",
-        "subtitle_both": "Recupere acceso a la cámara y el micrófono para grabar un video y completar el proceso de verificación",
-        "subtitle_cam": "Recupere acceso a la cámara para continuar la verificación",
-        "subtitle_cam_old": "Recupere acceso a la cámara para continuar la verificación facial",
-        "title_both": "Acceso denegado a la cámara y al micrófono",
-        "title_cam": "Acceso a la cámara no permitido"
-    },
+    "lazy_load_placeholder": "Cargando...",
+    "loading": "Cargando"
+  },
+  "get_link": {
+    "alert_wrong_number": "Compruebe que su número de móvil sea correcto",
+    "button_copied": "Copiado",
+    "button_copy": "Copiar",
+    "button_submit": "Enviar enlace",
+    "info_qr_how": "Cómo escanear un código QR",
+    "info_qr_how_list_item_camera": "Apunte la cámara de su teléfono al código QR",
+    "info_qr_how_list_item_download": "Si esto no funciona, descargue una aplicación para escanear códigos QR desde Google Play o Apple Store",
+    "link_divider": "o elige un método alternativo",
+    "link_qr": "Escanear código QR",
+    "link_sms": "Obtener enlace via mensaje de texto",
+    "link_url": "Copiar enlace",
+    "loader_sending": "Enviando",
+    "number_field_input_placeholder": "Introduzca su número de móvil",
+    "number_field_label": "Ingrese su número de teléfono móvil:",
+    "subtitle_qr": "Escanear el código QR con su teléfono",
+    "subtitle_sms": "Abrir el enlace en su teléfono",
+    "subtitle_url": "Abrir el enlace en su teléfono",
+    "title": "Obtener enlace seguro",
+    "url_field_label": "Copie el enlace al navegador de internet de su teléfono"
+  },
+  "livenessV2": {
+    "error_reload_instructions": "Volver a cargar instrucciones",
+    "intro_note_no1": "Primero, coloque su cara en el marco",
+    "intro_note_no2": "Luego, gire la cabeza despacio hacia ambos lados",
+    "intro_ready_button": "Tenga en cuenta que podemos registrar su rostro y el fondo",
+    "intro_subtitle": "Esto es para verificar que es una persona real",
+    "intro_warning": "Tenga en cuenta que registraremos su rostro y el fondo",
+    "success_main_button": "Enviar verificación",
+    "success_title": "Es todo lo que necesitamos para empezar a verificar su identidad"
+  },
+  "mobilePhrases": {
     "photo_upload": {
-        "body_bank_statement": "Facilite la página completa del documento para obtener mejores resultados",
-        "body_benefits_letter": "Facilite la página completa del documento para obtener mejores resultados",
-        "body_bill": "Facilite la página completa del documento para obtener mejores resultados",
-        "body_id_back": "Suba el reverso de la tarjeta desde su computadora",
-        "body_id_front": "Suba el frente de la tarjeta desde su computadora",
-        "body_license_back": "Suba el reverso de la licencia desde su computadora",
-        "body_license_front": "Suba el frente de la licencia desde su computadora",
-        "body_passport": "Suba la página del pasaporte con su foto desde su computadora",
-        "body_selfie": "Suba una selfie desde su computadora",
-        "body_tax_letter": "Facilite la página completa del documento para obtener mejores resultados",
-        "button_take_photo": "Tomar foto",
-        "button_upload": "Subir",
-        "title_selfie": "Selfie"
-    },
-    "poa_cancel": "Cancelar",
-    "poa_err_invalid_file": {
-        "message": "Elija un archivo distinto.",
-        "ok": "De acuerdo",
-        "title": "El archivo no es válido"
-    },
-    "poa_guidance": {
-        "button_primary": "Continuar",
-        "instructions": {
-            "address": "Dirección actual",
-            "full_name": "Nombre completo",
-            "issue_date": "Fecha de emisión o período de resumen",
-            "label": "Capture todo el documento y asegúrese de que los siguientes datos se muestran con claridad:",
-            "logo": "Logo"
-        },
-        "subtitle_bank_statement": "Debe haberse emitido en los <strong>últimos 3 meses<\/strong>",
-        "subtitle_benefits_letter": "Debe haberse emitido en los <strong>últimos 12 meses<\/strong>",
-        "subtitle_bill": "Debe haberse emitido en los <strong>últimos 3 meses<\/strong>",
-        "subtitle_tax_letter": "Debe haberse emitido en los <strong>últimos 12 meses<\/strong>"
-    },
-    "poa_intro": {
-        "button_primary": "Iniciar verificación",
-        "list_matches_signup": "<strong>Coincide<\/strong> con la dirección utilizada para el registro",
-        "list_most_recent": "Es su documento más <strong>reciente<\/strong>",
-        "list_shows_address": "Muestra su dirección <strong>actual<\/strong>",
-        "subtitle": "Necesitará un documento que:",
-        "title": "Vamos a verificar su dirección"
-    },
-    "profile_data": {
-        "address_title": "Añada su dirección",
-        "button_continue": "Continuar",
-        "components": {
-            "country_select": {
-                "placeholder": "Seleccione un país"
-            },
-            "nationality_select": {
-                "placeholder": "Seleccione un país"
-            },
-            "pan": {
-                "placeholder": "ABCDE1234F"
-            },
-            "ssn": {
-                "placeholder": "123-45-6789"
-            },
-            "state_select": {
-                "placeholder": "Seleccione un estado"
-            }
-        },
-        "country_of_residence_title": "",
-        "field_labels": {
-            "country": "País",
-            "dob": "Fecha de nacimiento",
-            "email": "Correo electrónico",
-            "first_name": "Nombre",
-            "gbr_specific": {
-                "postcode": "Código postal",
-                "town": "Ciudad\/Población"
-            },
-            "last_name": "Apellido",
-            "line1": "Línea de dirección 1",
-            "line2": "Línea de dirección 2",
-            "line3": "Línea de dirección 3",
-            "mobile_number": "Número de móvil",
-            "nationality": "Nacionalidad",
-            "pan": "Número de cuenta permanente (PAN)",
-            "postcode": "Código postal",
-            "ssn": "Número de la seguridad social (NSS)",
-            "town": "Población",
-            "usa_specific": {
-                "line1_helper_text": "Dirección, por ejemplo: calle Alberto, n.º 200",
-                "line2_helper_text": "Apartamento, suite, unidad, etc.",
-                "postcode": "Código postal",
-                "state": "Estado"
-            }
-        },
-        "field_optional": "(opcional)",
-        "field_validation": {
-            "gbr_specific": {
-                "required_postcode": "Introduzca su código postal",
-                "too_long_postcode": "El código postal es demasiado largo",
-                "too_short_postcode": "El código postal es demasiado corto"
-            },
-            "invalid": "Compruebe si hay caracteres o símbolos no válidos",
-            "invalid_dob": "Introduzca una fecha de nacimiento válida",
-            "required_country": "Seleccione un país",
-            "required_dob": "Introduzca su fecha de nacimiento",
-            "required_email": "Introduzca su correo electrónico",
-            "required_first_name": "",
-            "required_last_name": "Introduzca su apellido",
-            "required_line1": "Introduzca su dirección",
-            "required_mobile_number": "Introduzca su número de móvil",
-            "required_nationality": "Seleccione un país",
-            "required_pan": "Introduzca su PAN",
-            "required_postcode": "Introduzca su código postal",
-            "required_ssn": "Introduzca su NSS",
-            "too_long__line1": "La línea de dirección es demasiado larga",
-            "too_long_first_name": "El nombre es demasiado largo",
-            "too_long_last_name": "El apellido es demasiado largo",
-            "too_long_postcode": "El código postal es demasiado largo",
-            "too_long_town": "",
-            "too_short_first_name": "El nombre es demasiado corto",
-            "too_short_last_name": "El apellido es demasiado corto",
-            "too_short_postcode": "El código postal es demasiado corto",
-            "usa_specific": {
-                "required_state": "Seleccione un estado"
-            },
-            "valid_email": "Introduzca un correo electrónico válido",
-            "valid_mobile_number": "Introduzca un número de móvil válido",
-            "valid_pan": "Introduzca un PAN válido",
-            "valid_ssn": "Introduzca un NSS válido"
-        },
-        "personal_information_title": "Añada sus datos personales",
-        "prompt": {
-            "details_timeout": "Empezar de nuevo",
-            "header_timeout": "Parece que ha tardado demasiado"
-        }
-    },
-    "retry_feedback": {
-        "button_primary": "Intentar otra vez"
-    },
-    "retry_feedback_id_expired": {
-        "subtitle": "Inténtelo de nuevo con un documento de identidad con fotografía válido y asegúrese de que sus datos se vean con claridad",
-        "title": "Su documento ha caducado"
-    },
-    "retry_feedback_id_generic": {
-        "subtitle": "Inténtelo de nuevo con un documento de identidad con fotografía válido y asegúrese de que sus datos se vean con claridad",
-        "title": "Ha habido un problema con su documento"
-    },
-    "retry_feedback_id_unaccepted": {
-        "subtitle": "Inténtelo de nuevo con un documento de identidad con fotografía válido y asegúrese de que sus datos se vean con claridad",
-        "title": "Documento no aceptado"
-    },
-    "retry_feedback_selfie_generic": {
-        "subtitle": "Inténtelo de nuevo y asegúrese que su cara sea visible y esté bien iluminada",
-        "title": "Ha habido un problema con su selfie"
+      "body_id_back": "Tome una foto del reverso de su tarjeta",
+      "body_id_front": "Tome una foto del frente de su tarjeta",
+      "body_license_back": "Tome una foto del reverso de su licencia",
+      "body_license_front": "Tome una foto del frente de su licencia",
+      "body_passport": "Tome una foto de la página del pasaporte que incluye su fotografía",
+      "body_selfie": "Tome una selfie que muestre su cara"
     },
     "selfie_capture": {
-        "alert": {
-            "camera_inactive": {
-                "detail": "Revise que esté conectada y funcione. También puede<fallback>continuar con la verificación de identidad en su teléfono móvil<\/fallback>",
-                "detail_no_fallback": "Asegúrese de que su dispositivo tenga una cámara que funcione",
-                "title": "¿La cámara no está funcionando?"
-            },
-            "camera_not_working": {
-                "detail": "Puede estar desconectada o no funcionando. <fallback>Use su móvil<\/fallback> para continuar la verificación",
-                "detail_no_fallback": "Asegúrese de que su dispositivo tenga una cámara que funcione",
-                "title": "Su cámara no esta funcionando"
-            },
-            "timeout": {
-                "detail": "Recuerde presionar el botón cuando haya terminado. <fallback>Rehacer acciones<\/fallback>",
-                "title": "Parece que ha demorado demasiado"
-            }
+      "alert": {
+        "camera_inactive": {
+          "detail": "Tome una foto usando el <fallback>modo de cámara básica</fallback> en su lugar"
         },
-        "body": "Mantenga la cara dentro del óvalo",
-        "button_accessibility": "Tomar foto",
-        "button_primary": "Iniciar escaneo del rostro",
-        "frame_accessibility": "Vista desde la cámara",
-        "title": "Mantenga la cara dentro del óvalo"
-    },
-    "selfie_confirmation": {
-        "image_accessibility": "Foto de su cara",
-        "subtitle": "Asegúrese de que la selfie muestre claramente su cara",
-        "title": "Verificar selfie"
-    },
-    "selfie_intro": {
-        "button_primary": "Continuar",
-        "list_accessibility": "Consejos para capturar un buen selfie",
-        "list_item_face_forward": "Mire hacia delante y asegúrese de que sus ojos se vean con claridad",
-        "list_item_no_glasses": "Quítese las gafas si es necesario",
-        "subtitle": "Compararemos esto con su documento",
-        "title": "Tome una selfie"
-    },
-    "sms_sent": {
-        "info": "Recomendaciones",
-        "info_link_expire": "Su enlace móvil caducará en una hora",
-        "info_link_window": "Mantenga esta ventana abierta mientras usa su dispositivo móvil",
-        "link": "Reenviar enlace",
-        "subtitle": "Hemos enviado un enlace seguro a %{number}",
-        "subtitle_minutes": "Puede tardar unos minutos en llegar",
-        "title": "Controle su dispositivo móvil"
-    },
-    "switch_phone": {
-        "info": "Recomendaciones",
-        "info_link_expire": "El enlace móvil caducará en una hora",
-        "info_link_refresh": "No actualizar esta página",
-        "info_link_window": "Mantenga esta ventana abierta mientras usa su dispositivo móvil",
-        "link": "Cancelar",
-        "subtitle": "Cuando haya terminado, le llevaremos al próximo paso",
-        "title": "Conectado con su móvil"
+        "camera_not_working": {
+          "detail": "Tome una foto usando el <fallback>modo de cámara básica</fallback> en su lugar"
+        }
+      }
     },
     "upload_guide": {
-        "button_primary": "Subir foto",
-        "image_detail_blur_alt": "Ejemplo de un documento borroso",
-        "image_detail_blur_label": "Todos los detalles deben ser claros, nada borroso",
-        "image_detail_cutoff_label": "Mostrar todos los detalles, incluidas las dos líneas inferiores",
-        "image_detail_glare_label": "Aléjese de la luz directa, sin reflejos",
-        "image_detail_good_label": "La foto debe mostrar claramente su documento",
-        "subtitle": "No se aceptan fotos escaneadas ni fotocopias",
-        "title": "Subir la página del pasaporte con su foto"
-    },
-    "user_consent": {
-        "button_primary": "Accept",
-        "button_secondary": "Do not accept",
-        "prompt": {
-            "button_primary": "Review again",
-            "button_secondary": "Yes, don’t verify me",
-            "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
-            "no_consent_title": "Are you sure?"
-        }
-    },
-    "user_consent_load_fail": {
-        "button_primary": "Reload screen",
-        "detail": "Check that your connection is stable, then try again",
-        "title": "Content failed to load"
-    },
-    "video_capture": {
-        "body": "Mantenga la cara dentro del óvalo",
-        "body_record": "Presione el botón cuando esté listo",
-        "body_stop": "Presione \"parar\" cuando haya terminado",
-        "button_primary_finish": "Finalizar grabación",
-        "button_primary_next": "Siguiente paso",
-        "button_primary_start": "Iniciar grabación",
-        "button_record_accessibility": "Iniciar grabación",
-        "frame_accessibility": "Vista desde la cámara",
-        "header": {
-            "challenge_digit_instructions": "Lea en voz alta cada dígito",
-            "challenge_turn_forward": "luego vuelva a mirar hacia delante",
-            "challenge_turn_left": "Mire sobre su hombro izquierdo",
-            "challenge_turn_right": "Mire sobre su hombro derecho"
-        },
-        "prompt": {
-            "header_timeout": "Parece que ha demorado demasiado"
-        }
-    },
-    "video_confirmation": {
-        "body": "Su video ha sido grabado",
-        "button_primary": "Enviar video",
-        "button_secondary": "Retomar el video",
-        "title": "Verifique video",
-        "video_accessibility": "Reproducir su video grabado"
-    },
-    "video_intro": {
-        "button_primary": "Grábese en un vídeo",
-        "list_accessibility": "Acciones para grabar un video selfie",
-        "list_item_actions": "Termine las instrucciones en 20 segundos",
-        "list_item_speak": "Siga las instrucciones para moverse o hablar",
-        "title": "Grábese en un vídeo"
-    },
-    "welcome": {
-        "doc_video_subtitle": "Debería tomar unos minutos",
-        "list_header_doc_video": "Utilice su móvil para la grabación:",
-        "list_header_webcam": "Utilice su cámara web o su teléfono para fotografiar:",
-        "list_item_doc": "su documento de identidad",
-        "list_item_doc_video_timeout": "La grabación tiene un límite de <timeout><\/timeout> segundos",
-        "list_item_poa": "la prueba de su dirección",
-        "list_item_selfie": "su cara",
-        "next_button": "Seleccione un documento",
-        "start_workflow_button": "Empezar la verificación",
-        "subtitle": "Debería tomar unos minutos",
-        "title": "Verifique su identidad"
-    },
-    "workflow_complete": {
-        "pass": {
-            "description": "",
-            "title": ""
-        },
-        "reject": {
-            "description": "",
-            "title": ""
-        }
-    },
-    "workflow_erros": {
-        "generic_title": "",
-        "no_workflow_run_id": "",
-        "reload_app": "",
-        "task_not_completed": "",
-        "task_not_retrieved": "",
-        "task_not_supported": ""
+      "button_primary": "Tomar foto",
+      "title": "Página del pasaporte con su foto"
     }
+  },
+  "outro": {
+    "body": "Eso es todo lo que necesitamos para comenzar a verificar su identidad",
+    "body_government_letter": "Facilite la página completa del documento para obtener mejores resultados",
+    "title": "Gracias"
+  },
+  "permission": {
+    "body_both": "No lo podemos verificar sin acceso a su cámara y micrófono",
+    "body_cam": "No le podemos verificar sin usar su cámara",
+    "button_primary_both": "Conceder acceso a ambos",
+    "button_primary_cam": "Activar cámara",
+    "subtitle_both": "Deberá conceder acceso a ambos para continuar",
+    "subtitle_cam": "Deberá activar la cámara para continuar",
+    "title_both": "Permitir acceso a la cámara y al micrófono",
+    "title_cam": "Permitir acceso a la cámara"
+  },
+  "permission_recovery": {
+    "button_primary": "Actualizar",
+    "info": "Recuperación",
+    "list_header_both": "Siga estos pasos para recuperar acceso a ambos:",
+    "list_header_cam": "Siga estos pasos para recuperar acceso a la cámara:",
+    "list_item_action_cam": "Actualice esta página para reiniciar el proceso de verificación",
+    "list_item_how_to_both": "Autorice acceso a la cámara y el micrófono desde los ajustes del navegador",
+    "list_item_how_to_cam": "Autorice acceso a su cámara desde los ajustes del navegador",
+    "subtitle_both": "Recupere acceso a la cámara y el micrófono para grabar un video y completar el proceso de verificación",
+    "subtitle_cam": "Recupere acceso a la cámara para continuar la verificación",
+    "subtitle_cam_old": "Recupere acceso a la cámara para continuar la verificación facial",
+    "title_both": "Acceso denegado a la cámara y al micrófono",
+    "title_cam": "Acceso a la cámara no permitido"
+  },
+  "photo_upload": {
+    "body_bank_statement": "Facilite la página completa del documento para obtener mejores resultados",
+    "body_benefits_letter": "Facilite la página completa del documento para obtener mejores resultados",
+    "body_bill": "Facilite la página completa del documento para obtener mejores resultados",
+    "body_id_back": "Suba el reverso de la tarjeta desde su computadora",
+    "body_id_front": "Suba el frente de la tarjeta desde su computadora",
+    "body_license_back": "Suba el reverso de la licencia desde su computadora",
+    "body_license_front": "Suba el frente de la licencia desde su computadora",
+    "body_passport": "Suba la página del pasaporte con su foto desde su computadora",
+    "body_selfie": "Suba una selfie desde su computadora",
+    "body_tax_letter": "Facilite la página completa del documento para obtener mejores resultados",
+    "button_take_photo": "Tomar foto",
+    "button_upload": "Subir",
+    "title_selfie": "Selfie"
+  },
+  "poa_cancel": "Cancelar",
+  "poa_err_invalid_file": {
+    "message": "Elija un archivo distinto.",
+    "ok": "De acuerdo",
+    "title": "El archivo no es válido"
+  },
+  "poa_guidance": {
+    "button_primary": "Continuar",
+    "instructions": {
+      "address": "Dirección actual",
+      "full_name": "Nombre completo",
+      "issue_date": "Fecha de emisión o período de resumen",
+      "label": "Capture todo el documento y asegúrese de que los siguientes datos se muestran con claridad:",
+      "logo": "Logo"
+    },
+    "subtitle_bank_statement": "Debe haberse emitido en los <strong>últimos 3 meses</strong>",
+    "subtitle_benefits_letter": "Debe haberse emitido en los <strong>últimos 12 meses</strong>",
+    "subtitle_bill": "Debe haberse emitido en los <strong>últimos 3 meses</strong>",
+    "subtitle_tax_letter": "Debe haberse emitido en los <strong>últimos 12 meses</strong>"
+  },
+  "poa_intro": {
+    "button_primary": "Iniciar verificación",
+    "list_matches_signup": "<strong>Coincide</strong> con la dirección utilizada para el registro",
+    "list_most_recent": "Es su documento más <strong>reciente</strong>",
+    "list_shows_address": "Muestra su dirección <strong>actual</strong>",
+    "subtitle": "Necesitará un documento que:",
+    "title": "Vamos a verificar su dirección"
+  },
+  "profile_data": {
+    "address_title": "Añada su dirección",
+    "button_continue": "Continuar",
+    "components": {
+      "country_select": {
+        "placeholder": "Seleccione un país"
+      },
+      "nationality_select": {
+        "placeholder": "Seleccione un país"
+      },
+      "pan": {
+        "placeholder": "ABCDE1234F"
+      },
+      "ssn": {
+        "placeholder": "123-45-6789"
+      },
+      "state_select": {
+        "placeholder": "Seleccione un estado"
+      }
+    },
+    "country_of_residence_title": "",
+    "field_labels": {
+      "country": "País",
+      "dob": "Fecha de nacimiento",
+      "email": "Correo electrónico",
+      "first_name": "Nombre",
+      "gbr_specific": {
+        "postcode": "Código postal",
+        "town": "Ciudad/Población"
+      },
+      "last_name": "Apellido",
+      "line1": "Línea de dirección 1",
+      "line2": "Línea de dirección 2",
+      "line3": "Línea de dirección 3",
+      "mobile_number": "Número de móvil",
+      "nationality": "Nacionalidad",
+      "pan": "Número de cuenta permanente (PAN)",
+      "postcode": "Código postal",
+      "ssn": "Número de la seguridad social (NSS)",
+      "town": "Población",
+      "usa_specific": {
+        "line1_helper_text": "Dirección, por ejemplo: calle Alberto, n.º 200",
+        "line2_helper_text": "Apartamento, suite, unidad, etc.",
+        "postcode": "Código postal",
+        "state": "Estado"
+      }
+    },
+    "field_optional": "(opcional)",
+    "field_validation": {
+      "gbr_specific": {
+        "required_postcode": "Introduzca su código postal",
+        "too_long_postcode": "El código postal es demasiado largo",
+        "too_short_postcode": "El código postal es demasiado corto"
+      },
+      "invalid": "Compruebe si hay caracteres o símbolos no válidos",
+      "invalid_dob": "Introduzca una fecha de nacimiento válida",
+      "required_country": "Seleccione un país",
+      "required_dob": "Introduzca su fecha de nacimiento",
+      "required_email": "Introduzca su correo electrónico",
+      "required_first_name": "",
+      "required_last_name": "Introduzca su apellido",
+      "required_line1": "Introduzca su dirección",
+      "required_mobile_number": "Introduzca su número de móvil",
+      "required_nationality": "Seleccione un país",
+      "required_pan": "Introduzca su PAN",
+      "required_postcode": "Introduzca su código postal",
+      "required_ssn": "Introduzca su NSS",
+      "too_long__line1": "La línea de dirección es demasiado larga",
+      "too_long_first_name": "El nombre es demasiado largo",
+      "too_long_last_name": "El apellido es demasiado largo",
+      "too_long_postcode": "El código postal es demasiado largo",
+      "too_long_town": "",
+      "too_short_first_name": "El nombre es demasiado corto",
+      "too_short_last_name": "El apellido es demasiado corto",
+      "too_short_postcode": "El código postal es demasiado corto",
+      "usa_specific": {
+        "required_state": "Seleccione un estado"
+      },
+      "valid_email": "Introduzca un correo electrónico válido",
+      "valid_mobile_number": "Introduzca un número de móvil válido",
+      "valid_pan": "Introduzca un PAN válido",
+      "valid_ssn": "Introduzca un NSS válido"
+    },
+    "personal_information_title": "Añada sus datos personales",
+    "prompt": {
+      "details_timeout": "Empezar de nuevo",
+      "header_timeout": "Parece que ha tardado demasiado"
+    }
+  },
+  "retry_feedback": {
+    "button_primary": "Intentar otra vez"
+  },
+  "retry_feedback_id_expired": {
+    "subtitle": "Inténtelo de nuevo con un documento de identidad con fotografía válido y asegúrese de que sus datos se vean con claridad",
+    "title": "Su documento ha caducado"
+  },
+  "retry_feedback_id_generic": {
+    "subtitle": "Inténtelo de nuevo con un documento de identidad con fotografía válido y asegúrese de que sus datos se vean con claridad",
+    "title": "Ha habido un problema con su documento"
+  },
+  "retry_feedback_id_unaccepted": {
+    "subtitle": "Inténtelo de nuevo con un documento de identidad con fotografía válido y asegúrese de que sus datos se vean con claridad",
+    "title": "Documento no aceptado"
+  },
+  "retry_feedback_selfie_generic": {
+    "subtitle": "Inténtelo de nuevo y asegúrese que su cara sea visible y esté bien iluminada",
+    "title": "Ha habido un problema con su selfie"
+  },
+  "selfie_capture": {
+    "alert": {
+      "camera_inactive": {
+        "detail": "Revise que esté conectada y funcione. También puede<fallback>continuar con la verificación de identidad en su teléfono móvil</fallback>",
+        "detail_no_fallback": "Asegúrese de que su dispositivo tenga una cámara que funcione",
+        "title": "¿La cámara no está funcionando?"
+      },
+      "camera_not_working": {
+        "detail": "Puede estar desconectada o no funcionando. <fallback>Use su móvil</fallback> para continuar la verificación",
+        "detail_no_fallback": "Asegúrese de que su dispositivo tenga una cámara que funcione",
+        "title": "Su cámara no esta funcionando"
+      },
+      "timeout": {
+        "detail": "Recuerde presionar el botón cuando haya terminado. <fallback>Rehacer acciones</fallback>",
+        "title": "Parece que ha demorado demasiado"
+      }
+    },
+    "body": "Mantenga la cara dentro del óvalo",
+    "button_accessibility": "Tomar foto",
+    "button_primary": "Iniciar escaneo del rostro",
+    "frame_accessibility": "Vista desde la cámara",
+    "title": "Mantenga la cara dentro del óvalo"
+  },
+  "selfie_confirmation": {
+    "image_accessibility": "Foto de su cara",
+    "subtitle": "Asegúrese de que la selfie muestre claramente su cara",
+    "title": "Verificar selfie"
+  },
+  "selfie_intro": {
+    "button_primary": "Continuar",
+    "list_accessibility": "Consejos para capturar un buen selfie",
+    "list_item_face_forward": "Mire hacia delante y asegúrese de que sus ojos se vean con claridad",
+    "list_item_no_glasses": "Quítese las gafas si es necesario",
+    "subtitle": "Compararemos esto con su documento",
+    "title": "Tome una selfie"
+  },
+  "sms_sent": {
+    "info": "Recomendaciones",
+    "info_link_expire": "Su enlace móvil caducará en una hora",
+    "info_link_window": "Mantenga esta ventana abierta mientras usa su dispositivo móvil",
+    "link": "Reenviar enlace",
+    "subtitle": "Hemos enviado un enlace seguro a %{number}",
+    "subtitle_minutes": "Puede tardar unos minutos en llegar",
+    "title": "Controle su dispositivo móvil"
+  },
+  "switch_phone": {
+    "info": "Recomendaciones",
+    "info_link_expire": "El enlace móvil caducará en una hora",
+    "info_link_refresh": "No actualizar esta página",
+    "info_link_window": "Mantenga esta ventana abierta mientras usa su dispositivo móvil",
+    "link": "Cancelar",
+    "subtitle": "Cuando haya terminado, le llevaremos al próximo paso",
+    "title": "Conectado con su móvil"
+  },
+  "upload_guide": {
+    "button_primary": "Subir foto",
+    "image_detail_blur_alt": "Ejemplo de un documento borroso",
+    "image_detail_blur_label": "Todos los detalles deben ser claros, nada borroso",
+    "image_detail_cutoff_label": "Mostrar todos los detalles, incluidas las dos líneas inferiores",
+    "image_detail_glare_label": "Aléjese de la luz directa, sin reflejos",
+    "image_detail_good_label": "La foto debe mostrar claramente su documento",
+    "subtitle": "No se aceptan fotos escaneadas ni fotocopias",
+    "title": "Subir la página del pasaporte con su foto"
+  },
+  "user_consent": {
+    "button_primary": "Accept",
+    "button_secondary": "Do not accept",
+    "prompt": {
+      "button_primary": "Review again",
+      "button_secondary": "Yes, don’t verify me",
+      "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
+      "no_consent_title": "Are you sure?"
+    }
+  },
+  "user_consent_load_fail": {
+    "button_primary": "Reload screen",
+    "detail": "Check that your connection is stable, then try again",
+    "title": "Content failed to load"
+  },
+  "video_capture": {
+    "body": "Mantenga la cara dentro del óvalo",
+    "body_record": "Presione el botón cuando esté listo",
+    "body_stop": "Presione \"parar\" cuando haya terminado",
+    "button_primary_finish": "Finalizar grabación",
+    "button_primary_next": "Siguiente paso",
+    "button_primary_start": "Iniciar grabación",
+    "button_record_accessibility": "Iniciar grabación",
+    "frame_accessibility": "Vista desde la cámara",
+    "header": {
+      "challenge_digit_instructions": "Lea en voz alta cada dígito",
+      "challenge_turn_forward": "luego vuelva a mirar hacia delante",
+      "challenge_turn_left": "Mire sobre su hombro izquierdo",
+      "challenge_turn_right": "Mire sobre su hombro derecho"
+    },
+    "prompt": {
+      "header_timeout": "Parece que ha demorado demasiado"
+    }
+  },
+  "video_confirmation": {
+    "body": "Su video ha sido grabado",
+    "button_primary": "Enviar video",
+    "button_secondary": "Retomar el video",
+    "title": "Verifique video",
+    "video_accessibility": "Reproducir su video grabado"
+  },
+  "video_intro": {
+    "button_primary": "Grábese en un vídeo",
+    "list_accessibility": "Acciones para grabar un video selfie",
+    "list_item_actions": "Termine las instrucciones en 20 segundos",
+    "list_item_speak": "Siga las instrucciones para moverse o hablar",
+    "title": "Grábese en un vídeo"
+  },
+  "welcome": {
+    "doc_video_subtitle": "Debería tomar unos minutos",
+    "list_header_doc_video": "Utilice su móvil para la grabación:",
+    "list_header_webcam": "Utilice su cámara web o su teléfono para fotografiar:",
+    "list_item_doc": "su documento de identidad",
+    "list_item_doc_video_timeout": "La grabación tiene un límite de <timeout></timeout> segundos",
+    "list_item_poa": "la prueba de su dirección",
+    "list_item_selfie": "su cara",
+    "next_button": "Seleccione un documento",
+    "start_workflow_button": "Empezar la verificación",
+    "subtitle": "Debería tomar unos minutos",
+    "title": "Verifique su identidad"
+  },
+  "workflow_complete": {
+    "pass": {
+      "description": "",
+      "title": ""
+    },
+    "reject": {
+      "description": "",
+      "title": ""
+    }
+  },
+  "workflow_erros": {
+    "generic_title": "",
+    "no_workflow_run_id": "",
+    "reload_app": "",
+    "task_not_completed": "",
+    "task_not_retrieved": "",
+    "task_not_supported": ""
+  }
 }

--- a/src/locales/fr_FR/fr_FR.json
+++ b/src/locales/fr_FR/fr_FR.json
@@ -1,765 +1,765 @@
 {
-    "auth_accessibility": {
-        "back_button": "Annuler"
+  "auth_accessibility": {
+    "back_button": "Annuler"
+  },
+  "auth_cam_encrypt": {
+    "loader": "Cryptage du flux de l’appareil photo"
+  },
+  "auth_cam_start": {
+    "loader": "Démarrage de l’appareil photo"
+  },
+  "auth_capture_start": {
+    "body": "Gardez votre visage dans l’ovale.",
+    "button_primary": "Démarrer le scan du visage",
+    "feedback": {
+      "center_face": "Encadrez votre visage",
+      "conditions_too_bright": "Trouvez un environnement moins lumineux",
+      "conditions_too_dark": "Trouvez un environnement plus lumineux",
+      "head_not_upright": "Gardez la tête droite",
+      "neutral_expression": "Gardez une expression neutre",
+      "not_looking_straight": "Regardez devant vous",
+      "remove_sunglasses": "Retirez vos lunettes de soleil",
+      "steady_count_1": "Restez immobile : 1",
+      "steady_count_2": "Restez immobile : 2",
+      "steady_count_3": "Restez immobile : 3"
     },
-    "auth_cam_encrypt": {
-        "loader": "Cryptage du flux de l’appareil photo"
+    "title": "Démarrer le scan du visage"
+  },
+  "auth_capture": {
+    "feedback": {
+      "center_face": "Encadrez votre visage",
+      "even_lighting": "Assurez-vous que votre éclairage est uniforme",
+      "eye_level": "Gardez votre appareil photo au niveau des yeux",
+      "face_not_found": "Assurez-vous que votre visage est visible",
+      "head_not_upright": "Gardez la tête droite",
+      "move_back": "Maintenant, reculez",
+      "move_close": "Maintenant, approchez-vous",
+      "move_closer": "Approchez-vous",
+      "not_looking_straight": "Regardez devant vous",
+      "steady": "Ne bougez pas"
+    }
+  },
+  "auth_error": {
+    "cam_encryption": {
+      "body": "Cette application bloque les configurations de webcam suspectes. <fallback>En savoir plus</fallback>.",
+      "button_primary": "Réessayer",
+      "button_primary_firefox": "Réessayer",
+      "subtitle": "Ce système ne peut pas être vérifié pour les raisons suivantes :",
+      "table_header_1": "Problème possible",
+      "table_header_2": "Réparer",
+      "table_row_1_cell_1": "Appareil photo déjà utilisé par une autre application.",
+      "table_row_1_cell_1_firefox": "Les autorisations de l’appareil photo ne sont pas mémorisées dans Firefox.",
+      "table_row_1_cell_2": "Fermez l’autre application.",
+      "table_row_1_cell_2_firefox": "Vérifiez Se souvenir des autorisations.",
+      "table_row_2_cell_1": "Une application tierce modifie la vidéo.",
+      "table_row_2_cell_2": "Fermez/désinstallez l’autre application.",
+      "table_row_3_cell_1": "Le matériel ne peut pas être sécurisé.",
+      "table_row_3_cell_2": "Utilisez un autre appareil.",
+      "title": "<b>Problème de cryptage du flux de l’appareil photo</b>"
+    }
+  },
+  "auth_full_screen": {
+    "body": "Cela lancera la capture du selfie en mode plein écran.",
+    "button_primary": "Ouvrir en plein écran",
+    "title": "Mode selfie plein écran"
+  },
+  "auth_permission_denied": {
+    "body_cam": "Pour continuer, vous devez activer les autorisations de la caméra dans les paramètres de votre mobile.",
+    "button_primary_cam": "Paramètres de lancement"
+  },
+  "auth_permission": {
+    "body_cam": "Pour continuer, vous devez activer les autorisations de la caméra lorsque vous y êtes invité.",
+    "button_primary_cam": "Activer la caméra",
+    "title_cam": "Autoriser l’accès à la caméra"
+  },
+  "auth_progress": {
+    "loader": "Téléversement"
+  },
+  "auth_retry": {
+    "body_blur": "Nettoyez l’objectif de votre appareil photo",
+    "body_neutral_expression": "Gardez une expression neutre",
+    "body_too_bright": "Trouvez un environnement moins lumineux",
+    "button_primary": "Démarrer la caméra",
+    "subtitle": "Nous n’avons pas été en mesure de capturer votre visage correctement",
+    "title": "Scannez à nouveau votre visage"
+  },
+  "auth_upload_pass": {
+    "body": "Téléversement réussi"
+  },
+  "avc_confirmation": {
+    "button_primary_upload": "Téléverser l’enregistrement",
+    "subtitle": "Une vidéo de votre visage a bien été enregistrée",
+    "title": "Enregistrement terminé"
+  },
+  "avc_connection_error": {
+    "button_primary_reload": "Recharger les instructions",
+    "button_primary_retry_upload": "Réessayer de téléverser",
+    "button_secondary_restart_recording": "Redémarrer l’enregistrement",
+    "subtitle": "Vérifiez que votre connexion est stable, puis réessayez",
+    "title": "Erreur de connexion"
+  },
+  "avc_face_alignment": {
+    "feedback_move_back": "Reculez",
+    "feedback_move_closer": "Approchez-vous",
+    "feedback_no_face_detected": "Visage non détecté",
+    "feedback_not_centered": "Visage non centré",
+    "title": "Positionnez votre visage dans le cadre"
+  },
+  "avc_face_capture": {
+    "alert": {
+      "timeout_body": "Vous avez jusqu'à 15 secondes pour compléter votre enregistrement",
+      "timeout_button_primary": "Réessayer",
+      "timeout_title": "Désolé, nous devons redémarrer l'enregistrement",
+      "too_fast_body": "Veuillez réessayer et tournez votre tête plus lentement",
+      "too_fast_button_primary": "Réessayer",
+      "too_fast_title": "Vous avez tourné votre tête trop vite"
     },
-    "auth_cam_start": {
-        "loader": "Démarrage de l’appareil photo"
+    "title": "Tournez votre tête lentement des deux côtés",
+    "title_completed": "Enregistrement terminé"
+  },
+  "avc_intro": {
+    "button_primary_ready": "Je suis prêt(e)",
+    "disclaimer": "Sachez que nous enregistrerons votre visage et l'arrière-plan",
+    "list_item_one": "D'abord, positionnez votre visage dans le cadre",
+    "list_item_two": "Ensuite, tournez votre tête lentement des deux côtés",
+    "subtitle": "Ceci sert à vérifier que vous êtes une personne authentique",
+    "title": "Enregistrez une vidéo"
+  },
+  "avc_no_face_detected": {
+    "button_primary_restart": "Redémarrer l’enregistrement",
+    "list_item_eyes": "Assurez-vous que vos yeux sont clairement visibles",
+    "list_item_face": "Assurez-vous de ne montrer que votre visage, nous n'avons pas besoin de voir votre pièce d'identité",
+    "list_item_lighting": "Assurez-vous d'être à un endroit bien éclairé",
+    "list_item_mask": "Assurez-vous d'ôter le masque ou outres éléments qui couvrent votre visage. Les lunettes sont acceptées",
+    "title": "Nous ne pouvons pas détecter votre visage"
+  },
+  "avc_uploading": {
+    "title": "Téléversement"
+  },
+  "country_select": {
+    "alert": {
+      "another_doc": "Les documents de ce pays ne sont actuellement pas pris en charge — <fallback>essayez un autre type de document</fallback>"
     },
-    "auth_capture_start": {
-        "body": "Gardez votre visage dans l’ovale.",
-        "button_primary": "Démarrer le scan du visage",
-        "feedback": {
-            "center_face": "Encadrez votre visage",
-            "conditions_too_bright": "Trouvez un environnement moins lumineux",
-            "conditions_too_dark": "Trouvez un environnement plus lumineux",
-            "head_not_upright": "Gardez la tête droite",
-            "neutral_expression": "Gardez une expression neutre",
-            "not_looking_straight": "Regardez devant vous",
-            "remove_sunglasses": "Retirez vos lunettes de soleil",
-            "steady_count_1": "Restez immobile : 1",
-            "steady_count_2": "Restez immobile : 2",
-            "steady_count_3": "Restez immobile : 3"
-        },
-        "title": "Démarrer le scan du visage"
+    "alert_dropdown": {
+      "country_not_found": "Pays introuvable"
     },
-    "auth_capture": {
-        "feedback": {
-            "center_face": "Encadrez votre visage",
-            "even_lighting": "Assurez-vous que votre éclairage est uniforme",
-            "eye_level": "Gardez votre appareil photo au niveau des yeux",
-            "face_not_found": "Assurez-vous que votre visage est visible",
-            "head_not_upright": "Gardez la tête droite",
-            "move_back": "Maintenant, reculez",
-            "move_close": "Maintenant, approchez-vous",
-            "move_closer": "Approchez-vous",
-            "not_looking_straight": "Regardez devant vous",
-            "steady": "Ne bougez pas"
-        }
+    "button_primary": "Envoyer le document",
+    "poa_alert": {
+      "country_not_found": "Nous sommes désolés. Nous travaillons à prendre en charge plus de pays.",
+      "intro": "Vous ne trouvez pas votre pays ?"
     },
-    "auth_error": {
-        "cam_encryption": {
-            "body": "Cette application bloque les configurations de webcam suspectes. <fallback>En savoir plus<\/fallback>.",
-            "button_primary": "Réessayer",
-            "button_primary_firefox": "Réessayer",
-            "subtitle": "Ce système ne peut pas être vérifié pour les raisons suivantes :",
-            "table_header_1": "Problème possible",
-            "table_header_2": "Réparer",
-            "table_row_1_cell_1": "Appareil photo déjà utilisé par une autre application.",
-            "table_row_1_cell_1_firefox": "Les autorisations de l’appareil photo ne sont pas mémorisées dans Firefox.",
-            "table_row_1_cell_2": "Fermez l’autre application.",
-            "table_row_1_cell_2_firefox": "Vérifiez Se souvenir des autorisations.",
-            "table_row_2_cell_1": "Une application tierce modifie la vidéo.",
-            "table_row_2_cell_2": "Fermez\/désinstallez l’autre application.",
-            "table_row_3_cell_1": "Le matériel ne peut pas être sécurisé.",
-            "table_row_3_cell_2": "Utilisez un autre appareil.",
-            "title": "<b>Problème de cryptage du flux de l’appareil photo<\/b>"
-        }
+    "search": {
+      "accessibility": "Choisissez le pays",
+      "input_placeholder": "ex : France",
+      "label": "Chercher un pays"
     },
-    "auth_full_screen": {
-        "body": "Cela lancera la capture du selfie en mode plein écran.",
-        "button_primary": "Ouvrir en plein écran",
-        "title": "Mode selfie plein écran"
+    "title": "Sélectionnez votre pays"
+  },
+  "cross_device_checklist": {
+    "button_primary": "Envoyer la vérification",
+    "info": "Conseils",
+    "list_item_doc_multiple": "Documents envoyés",
+    "list_item_doc_one": "Document envoyé",
+    "list_item_poa": "Justificatif d'adresse",
+    "list_item_selfie": "Selfie envoyé",
+    "list_item_video": "Vidéo envoyée",
+    "subtitle": "Voici ce que vous avez téléversé :",
+    "title": "Dernière étape"
+  },
+  "cross_device_error_desktop": {
+    "subtitle": "Le lien ne fonctionne que sur les appareils mobiles",
+    "title": "Quelque chose ne va pas"
+  },
+  "cross_device_error_restart": {
+    "subtitle": "Vous devrez redémarrer votre vérification sur votre ordinateur",
+    "title": "Quelque chose ne va pas"
+  },
+  "cross_device_intro": {
+    "button_primary": "Obtenir un lien sécurisé",
+    "list_accessibility": "Étapes requises pour continuer la vérification sur votre mobile",
+    "list_item_finish": "Revenez ici pour finaliser l’envoi",
+    "list_item_open_link": "Ouvrez le lien et complétez les tâches",
+    "list_item_send_phone": "Envoyez un lien sécurisé vers votre téléphone",
+    "subtitle": "Voici comment faire :",
+    "title": "Continuez sur votre mobile"
+  },
+  "cross_device_return": {
+    "body": "Votre ordinateur peut prendre quelques secondes pour mettre à jour la page",
+    "subtitle": "Vous pouvez maintenant retourner sur votre ordinateur pour continuer",
+    "title": "Envois réussis"
+  },
+  "cross_device_session_linked": {
+    "button_primary": "Continuer",
+    "info": "Revérifier",
+    "list_item_desktop_open": "Votre fenêtre de bureau reste ouverte",
+    "list_item_sent_by_you": "Ce lien a été envoyé par vous. Demandez conseil si vous pensez qu’il s’agit d’une escroquerie.",
+    "subtitle": "Poursuivre la vérification",
+    "title": "Lié à votre ordinateur"
+  },
+  "doc_capture": {
+    "button_primary": "Démarrer le scan du document",
+    "detail": {
+      "folded_doc_front": "Dépliez votre document, prenez en photo les pages intérieures (qui contiennent votre photo)"
     },
-    "auth_permission_denied": {
-        "body_cam": "Pour continuer, vous devez activer les autorisations de la caméra dans les paramètres de votre mobile.",
-        "button_primary_cam": "Paramètres de lancement"
+    "header_folded_doc_front": "Côté contenant votre photo",
+    "prompt": {
+      "button_card": "Carte plastique",
+      "button_paper": "Document papier",
+      "title_id": "Quelle type de carte d’identité avez-vous ?",
+      "title_license": "Quel type de permis avez-vous ?"
+    }
+  },
+  "doc_confirmation": {
+    "alert": {
+      "blur_detail": "Assurez-vous que tout est bien net",
+      "blur_title": "L’image est floue",
+      "crop_detail": "Assurez-vous que l’intégralité du document est visible",
+      "crop_title": "Image tronquée détectée",
+      "glare_detail": "Éloignez-vous de la lumière directe",
+      "glare_title": "Attention aux reflets",
+      "no_doc_detail": "Assurez-vous que le document entier est sur la photo",
+      "no_doc_title": "Aucun document détecté"
     },
-    "auth_permission": {
-        "body_cam": "Pour continuer, vous devez activer les autorisations de la caméra lorsque vous y êtes invité.",
-        "button_primary_cam": "Activer la caméra",
-        "title_cam": "Autoriser l’accès à la caméra"
+    "body": "Assurez-vous d'avoir téléversé la page entière du document et que les détails sont clairement lisibles, sans flou et sans reflets",
+    "body_bank_statement": "Assurez-vous d'avoir téléversé la page entière du document et que les détails sont clairement lisibles, sans flou et sans reflets",
+    "body_benefits_letter": "Assurez-vous d'avoir téléversé la page entière du document et que les détails sont clairement lisibles, sans flou et sans reflets",
+    "body_bill": "Assurez-vous d'avoir téléversé la page entière du document et que les détails sont clairement lisibles, sans flou et sans reflets",
+    "body_id": "Assurez-vous que vos coordonnées sont lisibles et nettes",
+    "body_image_medium": "Il faudra plus de temps pour vous vérifier si la lecture est impossible",
+    "body_image_poor": "Pour vous vérifier au mieux, nous avons besoin d’une meilleure photo",
+    "body_license": "Assurez-vous que vos coordonnées sont lisibles et nettes",
+    "body_passport": "Assurez-vous que vos coordonnées sont lisibles et nettes",
+    "body_permit": "Assurez-vous que vos coordonnées sont lisibles et nettes",
+    "body_tax_letter": "Assurez-vous d'avoir téléversé la page entière du document et que les détails sont clairement lisibles, sans flou et sans reflets",
+    "button_close": "Fermer",
+    "button_primary_redo": "Recommencer",
+    "button_primary_upload": "Envoyer",
+    "button_primary_upload_anyway": "Envoyer quand même",
+    "button_secondary_redo": "Recommencer",
+    "button_zoom": "Agrandir l’image",
+    "image_accessibility": "Photo de votre document",
+    "title": "Vérifiez votre image"
+  },
+  "doc_multi_frame_capture": {
+    "capture_progress_title": "Scan en cours du document",
+    "instructions_title_back": "Positionnez le verso de votre document dans le cadre",
+    "instructions_title_front": "Positionnez le recto de votre document dans le cadre"
+  },
+  "doc_select": {
+    "button_bank_statement": "Relevé bancaire ou d'un organisme d'épargne",
+    "button_bank_statement_non_uk": "Relevé bancaire",
+    "button_benefits_letter": "Lettre des allocations",
+    "button_benefits_letter_detail": "Allocations autorisées par le gouvernement, par ex. allocation chômage, allocation logement, crédit d'impôt",
+    "button_bill": "Facture de gaz, électricité, etc.",
+    "button_bill_detail": "Gaz, électricité, eau, ligne fixe ou Internet",
+    "button_government_letter": "Lettre du gouvernement",
+    "button_government_letter_detail": "Toute lettre émise par le gouvernement, comme une lettre relative aux prestations, au vote ou la fiscalité, etc.",
+    "button_id": "Carte nationale d’identité",
+    "button_id_detail": "Recto et verso",
+    "button_license": "Permis de conduire",
+    "button_license_detail": "Recto et verso",
+    "button_passport": "Passeport",
+    "button_passport_detail": "Page de votre passeport contenant votre photo",
+    "button_permit": "Carte de séjour",
+    "button_permit_detail": "Recto et verso",
+    "button_tax_letter": "Lettre des impôts locaux",
+    "extra_estatements_ok": "relevés électroniques acceptés",
+    "extra_no_mobile": "Désolé, pas de factures de téléphone portable",
+    "list_accessibility": "Documents que vous pouvez utiliser pour vérifier votre identité",
+    "pill": "plus rapide",
+    "section": {
+      "header_country": "Pays émetteur",
+      "header_doc_type": "Documents acceptés",
+      "input_country_not_found": "Aucun résultat",
+      "input_placeholder_country": "Sélectionnez votre pays"
     },
-    "auth_progress": {
-        "loader": "Téléversement"
+    "subtitle": "Il doit s’agir d’une pièce d’identité officielle avec photo",
+    "subtitle_country": "Sélectionnez le pays émetteur pour voir quels documents nous acceptons",
+    "subtitle_entire_page": "Page entière",
+    "subtitle_front_back": "Avant et arrière",
+    "subtitle_photo_page": "Page de photos",
+    "subtitle_poa": "Voici les documents les plus susceptibles d'indiquer votre adresse de résidence actuelle",
+    "title": "Sélectionnez un document",
+    "title_poa": "Sélectionnez un document de %{country}"
+  },
+  "doc_submit": {
+    "button_link_upload": "ou envoyer une photo - pas de scans ou de photocopies",
+    "button_primary": "Continuez sur votre mobile",
+    "subtitle": "Prendre une photo avec votre téléphone",
+    "title_bank_statement": "Envoyer le relevé",
+    "title_benefits_letter": "Envoyer la lettre",
+    "title_bill": "Envoyer la facture",
+    "title_government_letter": "Lettre du gouvernement",
+    "title_id_back": "Envoyez votre carte d’identité (verso)",
+    "title_id_front": "Envoyer la carte d’identité (recto)",
+    "title_license_back": "Envoyer le permis (verso)",
+    "title_license_front": "Envoyer le permis (recto)",
+    "title_passport": "Envoyez la page du passeport contenant votre photo",
+    "title_permit_back": "Envoyer la carte de séjour (verso)",
+    "title_permit_front": "Envoyer la carte de séjour (recto)",
+    "title_tax_letter": "Envoyer la lettre"
+  },
+  "doc_video_capture": {
+    "button_primary_fallback": "Étape suivante",
+    "button_primary_fallback_end": "Terminer l’enregistrement",
+    "detail_step2": "Gardez le document visible à tout moment",
+    "header": "En tenant votre document, gardez son recto dans le cadre",
+    "header_paper_doc_step2": "Tournez lentement votre pièce d’identité pour montrer les pages extérieures",
+    "header_passport": "En tenant votre passeport, gardez la page de la photo dans le cadre",
+    "header_passport_progress": "Restez immobile",
+    "header_step1": "Patientez",
+    "header_step2": "Tournez lentement votre pièce d’identité pour montrer le verso",
+    "prompt": {
+      "detail_timeout": "L’enregistrement vidéo est limité à <timeout> </timeout> secondes. <fallback> Recommencez </fallback>"
     },
-    "auth_retry": {
-        "body_blur": "Nettoyez l’objectif de votre appareil photo",
-        "body_neutral_expression": "Gardez une expression neutre",
-        "body_too_bright": "Trouvez un environnement moins lumineux",
-        "button_primary": "Démarrer la caméra",
-        "subtitle": "Nous n’avons pas été en mesure de capturer votre visage correctement",
-        "title": "Scannez à nouveau votre visage"
+    "stepper": "Étape <step> </step> sur <total> </total>",
+    "success_accessibility": "Succès"
+  },
+  "doc_video_confirmation": {
+    "button_secondary": "Aperçu de la vidéo",
+    "title": "Veuillez vérifier votre vidéo"
+  },
+  "error_unsupported_browser": {
+    "subtitle_android": "Redémarrez le processus sur la dernière version de Google Chrome",
+    "subtitle_ios": "Redémarrer le processus sur la dernière version de Safari",
+    "title_android": "Navigateur non pris en charge",
+    "title_ios": "Navigateur non pris en charge"
+  },
+  "generic": {
+    "accessibility": {
+      "close_sdk_screen": "Fermer l’écran de vérification de l’identité",
+      "dismiss_alert": "Ignorer l’alerte"
     },
-    "auth_upload_pass": {
-        "body": "Téléversement réussi"
+    "back": "retour",
+    "close": "fermer",
+    "errors": {
+      "expired_token": {
+        "instruction": "Veuillez réessayer",
+        "message": "Votre jeton a expiré"
+      },
+      "geoblocked_error": {
+        "instruction": "Nous sommes désolés, il semble que nous ne puissions pas poursuivre car votre emplacement actuel n'est pas pris en charge",
+        "message": "Service indisponible"
+      },
+      "interrupted_flow_error": {
+        "instruction": "Redémarrez le processus sur un autre appareil",
+        "message": "Appareil photo non détecté"
+      },
+      "invalid_size": {
+        "instruction": "Doit être inférieur à 10MB.",
+        "message": "La taille du fichier a été dépassée."
+      },
+      "invalid_type": {
+        "instruction": "Essayez d’utiliser un autre type de fichier.",
+        "message": "Fichier non téléchargé."
+      },
+      "lazy_loading": {
+        "message": "Une erreur s’est produite lors du chargement du composant"
+      },
+      "multiple_faces": {
+        "instruction": "Votre visage doit être visible sur le selfie",
+        "message": "Plusieurs visages détectés"
+      },
+      "no_face": {
+        "instruction": "Assurez-vous que votre visage est visible",
+        "message": "Aucun visage détecté"
+      },
+      "request_error": {
+        "instruction": "Veuillez réessayer",
+        "message": "Quelque chose ne va pas"
+      },
+      "sms_failed": {
+        "instruction": "Copier le lien sur votre mobile",
+        "message": "Quelque chose ne va pas"
+      },
+      "sms_overuse": {
+        "instruction": "Copier le lien sur votre mobile",
+        "message": "Trop de tentatives infructueuses"
+      },
+      "unsupported_file": {
+        "instruction": "Essayez d’utiliser un fichier JPG ou PNG",
+        "message": "Type de fichier non pris en charge"
+      }
     },
-    "avc_confirmation": {
-        "button_primary_upload": "Téléverser l’enregistrement",
-        "subtitle": "Une vidéo de votre visage a bien été enregistrée",
-        "title": "Enregistrement terminé"
-    },
-    "avc_connection_error": {
-        "button_primary_reload": "Recharger les instructions",
-        "button_primary_retry_upload": "Réessayer de téléverser",
-        "button_secondary_restart_recording": "Redémarrer l’enregistrement",
-        "subtitle": "Vérifiez que votre connexion est stable, puis réessayez",
-        "title": "Erreur de connexion"
-    },
-    "avc_face_alignment": {
-        "feedback_move_back": "Reculez",
-        "feedback_move_closer": "Approchez-vous",
-        "feedback_no_face_detected": "Visage non détecté",
-        "feedback_not_centered": "Visage non centré",
-        "title": "Positionnez votre visage dans le cadre"
-    },
-    "avc_face_capture": {
-        "alert": {
-            "timeout_body": "Vous avez jusqu'à 15 secondes pour compléter votre enregistrement",
-            "timeout_button_primary": "Réessayer",
-            "timeout_title": "Désolé, nous devons redémarrer l'enregistrement",
-            "too_fast_body": "Veuillez réessayer et tournez votre tête plus lentement",
-            "too_fast_button_primary": "Réessayer",
-            "too_fast_title": "Vous avez tourné votre tête trop vite"
-        },
-        "title": "Tournez votre tête lentement des deux côtés",
-        "title_completed": "Enregistrement terminé"
-    },
-    "avc_intro": {
-        "button_primary_ready": "Je suis prêt(e)",
-        "disclaimer": "Sachez que nous enregistrerons votre visage et l'arrière-plan",
-        "list_item_one": "D'abord, positionnez votre visage dans le cadre",
-        "list_item_two": "Ensuite, tournez votre tête lentement des deux côtés",
-        "subtitle": "Ceci sert à vérifier que vous êtes une personne authentique",
-        "title": "Enregistrez une vidéo"
-    },
-    "avc_no_face_detected": {
-        "button_primary_restart": "Redémarrer l’enregistrement",
-        "list_item_eyes": "Assurez-vous que vos yeux sont clairement visibles",
-        "list_item_face": "Assurez-vous de ne montrer que votre visage, nous n'avons pas besoin de voir votre pièce d'identité",
-        "list_item_lighting": "Assurez-vous d'être à un endroit bien éclairé",
-        "list_item_mask": "Assurez-vous d'ôter le masque ou outres éléments qui couvrent votre visage. Les lunettes sont acceptées",
-        "title": "Nous ne pouvons pas détecter votre visage"
-    },
-    "avc_uploading": {
-        "title": "Téléversement"
-    },
-    "country_select": {
-        "alert": {
-            "another_doc": "Les documents de ce pays ne sont actuellement pas pris en charge — <fallback>essayez un autre type de document<\/fallback>"
-        },
-        "alert_dropdown": {
-            "country_not_found": "Pays introuvable"
-        },
-        "button_primary": "Envoyer le document",
-        "poa_alert": {
-            "country_not_found": "Nous sommes désolés. Nous travaillons à prendre en charge plus de pays.",
-            "intro": "Vous ne trouvez pas votre pays ?"
-        },
-        "search": {
-            "accessibility": "Choisissez le pays",
-            "input_placeholder": "ex : France",
-            "label": "Chercher un pays"
-        },
-        "title": "Sélectionnez votre pays"
-    },
-    "cross_device_checklist": {
-        "button_primary": "Envoyer la vérification",
-        "info": "Conseils",
-        "list_item_doc_multiple": "Documents envoyés",
-        "list_item_doc_one": "Document envoyé",
-        "list_item_poa": "Justificatif d'adresse",
-        "list_item_selfie": "Selfie envoyé",
-        "list_item_video": "Vidéo envoyée",
-        "subtitle": "Voici ce que vous avez téléversé :",
-        "title": "Dernière étape"
-    },
-    "cross_device_error_desktop": {
-        "subtitle": "Le lien ne fonctionne que sur les appareils mobiles",
-        "title": "Quelque chose ne va pas"
-    },
-    "cross_device_error_restart": {
-        "subtitle": "Vous devrez redémarrer votre vérification sur votre ordinateur",
-        "title": "Quelque chose ne va pas"
-    },
-    "cross_device_intro": {
-        "button_primary": "Obtenir un lien sécurisé",
-        "list_accessibility": "Étapes requises pour continuer la vérification sur votre mobile",
-        "list_item_finish": "Revenez ici pour finaliser l’envoi",
-        "list_item_open_link": "Ouvrez le lien et complétez les tâches",
-        "list_item_send_phone": "Envoyez un lien sécurisé vers votre téléphone",
-        "subtitle": "Voici comment faire :",
-        "title": "Continuez sur votre mobile"
-    },
-    "cross_device_return": {
-        "body": "Votre ordinateur peut prendre quelques secondes pour mettre à jour la page",
-        "subtitle": "Vous pouvez maintenant retourner sur votre ordinateur pour continuer",
-        "title": "Envois réussis"
-    },
-    "cross_device_session_linked": {
-        "button_primary": "Continuer",
-        "info": "Revérifier",
-        "list_item_desktop_open": "Votre fenêtre de bureau reste ouverte",
-        "list_item_sent_by_you": "Ce lien a été envoyé par vous. Demandez conseil si vous pensez qu’il s’agit d’une escroquerie.",
-        "subtitle": "Poursuivre la vérification",
-        "title": "Lié à votre ordinateur"
-    },
-    "doc_capture": {
-        "button_primary": "Démarrer le scan du document",
-        "detail": {
-            "folded_doc_front": "Dépliez votre document, prenez en photo les pages intérieures (qui contiennent votre photo)"
-        },
-        "header_folded_doc_front": "Côté contenant votre photo",
-        "prompt": {
-            "button_card": "Carte plastique",
-            "button_paper": "Document papier",
-            "title_id": "Quelle type de carte d’identité avez-vous ?",
-            "title_license": "Quel type de permis avez-vous ?"
-        }
-    },
-    "doc_confirmation": {
-        "alert": {
-            "blur_detail": "Assurez-vous que tout est bien net",
-            "blur_title": "L’image est floue",
-            "crop_detail": "Assurez-vous que l’intégralité du document est visible",
-            "crop_title": "Image tronquée détectée",
-            "glare_detail": "Éloignez-vous de la lumière directe",
-            "glare_title": "Attention aux reflets",
-            "no_doc_detail": "Assurez-vous que le document entier est sur la photo",
-            "no_doc_title": "Aucun document détecté"
-        },
-        "body": "Assurez-vous d'avoir téléversé la page entière du document et que les détails sont clairement lisibles, sans flou et sans reflets",
-        "body_bank_statement": "Assurez-vous d'avoir téléversé la page entière du document et que les détails sont clairement lisibles, sans flou et sans reflets",
-        "body_benefits_letter": "Assurez-vous d'avoir téléversé la page entière du document et que les détails sont clairement lisibles, sans flou et sans reflets",
-        "body_bill": "Assurez-vous d'avoir téléversé la page entière du document et que les détails sont clairement lisibles, sans flou et sans reflets",
-        "body_id": "Assurez-vous que vos coordonnées sont lisibles et nettes",
-        "body_image_medium": "Il faudra plus de temps pour vous vérifier si la lecture est impossible",
-        "body_image_poor": "Pour vous vérifier au mieux, nous avons besoin d’une meilleure photo",
-        "body_license": "Assurez-vous que vos coordonnées sont lisibles et nettes",
-        "body_passport": "Assurez-vous que vos coordonnées sont lisibles et nettes",
-        "body_permit": "Assurez-vous que vos coordonnées sont lisibles et nettes",
-        "body_tax_letter": "Assurez-vous d'avoir téléversé la page entière du document et que les détails sont clairement lisibles, sans flou et sans reflets",
-        "button_close": "Fermer",
-        "button_primary_redo": "Recommencer",
-        "button_primary_upload": "Envoyer",
-        "button_primary_upload_anyway": "Envoyer quand même",
-        "button_secondary_redo": "Recommencer",
-        "button_zoom": "Agrandir l’image",
-        "image_accessibility": "Photo de votre document",
-        "title": "Vérifiez votre image"
-    },
-    "doc_multi_frame_capture": {
-        "capture_progress_title": "Scan en cours du document",
-        "instructions_title_back": "Positionnez le verso de votre document dans le cadre",
-        "instructions_title_front": "Positionnez le recto de votre document dans le cadre"
-    },
-    "doc_select": {
-        "button_bank_statement": "Relevé bancaire ou d'un organisme d'épargne",
-        "button_bank_statement_non_uk": "Relevé bancaire",
-        "button_benefits_letter": "Lettre des allocations",
-        "button_benefits_letter_detail": "Allocations autorisées par le gouvernement, par ex. allocation chômage, allocation logement, crédit d'impôt",
-        "button_bill": "Facture de gaz, électricité, etc.",
-        "button_bill_detail": "Gaz, électricité, eau, ligne fixe ou Internet",
-        "button_government_letter": "Lettre du gouvernement",
-        "button_government_letter_detail": "Toute lettre émise par le gouvernement, comme une lettre relative aux prestations, au vote ou la fiscalité, etc.",
-        "button_id": "Carte nationale d’identité",
-        "button_id_detail": "Recto et verso",
-        "button_license": "Permis de conduire",
-        "button_license_detail": "Recto et verso",
-        "button_passport": "Passeport",
-        "button_passport_detail": "Page de votre passeport contenant votre photo",
-        "button_permit": "Carte de séjour",
-        "button_permit_detail": "Recto et verso",
-        "button_tax_letter": "Lettre des impôts locaux",
-        "extra_estatements_ok": "relevés électroniques acceptés",
-        "extra_no_mobile": "Désolé, pas de factures de téléphone portable",
-        "list_accessibility": "Documents que vous pouvez utiliser pour vérifier votre identité",
-        "pill": "plus rapide",
-        "section": {
-            "header_country": "Pays émetteur",
-            "header_doc_type": "Documents acceptés",
-            "input_country_not_found": "Aucun résultat",
-            "input_placeholder_country": "Sélectionnez votre pays"
-        },
-        "subtitle": "Il doit s’agir d’une pièce d’identité officielle avec photo",
-        "subtitle_country": "Sélectionnez le pays émetteur pour voir quels documents nous acceptons",
-        "subtitle_entire_page": "Page entière",
-        "subtitle_front_back": "Avant et arrière",
-        "subtitle_photo_page": "Page de photos",
-        "subtitle_poa": "Voici les documents les plus susceptibles d'indiquer votre adresse de résidence actuelle",
-        "title": "Sélectionnez un document",
-        "title_poa": "Sélectionnez un document de %{country}"
-    },
-    "doc_submit": {
-        "button_link_upload": "ou envoyer une photo - pas de scans ou de photocopies",
-        "button_primary": "Continuez sur votre mobile",
-        "subtitle": "Prendre une photo avec votre téléphone",
-        "title_bank_statement": "Envoyer le relevé",
-        "title_benefits_letter": "Envoyer la lettre",
-        "title_bill": "Envoyer la facture",
-        "title_government_letter": "Lettre du gouvernement",
-        "title_id_back": "Envoyez votre carte d’identité (verso)",
-        "title_id_front": "Envoyer la carte d’identité (recto)",
-        "title_license_back": "Envoyer le permis (verso)",
-        "title_license_front": "Envoyer le permis (recto)",
-        "title_passport": "Envoyez la page du passeport contenant votre photo",
-        "title_permit_back": "Envoyer la carte de séjour (verso)",
-        "title_permit_front": "Envoyer la carte de séjour (recto)",
-        "title_tax_letter": "Envoyer la lettre"
-    },
-    "doc_video_capture": {
-        "button_primary_fallback": "Étape suivante",
-        "button_primary_fallback_end": "Terminer l’enregistrement",
-        "detail_step2": "Gardez le document visible à tout moment",
-        "header": "En tenant votre document, gardez son recto dans le cadre",
-        "header_paper_doc_step2": "Tournez lentement votre pièce d’identité pour montrer les pages extérieures",
-        "header_passport": "En tenant votre passeport, gardez la page de la photo dans le cadre",
-        "header_passport_progress": "Restez immobile",
-        "header_step1": "Patientez",
-        "header_step2": "Tournez lentement votre pièce d’identité pour montrer le verso",
-        "prompt": {
-            "detail_timeout": "L’enregistrement vidéo est limité à <timeout> <\/timeout> secondes. <fallback> Recommencez <\/fallback>"
-        },
-        "stepper": "Étape <step> <\/step> sur <total> <\/total>",
-        "success_accessibility": "Succès"
-    },
-    "doc_video_confirmation": {
-        "button_secondary": "Aperçu de la vidéo",
-        "title": "Veuillez vérifier votre vidéo"
-    },
-    "error_unsupported_browser": {
-        "subtitle_android": "Redémarrez le processus sur la dernière version de Google Chrome",
-        "subtitle_ios": "Redémarrer le processus sur la dernière version de Safari",
-        "title_android": "Navigateur non pris en charge",
-        "title_ios": "Navigateur non pris en charge"
-    },
-    "generic": {
-        "accessibility": {
-            "close_sdk_screen": "Fermer l’écran de vérification de l’identité",
-            "dismiss_alert": "Ignorer l’alerte"
-        },
-        "back": "retour",
-        "close": "fermer",
-        "errors": {
-            "expired_token": {
-                "instruction": "Veuillez réessayer",
-                "message": "Votre jeton a expiré"
-            },
-            "geoblocked_error": {
-                "instruction": "Nous sommes désolés, il semble que nous ne puissions pas poursuivre car votre emplacement actuel n'est pas pris en charge",
-                "message": "Service indisponible"
-            },
-            "interrupted_flow_error": {
-                "instruction": "Redémarrez le processus sur un autre appareil",
-                "message": "Appareil photo non détecté"
-            },
-            "invalid_size": {
-                "instruction": "Doit être inférieur à 10MB.",
-                "message": "La taille du fichier a été dépassée."
-            },
-            "invalid_type": {
-                "instruction": "Essayez d’utiliser un autre type de fichier.",
-                "message": "Fichier non téléchargé."
-            },
-            "lazy_loading": {
-                "message": "Une erreur s’est produite lors du chargement du composant"
-            },
-            "multiple_faces": {
-                "instruction": "Votre visage doit être visible sur le selfie",
-                "message": "Plusieurs visages détectés"
-            },
-            "no_face": {
-                "instruction": "Assurez-vous que votre visage est visible",
-                "message": "Aucun visage détecté"
-            },
-            "request_error": {
-                "instruction": "Veuillez réessayer",
-                "message": "Quelque chose ne va pas"
-            },
-            "sms_failed": {
-                "instruction": "Copier le lien sur votre mobile",
-                "message": "Quelque chose ne va pas"
-            },
-            "sms_overuse": {
-                "instruction": "Copier le lien sur votre mobile",
-                "message": "Trop de tentatives infructueuses"
-            },
-            "unsupported_file": {
-                "instruction": "Essayez d’utiliser un fichier JPG ou PNG",
-                "message": "Type de fichier non pris en charge"
-            }
-        },
-        "lazy_load_placeholder": "Chargement...",
-        "loading": "Chargement"
-    },
-    "get_link": {
-        "alert_wrong_number": "Vérifiez que votre numéro est correct",
-        "button_copied": "Copié",
-        "button_copy": "Copier",
-        "button_submit": "Envoyer le lien",
-        "info_qr_how": "Comment scanner un QR code",
-        "info_qr_how_list_item_camera": "Pointez l’appareil photo de votre mobile sur le QR code",
-        "info_qr_how_list_item_download": "Si cela ne fonctionne pas, téléchargez un scanner de QR code sur Google Play ou l’App Store",
-        "link_divider": "ou choisissez l’une de ces alternatives",
-        "link_qr": "Scanner le QR code",
-        "link_sms": "Obtenir le lien par SMS",
-        "link_url": "Copier le lien",
-        "loader_sending": "Envoi en cours",
-        "number_field_input_placeholder": "Entrez votre numéro de mobile",
-        "number_field_label": "Entrez votre numéro de mobile",
-        "subtitle_qr": "Scannez le QR code avec votre mobile",
-        "subtitle_sms": "Ouvrez le lien sur votre mobile",
-        "subtitle_url": "Ouvrez le lien sur votre mobile",
-        "title": "Obtenez votre lien sécurisé",
-        "url_field_label": "Copier le lien sur votre mobile"
-    },
-    "livenessV2": {
-        "error_reload_instructions": "Recharger les instructions",
-        "intro_note_no1": "D'abord, positionnez votre visage dans le cadre",
-        "intro_note_no2": "Ensuite, tournez votre tête lentement des deux côtés",
-        "intro_ready_button": "Sachez que nous enregistrerons votre visage et l'arrière-plan",
-        "intro_subtitle": "Ceci sert à vérifier que vous êtes une personne authentique",
-        "intro_warning": "Sachez que nous enregistrerons votre visage et l'arrière-plan",
-        "success_main_button": "Envoyer la vérification",
-        "success_title": "C’est tout ce dont nous avons besoin pour commencer à vérifier votre identité"
-    },
-    "mobilePhrases": {
-        "photo_upload": {
-            "body_id_back": "Prenez une photo du verso de votre carte",
-            "body_id_front": "Prenez une photo du recto de votre carte",
-            "body_license_back": "Prenez une photo du verso de votre permis",
-            "body_license_front": "Prenez une photo du recto de votre permis",
-            "body_passport": "Prenez une photo de la page du passeport contenant votre photo",
-            "body_selfie": "Prenez un selfie"
-        },
-        "selfie_capture": {
-            "alert": {
-                "camera_inactive": {
-                    "detail": "Prenez une photo en utilisant le <fallback> mode appareil photo basique <\/fallback>"
-                },
-                "camera_not_working": {
-                    "detail": "Prenez une photo en utilisant le <fallback> mode appareil photo basique <\/fallback>"
-                }
-            }
-        },
-        "upload_guide": {
-            "button_primary": "Prendre une photo",
-            "title": "Page du passeport contenant votre photo"
-        }
-    },
-    "outro": {
-        "body": "C’est tout ce dont nous avons besoin pour commencer à vérifier votre identité",
-        "body_government_letter": "Fournissez la page entière du document pour de meilleurs résultats",
-        "title": "Merci"
-    },
-    "permission": {
-        "body_both": "Nous ne pouvons pas vous vérifier sans utiliser votre appareil photo et votre micro",
-        "body_cam": "Nous ne pouvons pas vous vérifier sans utiliser votre appareil photo",
-        "button_primary_both": "Activer les deux",
-        "button_primary_cam": "Activer l’appareil photo",
-        "subtitle_both": "Autorisez l’accès aux deux pour continuer",
-        "subtitle_cam": "Lorsque vous y serez invité, vous devez autoriser l’accès à l’appareil photo pour continuer",
-        "title_both": "Autoriser l’accès à l’appareil photo et au micro",
-        "title_cam": "Autoriser l’accès à l’appareil photo"
-    },
-    "permission_recovery": {
-        "button_primary": "Actualiser",
-        "info": "Récupération",
-        "list_header_both": "Suivez ces étapes pour autoriser l’accès à l'un et à l'autre :",
-        "list_header_cam": "Suivez ces étapes pour autoriser l’accès à l’appareil photo :",
-        "list_item_action_cam": "Actualisez cette page pour redémarrer la vérification d’identité",
-        "list_item_how_to_both": "Autorisez l’accès à l’appareil photo et au micro à partir des paramètres de votre navigateur",
-        "list_item_how_to_cam": "Autorisez l’accès à l’appareil photo à partir des paramètres de votre navigateur",
-        "subtitle_both": "Autorisez l’accès à l’appareil photo et au micro pour prendre une vidéo et compléter votre vérification d’identité",
-        "subtitle_cam": "Récupérez l’accès à l’appareil photo pour continuer la vérification",
-        "subtitle_cam_old": "Récupérez l’accès à l’appareil photo pour continuer la vérification",
-        "title_both": "L’accès à l’appareil photo et au micro n’est pas autorisé",
-        "title_cam": "L’accès à l’appareil photo n’est pas autorisé"
-    },
+    "lazy_load_placeholder": "Chargement...",
+    "loading": "Chargement"
+  },
+  "get_link": {
+    "alert_wrong_number": "Vérifiez que votre numéro est correct",
+    "button_copied": "Copié",
+    "button_copy": "Copier",
+    "button_submit": "Envoyer le lien",
+    "info_qr_how": "Comment scanner un QR code",
+    "info_qr_how_list_item_camera": "Pointez l’appareil photo de votre mobile sur le QR code",
+    "info_qr_how_list_item_download": "Si cela ne fonctionne pas, téléchargez un scanner de QR code sur Google Play ou l’App Store",
+    "link_divider": "ou choisissez l’une de ces alternatives",
+    "link_qr": "Scanner le QR code",
+    "link_sms": "Obtenir le lien par SMS",
+    "link_url": "Copier le lien",
+    "loader_sending": "Envoi en cours",
+    "number_field_input_placeholder": "Entrez votre numéro de mobile",
+    "number_field_label": "Entrez votre numéro de mobile",
+    "subtitle_qr": "Scannez le QR code avec votre mobile",
+    "subtitle_sms": "Ouvrez le lien sur votre mobile",
+    "subtitle_url": "Ouvrez le lien sur votre mobile",
+    "title": "Obtenez votre lien sécurisé",
+    "url_field_label": "Copier le lien sur votre mobile"
+  },
+  "livenessV2": {
+    "error_reload_instructions": "Recharger les instructions",
+    "intro_note_no1": "D'abord, positionnez votre visage dans le cadre",
+    "intro_note_no2": "Ensuite, tournez votre tête lentement des deux côtés",
+    "intro_ready_button": "Sachez que nous enregistrerons votre visage et l'arrière-plan",
+    "intro_subtitle": "Ceci sert à vérifier que vous êtes une personne authentique",
+    "intro_warning": "Sachez que nous enregistrerons votre visage et l'arrière-plan",
+    "success_main_button": "Envoyer la vérification",
+    "success_title": "C’est tout ce dont nous avons besoin pour commencer à vérifier votre identité"
+  },
+  "mobilePhrases": {
     "photo_upload": {
-        "body_bank_statement": "Fournissez la page entière du document pour de meilleurs résultats",
-        "body_benefits_letter": "Fournissez la page entière du document pour de meilleurs résultats",
-        "body_bill": "Fournissez la page entière du document pour de meilleurs résultats",
-        "body_id_back": "Envoyez votre carte depuis votre ordinateur",
-        "body_id_front": "Envoyez le recto de votre carte depuis votre ordinateur",
-        "body_license_back": "Envoyez le verso de votre permis depuis votre ordinateur",
-        "body_license_front": "Envoyez votre permis depuis votre ordinateur",
-        "body_passport": "Envoyez votre passeport depuis votre ordinateur",
-        "body_selfie": "Envoyez votre selfie depuis votre ordinateur",
-        "body_tax_letter": "Fournissez la page entière du document pour de meilleurs résultats",
-        "button_take_photo": "Prendre une photo",
-        "button_upload": "Envoyer",
-        "title_selfie": "Selfie"
-    },
-    "poa_cancel": "Annuler",
-    "poa_err_invalid_file": {
-        "message": "Veuillez choisir un autre fichier.",
-        "ok": "OK",
-        "title": "Fichier invalide"
-    },
-    "poa_guidance": {
-        "button_primary": "Continuer",
-        "instructions": {
-            "address": "Adresse actuelle",
-            "full_name": "Nom et prénom(s)",
-            "issue_date": "Date d'émission ou période du résumé",
-            "label": "Prenez en photo tout le document et assurez-vous qu'il indique clairement :",
-            "logo": "Logo"
-        },
-        "subtitle_bank_statement": "Doit avoir été émis au cours des <strong>3 derniers mois<\/strong>",
-        "subtitle_benefits_letter": "Doit avoir été émis au cours des <strong> 12 derniers mois<\/strong>",
-        "subtitle_bill": "Doit avoir été émis au cours des <strong>3 derniers mois<\/strong>",
-        "subtitle_tax_letter": "Doit avoir été émis au cours des <strong> 12 derniers mois<\/strong>"
-    },
-    "poa_intro": {
-        "button_primary": "Commencer la vérification",
-        "list_matches_signup": "<strong>Correspond<\/strong> à l'adresse que vous avez utilisée lors de l'inscription",
-        "list_most_recent": "Est votre document le plus <strong>récent<\/strong>",
-        "list_shows_address": "Indique votre adresse <strong>actuelle<\/strong>",
-        "subtitle": "Vous aurez besoin d'un document qui :",
-        "title": "Vérifions votre adresse"
-    },
-    "profile_data": {
-        "address_title": "Ajoutez votre adresse",
-        "button_continue": "Continuer",
-        "components": {
-            "country_select": {
-                "placeholder": "Sélectionnez un pays"
-            },
-            "nationality_select": {
-                "placeholder": "Sélectionnez un pays"
-            },
-            "pan": {
-                "placeholder": "ABCDE1234F"
-            },
-            "ssn": {
-                "placeholder": "123-45-6789"
-            },
-            "state_select": {
-                "placeholder": "Sélectionnez un État"
-            }
-        },
-        "country_of_residence_title": "Votre pays de résidence",
-        "field_labels": {
-            "country": "Pays",
-            "dob": "Date de naissance",
-            "email": "E-mail",
-            "first_name": "Prénom",
-            "gbr_specific": {
-                "postcode": "Code postal",
-                "town": "Ville"
-            },
-            "last_name": "Nom de famille",
-            "line1": "Adresse ligne 1",
-            "line2": "Adresse ligne 2",
-            "line3": "Adresse ligne 3",
-            "mobile_number": "Numéro de mobile",
-            "nationality": "Nationalité",
-            "pan": "Numéro de compte permanent (PAN)",
-            "postcode": "Code postal",
-            "ssn": "Numéro de sécurité sociale (SSN)",
-            "town": "Ville",
-            "usa_specific": {
-                "line1_helper_text": "Nom de la rue, par exemple : 200 rue Albert",
-                "line2_helper_text": "Appartement, suite, unité, etc.",
-                "postcode": "Zip code (États-Unis)",
-                "state": "État"
-            }
-        },
-        "field_optional": "(facultatif)",
-        "field_validation": {
-            "gbr_specific": {
-                "required_postcode": "Veuillez renseigner votre code postal",
-                "too_long_postcode": "Le code postal est trop long",
-                "too_short_postcode": "Le code postal est trop court"
-            },
-            "invalid": "Veuillez vérifier s'il y a des caractères ou des symboles invalides",
-            "invalid_dob": "Veuillez saisir une date de naissance valide",
-            "required_country": "Veuillez sélectionner un pays",
-            "required_dob": "Veuillez saisir votre date de naissance",
-            "required_email": "Veuillez renseigner votre adresse",
-            "required_first_name": "",
-            "required_last_name": "Veuillez renseigner votre nom de famille",
-            "required_line1": "Veuillez renseigner votre adresse",
-            "required_mobile_number": "Veuillez renseigner votre numéro de mobile",
-            "required_nationality": "Veuillez sélectionner un pays",
-            "required_pan": "Veuillez renseigner votre PAN",
-            "required_postcode": "Veuillez renseigner votre code postal",
-            "required_ssn": "Veuillez renseigner votre SSN",
-            "too_long__line1": "La ligne de l'adresse est trop longue",
-            "too_long_first_name": "Le prénom est trop long",
-            "too_long_last_name": "Le nom de famille est trop long",
-            "too_long_postcode": "Le code postal est trop long",
-            "too_long_town": "",
-            "too_short_first_name": "Le prénom est trop court",
-            "too_short_last_name": "Le nom de famille est trop court",
-            "too_short_postcode": "Le code postal est trop court",
-            "usa_specific": {
-                "required_state": "Veuillez sélectionner un État"
-            },
-            "valid_email": "Veuillez saisir un e-mail valide",
-            "valid_mobile_number": "Veuillez renseigner un numéro de mobile valide",
-            "valid_pan": "Veuillez saisir un PAN valide",
-            "valid_ssn": "Veuillez saisir un SSN valide"
-        },
-        "personal_information_title": "Ajoutez vos informations personnelles",
-        "prompt": {
-            "details_timeout": "Recommencer",
-            "header_timeout": "Apparemment vous avez mis trop longtemps"
-        }
-    },
-    "retry_feedback": {
-        "button_primary": "Réessayer"
-    },
-    "retry_feedback_id_expired": {
-        "subtitle": "Veuillez réessayer avec une pièce d'identité valide avec photo et en vous assurant que vos coordonnées sont bien visibles",
-        "title": "Votre document a expiré"
-    },
-    "retry_feedback_id_generic": {
-        "subtitle": "Veuillez réessayer avec une pièce d'identité valide avec photo et en vous assurant que vos coordonnées sont bien visibles",
-        "title": "Un problème est survenu avec votre document"
-    },
-    "retry_feedback_id_unaccepted": {
-        "subtitle": "Veuillez réessayer avec une pièce d'identité valide avec photo et en vous assurant que vos coordonnées sont bien visibles",
-        "title": "Document non accepté"
-    },
-    "retry_feedback_selfie_generic": {
-        "subtitle": "Veuillez réessayer en vous assurant que votre visage est visible et suffisamment éclairé",
-        "title": "Un problème est survenu avec votre selfie"
+      "body_id_back": "Prenez une photo du verso de votre carte",
+      "body_id_front": "Prenez une photo du recto de votre carte",
+      "body_license_back": "Prenez une photo du verso de votre permis",
+      "body_license_front": "Prenez une photo du recto de votre permis",
+      "body_passport": "Prenez une photo de la page du passeport contenant votre photo",
+      "body_selfie": "Prenez un selfie"
     },
     "selfie_capture": {
-        "alert": {
-            "camera_inactive": {
-                "detail": "Vérifiez qu’il est connecté et fonctionnel. Vous pouvez également <fallback> continuer la vérification sur votre mobile <\/fallback>",
-                "detail_no_fallback": "Assurez-vous que votre appareil est équipé d’un appareil photo en état de marche",
-                "title": "L’appareil photo ne fonctionne pas ?"
-            },
-            "camera_not_working": {
-                "detail": "Il peut être déconnecté.<fallback> Essayez d’utiliser votre mobile à la place <\/fallback>.",
-                "detail_no_fallback": "Assurez-vous que l’appareil photo de votre mobile fonctionne",
-                "title": "L’appareil photo ne fonctionne pas"
-            },
-            "timeout": {
-                "detail": "N’oubliez pas d’appuyer sur le bouton lorsque vous avez terminé. <fallback>Refaire la vidéo<\/fallback>",
-                "title": "Le temps est écoulé"
-            }
+      "alert": {
+        "camera_inactive": {
+          "detail": "Prenez une photo en utilisant le <fallback> mode appareil photo basique </fallback>"
         },
-        "body": "Gardez le visage dans le cercle",
-        "button_accessibility": "Prendre une photo",
-        "button_primary": "Démarrer le scan du visage",
-        "frame_accessibility": "Vue de la caméra",
-        "title": "Gardez le visage dans le cercle"
-    },
-    "selfie_confirmation": {
-        "image_accessibility": "Photo de votre visage",
-        "subtitle": "Assurez-vous que votre selfie montre clairement votre visage",
-        "title": "Vérifier votre selfie"
-    },
-    "selfie_intro": {
-        "button_primary": "Continuer",
-        "list_accessibility": "Conseils pour prendre un bon selfie",
-        "list_item_face_forward": "Regardez vers l’avant et assurez-vous que vos yeux sont bien visibles",
-        "list_item_no_glasses": "Retirez vos lunettes, si nécessaire",
-        "subtitle": "Nous allons le comparer avec votre document",
-        "title": "Prendre un selfie"
-    },
-    "sms_sent": {
-        "info": "Conseils",
-        "info_link_expire": "Votre lien expirera dans une heure",
-        "info_link_window": "Gardez cette fenêtre ouverte lorsque vous utilisez votre mobile",
-        "link": "Renvoyer le lien",
-        "subtitle": "Nous vous avons envoyé un lien sécurisé au numéro suivant : %{number}",
-        "subtitle_minutes": "Le délai de réception peut varier entre les différents opérateurs",
-        "title": "Vérifiez votre mobile"
-    },
-    "switch_phone": {
-        "info": "Conseils",
-        "info_link_expire": "Votre lien expirera dans une heure",
-        "info_link_refresh": "N’actualisez pas cette page",
-        "info_link_window": "Gardez cette fenêtre ouverte lorsque vous utilisez votre mobile",
-        "link": "Annuler",
-        "subtitle": "Une fois terminé, vous passerez à l’étape suivante",
-        "title": "Connecté à votre mobile"
+        "camera_not_working": {
+          "detail": "Prenez une photo en utilisant le <fallback> mode appareil photo basique </fallback>"
+        }
+      }
     },
     "upload_guide": {
-        "button_primary": "Envoyer une photo",
-        "image_detail_blur_alt": "Exemple de document flou",
-        "image_detail_blur_label": "Tous les détails doivent être clairs — rien ne doit être flou",
-        "image_detail_cutoff_label": "Afficher tous les détails — y compris les deux dernières lignes",
-        "image_detail_glare_label": "Éloignez-vous de la lumière directe — évitez les reflets",
-        "image_detail_good_label": "La photo doit montrer clairement votre document",
-        "subtitle": "Les scans et photocopies ne sont pas acceptés",
-        "title": "Envoyez la page du passeport contenant votre photo"
-    },
-    "user_consent": {
-        "button_primary": "Accept",
-        "button_secondary": "Do not accept",
-        "prompt": {
-            "button_primary": "Review again",
-            "button_secondary": "Yes, don’t verify me",
-            "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
-            "no_consent_title": "Are you sure?"
-        }
-    },
-    "user_consent_load_fail": {
-        "button_primary": "Reload screen",
-        "detail": "Check that your connection is stable, then try again",
-        "title": "Content failed to load"
-    },
-    "video_capture": {
-        "body": "Gardez le visage dans le cercle",
-        "body_record": "Appuyez sur le bouton lorsque vous êtes prêt(e)",
-        "body_stop": "Appuyez sur \"Stop\" quand vous avez fini",
-        "button_primary_finish": "Terminer l’enregistrement",
-        "button_primary_next": "Étape suivante",
-        "button_primary_start": "Démarrer l’enregistrement",
-        "button_record_accessibility": "Démarrer l’enregistrement",
-        "frame_accessibility": "Vue de la caméra",
-        "header": {
-            "challenge_digit_instructions": "Prononcez chaque chiffre à voix haute",
-            "challenge_turn_forward": "puis regardez l’écran à nouveau",
-            "challenge_turn_left": "Tournez votre visage vers la gauche",
-            "challenge_turn_right": "Tournez votre visage vers la droite"
-        },
-        "prompt": {
-            "header_timeout": "Le temps est écoulé"
-        }
-    },
-    "video_confirmation": {
-        "body": "Votre vidéo a été enregistrée",
-        "button_primary": "Envoyer la vidéo",
-        "button_secondary": "Reprendre une vidéo",
-        "title": "Veuillez vérifier votre vidéo",
-        "video_accessibility": "Rejouer la vidéo"
-    },
-    "video_intro": {
-        "button_primary": "Commencer l’enregistrement",
-        "list_accessibility": "Actions pour enregistrer une vidéo de votre visage",
-        "list_item_actions": "Vous avez 20 secondes pour terminer",
-        "list_item_speak": "Suivez les instructions pour bouger ou parler",
-        "title": "Enregistrez une vidéo de votre visage"
-    },
-    "welcome": {
-        "doc_video_subtitle": "Cela ne prendra que quelques minutes",
-        "list_header_doc_video": "Utilisez votre mobile pour enregistrer :",
-        "list_header_webcam": "Utilisez votre webcam ou mobile pour prendre en photo :",
-        "list_item_doc": "votre document d’identité",
-        "list_item_doc_video_timeout": "L’enregistrement est limité à <timeout><\/timeout> secondes",
-        "list_item_poa": "votre justificatif d'adresse",
-        "list_item_selfie": "votre visage",
-        "next_button": "Sélectionner un document",
-        "start_workflow_button": "Commencer la vérification",
-        "subtitle": "Cela ne prendra que quelques minutes",
-        "title": "Vérification d’identité"
-    },
-    "workflow_complete": {
-        "pass": {
-            "description": "",
-            "title": ""
-        },
-        "reject": {
-            "description": "",
-            "title": ""
-        }
-    },
-    "workflow_erros": {
-        "generic_title": "",
-        "no_workflow_run_id": "",
-        "reload_app": "",
-        "task_not_completed": "",
-        "task_not_retrieved": "",
-        "task_not_supported": ""
+      "button_primary": "Prendre une photo",
+      "title": "Page du passeport contenant votre photo"
     }
+  },
+  "outro": {
+    "body": "C’est tout ce dont nous avons besoin pour commencer à vérifier votre identité",
+    "body_government_letter": "Fournissez la page entière du document pour de meilleurs résultats",
+    "title": "Merci"
+  },
+  "permission": {
+    "body_both": "Nous ne pouvons pas vous vérifier sans utiliser votre appareil photo et votre micro",
+    "body_cam": "Nous ne pouvons pas vous vérifier sans utiliser votre appareil photo",
+    "button_primary_both": "Activer les deux",
+    "button_primary_cam": "Activer l’appareil photo",
+    "subtitle_both": "Autorisez l’accès aux deux pour continuer",
+    "subtitle_cam": "Lorsque vous y serez invité, vous devez autoriser l’accès à l’appareil photo pour continuer",
+    "title_both": "Autoriser l’accès à l’appareil photo et au micro",
+    "title_cam": "Autoriser l’accès à l’appareil photo"
+  },
+  "permission_recovery": {
+    "button_primary": "Actualiser",
+    "info": "Récupération",
+    "list_header_both": "Suivez ces étapes pour autoriser l’accès à l'un et à l'autre :",
+    "list_header_cam": "Suivez ces étapes pour autoriser l’accès à l’appareil photo :",
+    "list_item_action_cam": "Actualisez cette page pour redémarrer la vérification d’identité",
+    "list_item_how_to_both": "Autorisez l’accès à l’appareil photo et au micro à partir des paramètres de votre navigateur",
+    "list_item_how_to_cam": "Autorisez l’accès à l’appareil photo à partir des paramètres de votre navigateur",
+    "subtitle_both": "Autorisez l’accès à l’appareil photo et au micro pour prendre une vidéo et compléter votre vérification d’identité",
+    "subtitle_cam": "Récupérez l’accès à l’appareil photo pour continuer la vérification",
+    "subtitle_cam_old": "Récupérez l’accès à l’appareil photo pour continuer la vérification",
+    "title_both": "L’accès à l’appareil photo et au micro n’est pas autorisé",
+    "title_cam": "L’accès à l’appareil photo n’est pas autorisé"
+  },
+  "photo_upload": {
+    "body_bank_statement": "Fournissez la page entière du document pour de meilleurs résultats",
+    "body_benefits_letter": "Fournissez la page entière du document pour de meilleurs résultats",
+    "body_bill": "Fournissez la page entière du document pour de meilleurs résultats",
+    "body_id_back": "Envoyez votre carte depuis votre ordinateur",
+    "body_id_front": "Envoyez le recto de votre carte depuis votre ordinateur",
+    "body_license_back": "Envoyez le verso de votre permis depuis votre ordinateur",
+    "body_license_front": "Envoyez votre permis depuis votre ordinateur",
+    "body_passport": "Envoyez votre passeport depuis votre ordinateur",
+    "body_selfie": "Envoyez votre selfie depuis votre ordinateur",
+    "body_tax_letter": "Fournissez la page entière du document pour de meilleurs résultats",
+    "button_take_photo": "Prendre une photo",
+    "button_upload": "Envoyer",
+    "title_selfie": "Selfie"
+  },
+  "poa_cancel": "Annuler",
+  "poa_err_invalid_file": {
+    "message": "Veuillez choisir un autre fichier.",
+    "ok": "OK",
+    "title": "Fichier invalide"
+  },
+  "poa_guidance": {
+    "button_primary": "Continuer",
+    "instructions": {
+      "address": "Adresse actuelle",
+      "full_name": "Nom et prénom(s)",
+      "issue_date": "Date d'émission ou période du résumé",
+      "label": "Prenez en photo tout le document et assurez-vous qu'il indique clairement :",
+      "logo": "Logo"
+    },
+    "subtitle_bank_statement": "Doit avoir été émis au cours des <strong>3 derniers mois</strong>",
+    "subtitle_benefits_letter": "Doit avoir été émis au cours des <strong> 12 derniers mois</strong>",
+    "subtitle_bill": "Doit avoir été émis au cours des <strong>3 derniers mois</strong>",
+    "subtitle_tax_letter": "Doit avoir été émis au cours des <strong> 12 derniers mois</strong>"
+  },
+  "poa_intro": {
+    "button_primary": "Commencer la vérification",
+    "list_matches_signup": "<strong>Correspond</strong> à l'adresse que vous avez utilisée lors de l'inscription",
+    "list_most_recent": "Est votre document le plus <strong>récent</strong>",
+    "list_shows_address": "Indique votre adresse <strong>actuelle</strong>",
+    "subtitle": "Vous aurez besoin d'un document qui :",
+    "title": "Vérifions votre adresse"
+  },
+  "profile_data": {
+    "address_title": "Ajoutez votre adresse",
+    "button_continue": "Continuer",
+    "components": {
+      "country_select": {
+        "placeholder": "Sélectionnez un pays"
+      },
+      "nationality_select": {
+        "placeholder": "Sélectionnez un pays"
+      },
+      "pan": {
+        "placeholder": "ABCDE1234F"
+      },
+      "ssn": {
+        "placeholder": "123-45-6789"
+      },
+      "state_select": {
+        "placeholder": "Sélectionnez un État"
+      }
+    },
+    "country_of_residence_title": "Votre pays de résidence",
+    "field_labels": {
+      "country": "Pays",
+      "dob": "Date de naissance",
+      "email": "E-mail",
+      "first_name": "Prénom",
+      "gbr_specific": {
+        "postcode": "Code postal",
+        "town": "Ville"
+      },
+      "last_name": "Nom de famille",
+      "line1": "Adresse ligne 1",
+      "line2": "Adresse ligne 2",
+      "line3": "Adresse ligne 3",
+      "mobile_number": "Numéro de mobile",
+      "nationality": "Nationalité",
+      "pan": "Numéro de compte permanent (PAN)",
+      "postcode": "Code postal",
+      "ssn": "Numéro de sécurité sociale (SSN)",
+      "town": "Ville",
+      "usa_specific": {
+        "line1_helper_text": "Nom de la rue, par exemple : 200 rue Albert",
+        "line2_helper_text": "Appartement, suite, unité, etc.",
+        "postcode": "Zip code (États-Unis)",
+        "state": "État"
+      }
+    },
+    "field_optional": "(facultatif)",
+    "field_validation": {
+      "gbr_specific": {
+        "required_postcode": "Veuillez renseigner votre code postal",
+        "too_long_postcode": "Le code postal est trop long",
+        "too_short_postcode": "Le code postal est trop court"
+      },
+      "invalid": "Veuillez vérifier s'il y a des caractères ou des symboles invalides",
+      "invalid_dob": "Veuillez saisir une date de naissance valide",
+      "required_country": "Veuillez sélectionner un pays",
+      "required_dob": "Veuillez saisir votre date de naissance",
+      "required_email": "Veuillez renseigner votre adresse",
+      "required_first_name": "",
+      "required_last_name": "Veuillez renseigner votre nom de famille",
+      "required_line1": "Veuillez renseigner votre adresse",
+      "required_mobile_number": "Veuillez renseigner votre numéro de mobile",
+      "required_nationality": "Veuillez sélectionner un pays",
+      "required_pan": "Veuillez renseigner votre PAN",
+      "required_postcode": "Veuillez renseigner votre code postal",
+      "required_ssn": "Veuillez renseigner votre SSN",
+      "too_long__line1": "La ligne de l'adresse est trop longue",
+      "too_long_first_name": "Le prénom est trop long",
+      "too_long_last_name": "Le nom de famille est trop long",
+      "too_long_postcode": "Le code postal est trop long",
+      "too_long_town": "",
+      "too_short_first_name": "Le prénom est trop court",
+      "too_short_last_name": "Le nom de famille est trop court",
+      "too_short_postcode": "Le code postal est trop court",
+      "usa_specific": {
+        "required_state": "Veuillez sélectionner un État"
+      },
+      "valid_email": "Veuillez saisir un e-mail valide",
+      "valid_mobile_number": "Veuillez renseigner un numéro de mobile valide",
+      "valid_pan": "Veuillez saisir un PAN valide",
+      "valid_ssn": "Veuillez saisir un SSN valide"
+    },
+    "personal_information_title": "Ajoutez vos informations personnelles",
+    "prompt": {
+      "details_timeout": "Recommencer",
+      "header_timeout": "Apparemment vous avez mis trop longtemps"
+    }
+  },
+  "retry_feedback": {
+    "button_primary": "Réessayer"
+  },
+  "retry_feedback_id_expired": {
+    "subtitle": "Veuillez réessayer avec une pièce d'identité valide avec photo et en vous assurant que vos coordonnées sont bien visibles",
+    "title": "Votre document a expiré"
+  },
+  "retry_feedback_id_generic": {
+    "subtitle": "Veuillez réessayer avec une pièce d'identité valide avec photo et en vous assurant que vos coordonnées sont bien visibles",
+    "title": "Un problème est survenu avec votre document"
+  },
+  "retry_feedback_id_unaccepted": {
+    "subtitle": "Veuillez réessayer avec une pièce d'identité valide avec photo et en vous assurant que vos coordonnées sont bien visibles",
+    "title": "Document non accepté"
+  },
+  "retry_feedback_selfie_generic": {
+    "subtitle": "Veuillez réessayer en vous assurant que votre visage est visible et suffisamment éclairé",
+    "title": "Un problème est survenu avec votre selfie"
+  },
+  "selfie_capture": {
+    "alert": {
+      "camera_inactive": {
+        "detail": "Vérifiez qu’il est connecté et fonctionnel. Vous pouvez également <fallback> continuer la vérification sur votre mobile </fallback>",
+        "detail_no_fallback": "Assurez-vous que votre appareil est équipé d’un appareil photo en état de marche",
+        "title": "L’appareil photo ne fonctionne pas ?"
+      },
+      "camera_not_working": {
+        "detail": "Il peut être déconnecté.<fallback> Essayez d’utiliser votre mobile à la place </fallback>.",
+        "detail_no_fallback": "Assurez-vous que l’appareil photo de votre mobile fonctionne",
+        "title": "L’appareil photo ne fonctionne pas"
+      },
+      "timeout": {
+        "detail": "N’oubliez pas d’appuyer sur le bouton lorsque vous avez terminé. <fallback>Refaire la vidéo</fallback>",
+        "title": "Le temps est écoulé"
+      }
+    },
+    "body": "Gardez le visage dans le cercle",
+    "button_accessibility": "Prendre une photo",
+    "button_primary": "Démarrer le scan du visage",
+    "frame_accessibility": "Vue de la caméra",
+    "title": "Gardez le visage dans le cercle"
+  },
+  "selfie_confirmation": {
+    "image_accessibility": "Photo de votre visage",
+    "subtitle": "Assurez-vous que votre selfie montre clairement votre visage",
+    "title": "Vérifier votre selfie"
+  },
+  "selfie_intro": {
+    "button_primary": "Continuer",
+    "list_accessibility": "Conseils pour prendre un bon selfie",
+    "list_item_face_forward": "Regardez vers l’avant et assurez-vous que vos yeux sont bien visibles",
+    "list_item_no_glasses": "Retirez vos lunettes, si nécessaire",
+    "subtitle": "Nous allons le comparer avec votre document",
+    "title": "Prendre un selfie"
+  },
+  "sms_sent": {
+    "info": "Conseils",
+    "info_link_expire": "Votre lien expirera dans une heure",
+    "info_link_window": "Gardez cette fenêtre ouverte lorsque vous utilisez votre mobile",
+    "link": "Renvoyer le lien",
+    "subtitle": "Nous vous avons envoyé un lien sécurisé au numéro suivant : %{number}",
+    "subtitle_minutes": "Le délai de réception peut varier entre les différents opérateurs",
+    "title": "Vérifiez votre mobile"
+  },
+  "switch_phone": {
+    "info": "Conseils",
+    "info_link_expire": "Votre lien expirera dans une heure",
+    "info_link_refresh": "N’actualisez pas cette page",
+    "info_link_window": "Gardez cette fenêtre ouverte lorsque vous utilisez votre mobile",
+    "link": "Annuler",
+    "subtitle": "Une fois terminé, vous passerez à l’étape suivante",
+    "title": "Connecté à votre mobile"
+  },
+  "upload_guide": {
+    "button_primary": "Envoyer une photo",
+    "image_detail_blur_alt": "Exemple de document flou",
+    "image_detail_blur_label": "Tous les détails doivent être clairs — rien ne doit être flou",
+    "image_detail_cutoff_label": "Afficher tous les détails — y compris les deux dernières lignes",
+    "image_detail_glare_label": "Éloignez-vous de la lumière directe — évitez les reflets",
+    "image_detail_good_label": "La photo doit montrer clairement votre document",
+    "subtitle": "Les scans et photocopies ne sont pas acceptés",
+    "title": "Envoyez la page du passeport contenant votre photo"
+  },
+  "user_consent": {
+    "button_primary": "Accept",
+    "button_secondary": "Do not accept",
+    "prompt": {
+      "button_primary": "Review again",
+      "button_secondary": "Yes, don’t verify me",
+      "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
+      "no_consent_title": "Are you sure?"
+    }
+  },
+  "user_consent_load_fail": {
+    "button_primary": "Reload screen",
+    "detail": "Check that your connection is stable, then try again",
+    "title": "Content failed to load"
+  },
+  "video_capture": {
+    "body": "Gardez le visage dans le cercle",
+    "body_record": "Appuyez sur le bouton lorsque vous êtes prêt(e)",
+    "body_stop": "Appuyez sur \"Stop\" quand vous avez fini",
+    "button_primary_finish": "Terminer l’enregistrement",
+    "button_primary_next": "Étape suivante",
+    "button_primary_start": "Démarrer l’enregistrement",
+    "button_record_accessibility": "Démarrer l’enregistrement",
+    "frame_accessibility": "Vue de la caméra",
+    "header": {
+      "challenge_digit_instructions": "Prononcez chaque chiffre à voix haute",
+      "challenge_turn_forward": "puis regardez l’écran à nouveau",
+      "challenge_turn_left": "Tournez votre visage vers la gauche",
+      "challenge_turn_right": "Tournez votre visage vers la droite"
+    },
+    "prompt": {
+      "header_timeout": "Le temps est écoulé"
+    }
+  },
+  "video_confirmation": {
+    "body": "Votre vidéo a été enregistrée",
+    "button_primary": "Envoyer la vidéo",
+    "button_secondary": "Reprendre une vidéo",
+    "title": "Veuillez vérifier votre vidéo",
+    "video_accessibility": "Rejouer la vidéo"
+  },
+  "video_intro": {
+    "button_primary": "Commencer l’enregistrement",
+    "list_accessibility": "Actions pour enregistrer une vidéo de votre visage",
+    "list_item_actions": "Vous avez 20 secondes pour terminer",
+    "list_item_speak": "Suivez les instructions pour bouger ou parler",
+    "title": "Enregistrez une vidéo de votre visage"
+  },
+  "welcome": {
+    "doc_video_subtitle": "Cela ne prendra que quelques minutes",
+    "list_header_doc_video": "Utilisez votre mobile pour enregistrer :",
+    "list_header_webcam": "Utilisez votre webcam ou mobile pour prendre en photo :",
+    "list_item_doc": "votre document d’identité",
+    "list_item_doc_video_timeout": "L’enregistrement est limité à <timeout></timeout> secondes",
+    "list_item_poa": "votre justificatif d'adresse",
+    "list_item_selfie": "votre visage",
+    "next_button": "Sélectionner un document",
+    "start_workflow_button": "Commencer la vérification",
+    "subtitle": "Cela ne prendra que quelques minutes",
+    "title": "Vérification d’identité"
+  },
+  "workflow_complete": {
+    "pass": {
+      "description": "",
+      "title": ""
+    },
+    "reject": {
+      "description": "",
+      "title": ""
+    }
+  },
+  "workflow_erros": {
+    "generic_title": "",
+    "no_workflow_run_id": "",
+    "reload_app": "",
+    "task_not_completed": "",
+    "task_not_retrieved": "",
+    "task_not_supported": ""
+  }
 }

--- a/src/locales/it_IT/it_IT.json
+++ b/src/locales/it_IT/it_IT.json
@@ -1,678 +1,678 @@
 {
-    "avc_confirmation": {
-        "button_primary_upload": "Carica registrazione",
-        "subtitle": "Un video del tuo viso è stato registrato con successo",
-        "title": "Registrazione completata"
+  "avc_confirmation": {
+    "button_primary_upload": "Carica registrazione",
+    "subtitle": "Un video del tuo viso è stato registrato con successo",
+    "title": "Registrazione completata"
+  },
+  "avc_connection_error": {
+    "button_primary_reload": "Ricarica le istruzioni",
+    "button_primary_retry_upload": "Ritenta il caricamento",
+    "button_secondary_restart_recording": "Riavvia la registrazione",
+    "subtitle": "Verifica che la tua connessione sia stabile e riprova",
+    "title": "Errore di connessione"
+  },
+  "avc_face_alignment": {
+    "feedback_move_back": "Allontanati",
+    "feedback_move_closer": "Avvicinati",
+    "feedback_no_face_detected": "Viso non rilevato",
+    "feedback_not_centered": "Viso non centrato",
+    "title": "Posiziona il viso nel riquadro"
+  },
+  "avc_face_capture": {
+    "alert": {
+      "timeout_body": "Hai fino a 15 secondi per completare la registrazione",
+      "timeout_button_primary": "Riprova",
+      "timeout_title": "Purtroppo è necessario riavviare la registrazione",
+      "too_fast_body": "Riprova girando la testa più lentamente",
+      "too_fast_button_primary": "Riprova",
+      "too_fast_title": "Hai girato la testa troppo rapidamente"
     },
-    "avc_connection_error": {
-        "button_primary_reload": "Ricarica le istruzioni",
-        "button_primary_retry_upload": "Ritenta il caricamento",
-        "button_secondary_restart_recording": "Riavvia la registrazione",
-        "subtitle": "Verifica che la tua connessione sia stabile e riprova",
-        "title": "Errore di connessione"
+    "title": "Gira lentamente la testa da entrambe le parti",
+    "title_completed": "Registrazione completata"
+  },
+  "avc_intro": {
+    "button_primary_ready": "È tutto pronto",
+    "disclaimer": "Ricorda che registreremo il tuo viso e lo sfondo",
+    "list_item_one": "Innanzitutto, posiziona il viso nel riquadro",
+    "list_item_two": "Poi, gira lentamente la testa da entrambe le parti",
+    "subtitle": "Questo serve a verificare che tu sia una persona reale",
+    "title": "Registra un video"
+  },
+  "avc_no_face_detected": {
+    "button_primary_restart": "Riavvia la registrazione",
+    "list_item_eyes": "Assicurati che i tuoi occhi siano ben visibili",
+    "list_item_face": "Assicurati di mostrare solo il tuo viso. Non ci serve vedere il documento.",
+    "list_item_lighting": "Assicurati di essere in un ambiente ben illuminato",
+    "list_item_mask": "Assicurati di rimuovere la mascherina o altri oggetti che coprono il viso. Puoi tenere gli occhiali da vista.",
+    "title": "Non riusciamo a rilevare il tuo viso"
+  },
+  "avc_uploading": {
+    "title": "Caricamento"
+  },
+  "country_select": {
+    "alert": {
+      "another_doc": "I documenti di questo paese non sono supportati al momento. <fallback>Prova con un altro tipo di documento</fallback>"
     },
-    "avc_face_alignment": {
-        "feedback_move_back": "Allontanati",
-        "feedback_move_closer": "Avvicinati",
-        "feedback_no_face_detected": "Viso non rilevato",
-        "feedback_not_centered": "Viso non centrato",
-        "title": "Posiziona il viso nel riquadro"
+    "alert_dropdown": {
+      "country_not_found": "Paese non trovato"
     },
-    "avc_face_capture": {
-        "alert": {
-            "timeout_body": "Hai fino a 15 secondi per completare la registrazione",
-            "timeout_button_primary": "Riprova",
-            "timeout_title": "Purtroppo è necessario riavviare la registrazione",
-            "too_fast_body": "Riprova girando la testa più lentamente",
-            "too_fast_button_primary": "Riprova",
-            "too_fast_title": "Hai girato la testa troppo rapidamente"
-        },
-        "title": "Gira lentamente la testa da entrambe le parti",
-        "title_completed": "Registrazione completata"
+    "button_primary": "Invia documento",
+    "poa_alert": {
+      "country_not_found": "Siamo spiacenti. Stiamo lavorando per supportare più Paesi.",
+      "intro": "Non trovi il tuo Paese?"
     },
-    "avc_intro": {
-        "button_primary_ready": "È tutto pronto",
-        "disclaimer": "Ricorda che registreremo il tuo viso e lo sfondo",
-        "list_item_one": "Innanzitutto, posiziona il viso nel riquadro",
-        "list_item_two": "Poi, gira lentamente la testa da entrambe le parti",
-        "subtitle": "Questo serve a verificare che tu sia una persona reale",
-        "title": "Registra un video"
+    "search": {
+      "accessibility": "Seleziona paese",
+      "input_placeholder": "es. Italia",
+      "label": "Cerca paese"
     },
-    "avc_no_face_detected": {
-        "button_primary_restart": "Riavvia la registrazione",
-        "list_item_eyes": "Assicurati che i tuoi occhi siano ben visibili",
-        "list_item_face": "Assicurati di mostrare solo il tuo viso. Non ci serve vedere il documento.",
-        "list_item_lighting": "Assicurati di essere in un ambiente ben illuminato",
-        "list_item_mask": "Assicurati di rimuovere la mascherina o altri oggetti che coprono il viso. Puoi tenere gli occhiali da vista.",
-        "title": "Non riusciamo a rilevare il tuo viso"
+    "title": "Seleziona il paese di emissione"
+  },
+  "cross_device_checklist": {
+    "button_primary": "Invia verifica",
+    "info": "Consigli",
+    "list_item_doc_multiple": "Documenti",
+    "list_item_doc_one": "Documento",
+    "list_item_poa": "Prova dell'indirizzo",
+    "list_item_selfie": "Selfie",
+    "list_item_video": "Video",
+    "subtitle": "Ecco tutto quello che hai caricato:",
+    "title": "Ultimo passaggio"
+  },
+  "cross_device_error_desktop": {
+    "subtitle": "Il link funziona solo sui dispositivi mobili",
+    "title": "Si è verificato un errore"
+  },
+  "cross_device_error_restart": {
+    "subtitle": "Dovrai riavviare il processo di verifica sul tuo computer",
+    "title": "Si è verificato un errore"
+  },
+  "cross_device_intro": {
+    "button_primary": "Ricevi link sicuro",
+    "list_accessibility": "Passaggi necessari per continuare la verifica sul tuo telefono",
+    "list_item_finish": "Torna qui per completare l’invio",
+    "list_item_open_link": "Apri il link e completa i passaggi",
+    "list_item_send_phone": "Invia un link sicuro al tuo telefono",
+    "subtitle": "Ecco come fare:",
+    "title": "Continua sul tuo telefono"
+  },
+  "cross_device_return": {
+    "body": "Il computer potrebbe richieder qualche secondo per mostrare le informazioni aggiornate",
+    "subtitle": "Ora puoi tornare al tuo computer per continuare",
+    "title": "Caricamenti riusciti"
+  },
+  "cross_device_session_linked": {
+    "button_primary": "Continua",
+    "info": "Assicurati di",
+    "list_item_desktop_open": "Tenere aperta la finestra del browser",
+    "list_item_sent_by_you": "Aver inviato tu il link — Cerca assistenza se pensi si possa trattare di una truffa",
+    "subtitle": "Continua la verifica",
+    "title": "Connesso al computer"
+  },
+  "doc_capture": {
+    "button_primary": "Inizia a scansionare il documento",
+    "detail": {
+      "folded_doc_front": "Appoggia il documento aperto sulle pagine interne (deve contenere la tua foto)"
     },
-    "avc_uploading": {
-        "title": "Caricamento"
+    "header_folded_doc_front": "Lato foto profilo",
+    "prompt": {
+      "button_card": "Card plastificata",
+      "button_paper": "Documento cartaceo",
+      "title_id": "Che tipo di carta d’identità hai?",
+      "title_license": "Che tipo di patente hai?"
+    }
+  },
+  "doc_confirmation": {
+    "alert": {
+      "blur_detail": "Assicurati che tutto sia nitido",
+      "blur_title": "Sfocatura rilevata",
+      "crop_detail": "Assicurati che tutto il documento sia visibile",
+      "crop_title": "Immagine tagliata rilevata",
+      "glare_detail": "Allontanati dalla luce diretta",
+      "glare_title": "Riflesso rilevato",
+      "no_doc_detail": "Assicurati che sia ben inquadrato",
+      "no_doc_title": "Documento non rilevato"
     },
-    "country_select": {
-        "alert": {
-            "another_doc": "I documenti di questo paese non sono supportati al momento. <fallback>Prova con un altro tipo di documento<\/fallback>"
-        },
-        "alert_dropdown": {
-            "country_not_found": "Paese non trovato"
-        },
-        "button_primary": "Invia documento",
-        "poa_alert": {
-            "country_not_found": "Siamo spiacenti. Stiamo lavorando per supportare più Paesi.",
-            "intro": "Non trovi il tuo Paese?"
-        },
-        "search": {
-            "accessibility": "Seleziona paese",
-            "input_placeholder": "es. Italia",
-            "label": "Cerca paese"
-        },
-        "title": "Seleziona il paese di emissione"
+    "body": "Assicurati di aver caricato l'intera pagina del documento e che i dati siano chiari e leggibili, senza sfocature o riflessi",
+    "body_bank_statement": "Assicurati di aver caricato l'intera pagina del documento e che i dati siano chiari e leggibili, senza sfocature o riflessi",
+    "body_benefits_letter": "Assicurati di aver caricato l'intera pagina del documento e che i dati siano chiari e leggibili, senza sfocature o riflessi",
+    "body_bill": "Assicurati di aver caricato l'intera pagina del documento e che i dati siano chiari e leggibili, senza sfocature o riflessi",
+    "body_id": "Assicurati che i tuoi dati siano nitidi e non coperti",
+    "body_image_medium": "La verifica richiederà più tempo se non riusciremo a leggere i dati",
+    "body_image_poor": "Per completare rapidamente la verifica ci serve una foto migliore",
+    "body_license": "Assicurati che i tuoi dati siano nitidi e non coperti",
+    "body_passport": "Assicurati che i tuoi dati siano nitidi e non coperti",
+    "body_permit": "Assicurati che i tuoi dati siano nitidi e non coperti",
+    "body_tax_letter": "Assicurati di aver caricato l'intera pagina del documento e che i dati siano chiari e leggibili, senza sfocature o riflessi",
+    "button_close": "Chiudi",
+    "button_primary_redo": "Ripeti",
+    "button_primary_upload": "Carica",
+    "button_primary_upload_anyway": "Carica comunque",
+    "button_secondary_redo": "Ripeti",
+    "button_zoom": "Ingrandisci l’immagine",
+    "image_accessibility": "Foto del tuo documento",
+    "title": "Controlla l’immagine"
+  },
+  "doc_multi_frame_capture": {
+    "capture_progress_title": "Scansione documento",
+    "instructions_title_back": "Posizionare il retro del documento nel riquadro",
+    "instructions_title_front": "Posizionare il fronte del documento nel riquadro"
+  },
+  "doc_select": {
+    "button_bank_statement": "Estratto conto della banca o istituto di credito",
+    "button_bank_statement_non_uk": "Estratto conto della banca",
+    "button_benefits_letter": "Lettera sulle prestazioni previdenziali",
+    "button_benefits_letter_detail": "Prestazioni previdenziali autorizzate dal governo, come sussidio di disoccupazione, indennità di alloggio o credito d'imposta",
+    "button_bill": "Bolletta",
+    "button_bill_detail": "Gas, elettricità, acqua, telefono fisso o Internet",
+    "button_government_letter": "Lettera del governo",
+    "button_government_letter_detail": "Qualsiasi lettera emessa dal governo, es. lettere sulle prestazioni previdenziali, lettere di voto, lettere sulle imposte ecc.",
+    "button_id": "Carta d’identità",
+    "button_id_detail": "Fronte e retro",
+    "button_license": "Patente di guida",
+    "button_license_detail": "Fronte e retro",
+    "button_passport": "Passaporto",
+    "button_passport_detail": "Pagina della foto",
+    "button_permit": "Permesso di soggiorno",
+    "button_permit_detail": "Fronte e retro",
+    "button_tax_letter": "Lettera sull'imposta locale",
+    "extra_estatements_ok": "sono accettati gli estratti conto elettronici",
+    "extra_no_mobile": "Non sono ammesse le bollette di telefonia mobile",
+    "list_accessibility": "Documenti che puoi utilizzare per verificare la tua identità",
+    "pill": "più veloce",
+    "section": {
+      "header_country": "Paese emittente",
+      "header_doc_type": "Documenti accettati",
+      "input_country_not_found": "Nessun risultato",
+      "input_placeholder_country": "Seleziona il paese di emissione"
     },
-    "cross_device_checklist": {
-        "button_primary": "Invia verifica",
-        "info": "Consigli",
-        "list_item_doc_multiple": "Documenti",
-        "list_item_doc_one": "Documento",
-        "list_item_poa": "Prova dell'indirizzo",
-        "list_item_selfie": "Selfie",
-        "list_item_video": "Video",
-        "subtitle": "Ecco tutto quello che hai caricato:",
-        "title": "Ultimo passaggio"
+    "subtitle": "Deve essere un documento d’identità ufficiale con foto",
+    "subtitle_country": "Seleziona il paese di emissione per vedere quali documenti accettiamo",
+    "subtitle_entire_page": "Intera pagina",
+    "subtitle_front_back": "Davanti e dietro",
+    "subtitle_photo_page": "Pagina delle foto",
+    "subtitle_poa": "Questi sono i documenti che più probabilmente mostrano il tuo indirizzo attuale",
+    "title": "Seleziona il tuo documento",
+    "title_poa": "Seleziona un documento %{country}"
+  },
+  "doc_submit": {
+    "button_link_upload": "o carica foto (no scansioni o fotocopie)",
+    "button_primary": "Continua sul telefono",
+    "subtitle": "Scatta una foto con il tuo telefono",
+    "title_bank_statement": "Invia estratto conto",
+    "title_benefits_letter": "Invia lettera",
+    "title_bill": "Invia bolletta",
+    "title_government_letter": "Lettera del governo",
+    "title_id_back": "Invia carta d’identità (retro)",
+    "title_id_front": "Invia carta d’identità (fronte)",
+    "title_license_back": "Invia patente (retro)",
+    "title_license_front": "Invia patente (fronte)",
+    "title_passport": "Invia la pagina con foto del passaporto",
+    "title_permit_back": "Invia permesso di soggiorno (retro)",
+    "title_permit_front": "Invia permesso di soggiorno (fronte)",
+    "title_tax_letter": "Invia lettera"
+  },
+  "doc_video_capture": {
+    "button_primary_fallback": "Avanti",
+    "button_primary_fallback_end": "Termina registrazione",
+    "detail_step2": "Fai in modo che il documento resti sempre visibile",
+    "header": "Tieni in mano il documento con il lato frontale nella cornice",
+    "header_paper_doc_step2": "Gira lentamente il documento per mostrare le pagine esterne",
+    "header_passport": "Tieni in mano il passaporto con la pagina della foto nella cornice",
+    "header_passport_progress": "Resta immobile",
+    "header_step1": "Ora resta immobile",
+    "header_step2": "Gira lentamente il documento per mostrare il retro",
+    "prompt": {
+      "detail_timeout": "La registrazione video ha un limite di <timeout></timeout> secondi. <fallback>Ricomincia</fallback>"
     },
-    "cross_device_error_desktop": {
-        "subtitle": "Il link funziona solo sui dispositivi mobili",
-        "title": "Si è verificato un errore"
+    "stepper": "Passaggio <step></step> di <total></total>",
+    "success_accessibility": "Riuscito"
+  },
+  "doc_video_confirmation": {
+    "button_secondary": "Anteprima video",
+    "title": "Controlla il video"
+  },
+  "error_unsupported_browser": {
+    "subtitle_android": "Riavvia il processo nell’ultima versione di Google Chrome",
+    "subtitle_ios": "Riavvia il processo nell’ultima versione di Safari",
+    "title_android": "Browser non supportato",
+    "title_ios": "Browser non supportato"
+  },
+  "generic": {
+    "accessibility": {
+      "close_sdk_screen": "Chiudi la schermata di verifica dell’identità",
+      "dismiss_alert": "Ignora avviso"
     },
-    "cross_device_error_restart": {
-        "subtitle": "Dovrai riavviare il processo di verifica sul tuo computer",
-        "title": "Si è verificato un errore"
+    "back": "indietro",
+    "close": "chiudi",
+    "errors": {
+      "expired_token": {
+        "instruction": "Riprova",
+        "message": "Il tuo token è scaduto"
+      },
+      "geoblocked_error": {
+        "instruction": "Siamo spiacenti. Sembra che non sia possibile procedere oltre perché la posizione attuale non è supportata",
+        "message": "Servizio non disponibile"
+      },
+      "interrupted_flow_error": {
+        "instruction": "Riavvia il processo su un altro dispositivo",
+        "message": "Fotocamera non rilevata"
+      },
+      "invalid_size": {
+        "instruction": "Deve essere sotto i 10MB.",
+        "message": "Dimensione file superata."
+      },
+      "invalid_type": {
+        "instruction": "Prova a utilizzare un altro tipo di file.",
+        "message": "File non caricato."
+      },
+      "lazy_loading": {
+        "message": "Si è verificato un errore nel caricamento del componente"
+      },
+      "multiple_faces": {
+        "instruction": "Il selfie deve contenere solo il tuo viso",
+        "message": "Più visi rilevati"
+      },
+      "no_face": {
+        "instruction": "Assicurati che il viso sia visibile",
+        "message": "Viso non rilevato"
+      },
+      "request_error": {
+        "instruction": "Riprova",
+        "message": "Si è verificato un errore"
+      },
+      "sms_failed": {
+        "instruction": "Copia il link nel tuo telefono",
+        "message": "Si è verificato un errore"
+      },
+      "sms_overuse": {
+        "instruction": "Copia il link nel tuo telefono",
+        "message": "Troppi tentativi non riusciti"
+      },
+      "unsupported_file": {
+        "instruction": "Prova con un file JPG o PNG",
+        "message": "Tipo di file non supportato"
+      }
     },
-    "cross_device_intro": {
-        "button_primary": "Ricevi link sicuro",
-        "list_accessibility": "Passaggi necessari per continuare la verifica sul tuo telefono",
-        "list_item_finish": "Torna qui per completare l’invio",
-        "list_item_open_link": "Apri il link e completa i passaggi",
-        "list_item_send_phone": "Invia un link sicuro al tuo telefono",
-        "subtitle": "Ecco come fare:",
-        "title": "Continua sul tuo telefono"
-    },
-    "cross_device_return": {
-        "body": "Il computer potrebbe richieder qualche secondo per mostrare le informazioni aggiornate",
-        "subtitle": "Ora puoi tornare al tuo computer per continuare",
-        "title": "Caricamenti riusciti"
-    },
-    "cross_device_session_linked": {
-        "button_primary": "Continua",
-        "info": "Assicurati di",
-        "list_item_desktop_open": "Tenere aperta la finestra del browser",
-        "list_item_sent_by_you": "Aver inviato tu il link — Cerca assistenza se pensi si possa trattare di una truffa",
-        "subtitle": "Continua la verifica",
-        "title": "Connesso al computer"
-    },
-    "doc_capture": {
-        "button_primary": "Inizia a scansionare il documento",
-        "detail": {
-            "folded_doc_front": "Appoggia il documento aperto sulle pagine interne (deve contenere la tua foto)"
-        },
-        "header_folded_doc_front": "Lato foto profilo",
-        "prompt": {
-            "button_card": "Card plastificata",
-            "button_paper": "Documento cartaceo",
-            "title_id": "Che tipo di carta d’identità hai?",
-            "title_license": "Che tipo di patente hai?"
-        }
-    },
-    "doc_confirmation": {
-        "alert": {
-            "blur_detail": "Assicurati che tutto sia nitido",
-            "blur_title": "Sfocatura rilevata",
-            "crop_detail": "Assicurati che tutto il documento sia visibile",
-            "crop_title": "Immagine tagliata rilevata",
-            "glare_detail": "Allontanati dalla luce diretta",
-            "glare_title": "Riflesso rilevato",
-            "no_doc_detail": "Assicurati che sia ben inquadrato",
-            "no_doc_title": "Documento non rilevato"
-        },
-        "body": "Assicurati di aver caricato l'intera pagina del documento e che i dati siano chiari e leggibili, senza sfocature o riflessi",
-        "body_bank_statement": "Assicurati di aver caricato l'intera pagina del documento e che i dati siano chiari e leggibili, senza sfocature o riflessi",
-        "body_benefits_letter": "Assicurati di aver caricato l'intera pagina del documento e che i dati siano chiari e leggibili, senza sfocature o riflessi",
-        "body_bill": "Assicurati di aver caricato l'intera pagina del documento e che i dati siano chiari e leggibili, senza sfocature o riflessi",
-        "body_id": "Assicurati che i tuoi dati siano nitidi e non coperti",
-        "body_image_medium": "La verifica richiederà più tempo se non riusciremo a leggere i dati",
-        "body_image_poor": "Per completare rapidamente la verifica ci serve una foto migliore",
-        "body_license": "Assicurati che i tuoi dati siano nitidi e non coperti",
-        "body_passport": "Assicurati che i tuoi dati siano nitidi e non coperti",
-        "body_permit": "Assicurati che i tuoi dati siano nitidi e non coperti",
-        "body_tax_letter": "Assicurati di aver caricato l'intera pagina del documento e che i dati siano chiari e leggibili, senza sfocature o riflessi",
-        "button_close": "Chiudi",
-        "button_primary_redo": "Ripeti",
-        "button_primary_upload": "Carica",
-        "button_primary_upload_anyway": "Carica comunque",
-        "button_secondary_redo": "Ripeti",
-        "button_zoom": "Ingrandisci l’immagine",
-        "image_accessibility": "Foto del tuo documento",
-        "title": "Controlla l’immagine"
-    },
-    "doc_multi_frame_capture": {
-        "capture_progress_title": "Scansione documento",
-        "instructions_title_back": "Posizionare il retro del documento nel riquadro",
-        "instructions_title_front": "Posizionare il fronte del documento nel riquadro"
-    },
-    "doc_select": {
-        "button_bank_statement": "Estratto conto della banca o istituto di credito",
-        "button_bank_statement_non_uk": "Estratto conto della banca",
-        "button_benefits_letter": "Lettera sulle prestazioni previdenziali",
-        "button_benefits_letter_detail": "Prestazioni previdenziali autorizzate dal governo, come sussidio di disoccupazione, indennità di alloggio o credito d'imposta",
-        "button_bill": "Bolletta",
-        "button_bill_detail": "Gas, elettricità, acqua, telefono fisso o Internet",
-        "button_government_letter": "Lettera del governo",
-        "button_government_letter_detail": "Qualsiasi lettera emessa dal governo, es. lettere sulle prestazioni previdenziali, lettere di voto, lettere sulle imposte ecc.",
-        "button_id": "Carta d’identità",
-        "button_id_detail": "Fronte e retro",
-        "button_license": "Patente di guida",
-        "button_license_detail": "Fronte e retro",
-        "button_passport": "Passaporto",
-        "button_passport_detail": "Pagina della foto",
-        "button_permit": "Permesso di soggiorno",
-        "button_permit_detail": "Fronte e retro",
-        "button_tax_letter": "Lettera sull'imposta locale",
-        "extra_estatements_ok": "sono accettati gli estratti conto elettronici",
-        "extra_no_mobile": "Non sono ammesse le bollette di telefonia mobile",
-        "list_accessibility": "Documenti che puoi utilizzare per verificare la tua identità",
-        "pill": "più veloce",
-        "section": {
-            "header_country": "Paese emittente",
-            "header_doc_type": "Documenti accettati",
-            "input_country_not_found": "Nessun risultato",
-            "input_placeholder_country": "Seleziona il paese di emissione"
-        },
-        "subtitle": "Deve essere un documento d’identità ufficiale con foto",
-        "subtitle_country": "Seleziona il paese di emissione per vedere quali documenti accettiamo",
-        "subtitle_entire_page": "Intera pagina",
-        "subtitle_front_back": "Davanti e dietro",
-        "subtitle_photo_page": "Pagina delle foto",
-        "subtitle_poa": "Questi sono i documenti che più probabilmente mostrano il tuo indirizzo attuale",
-        "title": "Seleziona il tuo documento",
-        "title_poa": "Seleziona un documento %{country}"
-    },
-    "doc_submit": {
-        "button_link_upload": "o carica foto (no scansioni o fotocopie)",
-        "button_primary": "Continua sul telefono",
-        "subtitle": "Scatta una foto con il tuo telefono",
-        "title_bank_statement": "Invia estratto conto",
-        "title_benefits_letter": "Invia lettera",
-        "title_bill": "Invia bolletta",
-        "title_government_letter": "Lettera del governo",
-        "title_id_back": "Invia carta d’identità (retro)",
-        "title_id_front": "Invia carta d’identità (fronte)",
-        "title_license_back": "Invia patente (retro)",
-        "title_license_front": "Invia patente (fronte)",
-        "title_passport": "Invia la pagina con foto del passaporto",
-        "title_permit_back": "Invia permesso di soggiorno (retro)",
-        "title_permit_front": "Invia permesso di soggiorno (fronte)",
-        "title_tax_letter": "Invia lettera"
-    },
-    "doc_video_capture": {
-        "button_primary_fallback": "Avanti",
-        "button_primary_fallback_end": "Termina registrazione",
-        "detail_step2": "Fai in modo che il documento resti sempre visibile",
-        "header": "Tieni in mano il documento con il lato frontale nella cornice",
-        "header_paper_doc_step2": "Gira lentamente il documento per mostrare le pagine esterne",
-        "header_passport": "Tieni in mano il passaporto con la pagina della foto nella cornice",
-        "header_passport_progress": "Resta immobile",
-        "header_step1": "Ora resta immobile",
-        "header_step2": "Gira lentamente il documento per mostrare il retro",
-        "prompt": {
-            "detail_timeout": "La registrazione video ha un limite di <timeout><\/timeout> secondi. <fallback>Ricomincia<\/fallback>"
-        },
-        "stepper": "Passaggio <step><\/step> di <total><\/total>",
-        "success_accessibility": "Riuscito"
-    },
-    "doc_video_confirmation": {
-        "button_secondary": "Anteprima video",
-        "title": "Controlla il video"
-    },
-    "error_unsupported_browser": {
-        "subtitle_android": "Riavvia il processo nell’ultima versione di Google Chrome",
-        "subtitle_ios": "Riavvia il processo nell’ultima versione di Safari",
-        "title_android": "Browser non supportato",
-        "title_ios": "Browser non supportato"
-    },
-    "generic": {
-        "accessibility": {
-            "close_sdk_screen": "Chiudi la schermata di verifica dell’identità",
-            "dismiss_alert": "Ignora avviso"
-        },
-        "back": "indietro",
-        "close": "chiudi",
-        "errors": {
-            "expired_token": {
-                "instruction": "Riprova",
-                "message": "Il tuo token è scaduto"
-            },
-            "geoblocked_error": {
-                "instruction": "Siamo spiacenti. Sembra che non sia possibile procedere oltre perché la posizione attuale non è supportata",
-                "message": "Servizio non disponibile"
-            },
-            "interrupted_flow_error": {
-                "instruction": "Riavvia il processo su un altro dispositivo",
-                "message": "Fotocamera non rilevata"
-            },
-            "invalid_size": {
-                "instruction": "Deve essere sotto i 10MB.",
-                "message": "Dimensione file superata."
-            },
-            "invalid_type": {
-                "instruction": "Prova a utilizzare un altro tipo di file.",
-                "message": "File non caricato."
-            },
-            "lazy_loading": {
-                "message": "Si è verificato un errore nel caricamento del componente"
-            },
-            "multiple_faces": {
-                "instruction": "Il selfie deve contenere solo il tuo viso",
-                "message": "Più visi rilevati"
-            },
-            "no_face": {
-                "instruction": "Assicurati che il viso sia visibile",
-                "message": "Viso non rilevato"
-            },
-            "request_error": {
-                "instruction": "Riprova",
-                "message": "Si è verificato un errore"
-            },
-            "sms_failed": {
-                "instruction": "Copia il link nel tuo telefono",
-                "message": "Si è verificato un errore"
-            },
-            "sms_overuse": {
-                "instruction": "Copia il link nel tuo telefono",
-                "message": "Troppi tentativi non riusciti"
-            },
-            "unsupported_file": {
-                "instruction": "Prova con un file JPG o PNG",
-                "message": "Tipo di file non supportato"
-            }
-        },
-        "lazy_load_placeholder": "Caricamento...",
-        "loading": "Caricamento in corso"
-    },
-    "get_link": {
-        "alert_wrong_number": "Controlla che il tuo numero sia corretto",
-        "button_copied": "Copiato",
-        "button_copy": "Copia",
-        "button_submit": "Invia link",
-        "info_qr_how": "Come scansionare un QR code",
-        "info_qr_how_list_item_camera": "Inquadra il QR code con la fotocamera del telefono",
-        "info_qr_how_list_item_download": "Se non funziona, scarica un’app per la scansione di QR code da Google Play o App Store",
-        "link_divider": "o scegli un metodo alternativo",
-        "link_qr": "Scansiona QR code",
-        "link_sms": "Ricevi link via SMS",
-        "link_url": "Copia link",
-        "loader_sending": "Invio in corso",
-        "number_field_input_placeholder": "Inserisci numero di telefono",
-        "number_field_label": "Inserisci il tuo numero di telefono:",
-        "subtitle_qr": "Scansiona il QR code con il tuo telefono",
-        "subtitle_sms": "Invia questo link monouso al tuo telefono",
-        "subtitle_url": "Invia questo link monouso al tuo telefono",
-        "title": "Ricevi il tuo link sicuro",
-        "url_field_label": "Copia il link nel browser del telefono"
-    },
-    "livenessV2": {
-        "error_reload_instructions": "Ricarica le istruzioni",
-        "intro_note_no1": "Innanzitutto, posiziona il viso nel riquadro",
-        "intro_note_no2": "Poi, gira lentamente la testa da entrambe le parti",
-        "intro_ready_button": "Ricorda che registreremo il tuo viso e lo sfondo",
-        "intro_subtitle": "Questo serve a verificare che tu sia una persona reale",
-        "intro_warning": "Ricorda che registreremo il tuo viso e lo sfondo",
-        "success_main_button": "Invia verifica",
-        "success_title": "Ora abbiamo tutto quello che ci serve per iniziare a verificare la tua identità"
-    },
-    "mobilePhrases": {
-        "photo_upload": {
-            "body_id_back": "Scatta una foto del retro della tua carta",
-            "body_id_front": "Scatta una foto del fronte della tua carta",
-            "body_license_back": "Scatta una foto del retro della tua patente",
-            "body_license_front": "Scatta una foto del fronte della tua patente",
-            "body_passport": "Scatta una foto del fronte della pagina con foto del tuo passaporto",
-            "body_selfie": "Scatta un selfie del tuo viso"
-        },
-        "selfie_capture": {
-            "alert": {
-                "camera_inactive": {
-                    "detail": "Oppure scatta una foto con la <fallback>modalità fotocamera base<\/fallback>"
-                },
-                "camera_not_working": {
-                    "detail": "Oppure scatta una foto con la <fallback>modalità fotocamera base<\/fallback>"
-                }
-            }
-        },
-        "upload_guide": {
-            "button_primary": "Scatta una foto",
-            "title": "Pagina con foto del passaporto"
-        }
-    },
-    "outro": {
-        "body": "Ora abbiamo tutto quello che ci serve per iniziare a verificare la tua identità",
-        "body_government_letter": "Invia l’intera pagina del documento per un risultato ottimale",
-        "title": "Grazie"
-    },
-    "permission": {
-        "body_both": "Impossibile verificare la tua identità senza usare sia la fotocamera che il microfono",
-        "body_cam": "Impossibile verificare la tua identità senza la fotocamera",
-        "button_primary_both": "Abilita entrambi",
-        "button_primary_cam": "Abilita la fotocamera",
-        "subtitle_both": "Per continuare è necessario abilitare l’accesso a entrambi quando richiesto",
-        "subtitle_cam": "Per continuare è necessario abilitare l’accesso alla fotocamera quando richiesto",
-        "title_both": "Consenti l’accesso alla fotocamera e al microfono",
-        "title_cam": "Consenti l’accesso alla fotocamera"
-    },
-    "permission_recovery": {
-        "button_primary": "Ricarica",
-        "info": "Ripristino",
-        "list_header_both": "Segui questi passaggi per ripristinare l’accesso alla entrambi:",
-        "list_header_cam": "Segui questi passaggi per ripristinare l’accesso alla fotocamera:",
-        "list_item_action_cam": "Ricarica la pagina per riavviare il processo di verifica dell’identità",
-        "list_item_how_to_both": "Consenti l’accesso alla fotocamera e al microfono dalle impostazioni del browser",
-        "list_item_how_to_cam": "Consenti l’accesso alla fotocamera dalle impostazioni del browser",
-        "subtitle_both": "Ripristina l’accesso alla fotocamera e al microfono per registrare un video e completare il processo di verifica",
-        "subtitle_cam": "Ripristina l’accesso alla fotocamera per continuare la verifica",
-        "subtitle_cam_old": "Ripristina l’accesso alla fotocamera per continuare il processo di verifica",
-        "title_both": "Accesso alla fotocamera e al microfono negato",
-        "title_cam": "Accesso alla fotocamera negato"
-    },
+    "lazy_load_placeholder": "Caricamento...",
+    "loading": "Caricamento in corso"
+  },
+  "get_link": {
+    "alert_wrong_number": "Controlla che il tuo numero sia corretto",
+    "button_copied": "Copiato",
+    "button_copy": "Copia",
+    "button_submit": "Invia link",
+    "info_qr_how": "Come scansionare un QR code",
+    "info_qr_how_list_item_camera": "Inquadra il QR code con la fotocamera del telefono",
+    "info_qr_how_list_item_download": "Se non funziona, scarica un’app per la scansione di QR code da Google Play o App Store",
+    "link_divider": "o scegli un metodo alternativo",
+    "link_qr": "Scansiona QR code",
+    "link_sms": "Ricevi link via SMS",
+    "link_url": "Copia link",
+    "loader_sending": "Invio in corso",
+    "number_field_input_placeholder": "Inserisci numero di telefono",
+    "number_field_label": "Inserisci il tuo numero di telefono:",
+    "subtitle_qr": "Scansiona il QR code con il tuo telefono",
+    "subtitle_sms": "Invia questo link monouso al tuo telefono",
+    "subtitle_url": "Invia questo link monouso al tuo telefono",
+    "title": "Ricevi il tuo link sicuro",
+    "url_field_label": "Copia il link nel browser del telefono"
+  },
+  "livenessV2": {
+    "error_reload_instructions": "Ricarica le istruzioni",
+    "intro_note_no1": "Innanzitutto, posiziona il viso nel riquadro",
+    "intro_note_no2": "Poi, gira lentamente la testa da entrambe le parti",
+    "intro_ready_button": "Ricorda che registreremo il tuo viso e lo sfondo",
+    "intro_subtitle": "Questo serve a verificare che tu sia una persona reale",
+    "intro_warning": "Ricorda che registreremo il tuo viso e lo sfondo",
+    "success_main_button": "Invia verifica",
+    "success_title": "Ora abbiamo tutto quello che ci serve per iniziare a verificare la tua identità"
+  },
+  "mobilePhrases": {
     "photo_upload": {
-        "body_bank_statement": "Invia l'intera pagina del documento per un risultato ottimale",
-        "body_benefits_letter": "Invia l'intera pagina del documento per un risultato ottimale",
-        "body_bill": "Invia l'intera pagina del documento per un risultato ottimale",
-        "body_id_back": "Carica il retro della carta d’identità dal tuo computer",
-        "body_id_front": "Carica il fronte della carta d’identità dal tuo computer",
-        "body_license_back": "Carica il retro della patente dal tuo computer",
-        "body_license_front": "Carica il fronte della patente dal tuo computer",
-        "body_passport": "Carica la pagina con foto del passaporto dal tuo computer",
-        "body_selfie": "Carica un selfie dal tuo computer",
-        "body_tax_letter": "Invia l'intera pagina del documento per un risultato ottimale",
-        "button_take_photo": "Scatta foto",
-        "button_upload": "Carica",
-        "title_selfie": "Selfie"
-    },
-    "poa_cancel": "Annulla",
-    "poa_err_invalid_file": {
-        "message": "Seleziona un altro file.",
-        "ok": "OK",
-        "title": "File non valido"
-    },
-    "poa_guidance": {
-        "button_primary": "Continua",
-        "instructions": {
-            "address": "Indirizzo attuale",
-            "full_name": "Nome e cognome",
-            "issue_date": "Data di emissione o periodo di riepilogo",
-            "label": "Riporta l'intero documento assicurandoti che mostri chiaramente:",
-            "logo": "Logo"
-        },
-        "subtitle_bank_statement": "Deve essere stato emesso negli <strong>ultimi 3 mesi<\/strong>",
-        "subtitle_benefits_letter": "Deve essere stata emessa negli <strong>ultimi 12 mesi<\/strong>",
-        "subtitle_bill": "Deve essere stato emesso negli <strong>ultimi 3 mesi<\/strong>",
-        "subtitle_tax_letter": "Deve essere stata emessa negli <strong>ultimi 12 mesi<\/strong>"
-    },
-    "poa_intro": {
-        "button_primary": "Inizia la verifica",
-        "list_matches_signup": "<strong>Corrisponde<\/strong> all'indirizzo utilizzato per la registrazione",
-        "list_most_recent": "È il tuo documento più <strong>recente<\/strong>",
-        "list_shows_address": "Mostra il tuo indirizzo <strong>attuale<\/strong>",
-        "subtitle": "Ti servirà un documento che:",
-        "title": "Verifichiamo il tuo indirizzo"
-    },
-    "profile_data": {
-        "address_title": "Aggiungere l’indirizzo",
-        "button_continue": "Continua",
-        "components": {
-            "country_select": {
-                "placeholder": "Selezionare un paese"
-            },
-            "nationality_select": {
-                "placeholder": "Seleziona un Paese"
-            },
-            "pan": {
-                "placeholder": "ABCDE1234F"
-            },
-            "ssn": {
-                "placeholder": "123-45-6789"
-            },
-            "state_select": {
-                "placeholder": "Selezionare uno stato"
-            }
-        },
-        "country_of_residence_title": "Il tuo paese di residenza",
-        "field_labels": {
-            "country": "Paese",
-            "dob": "Data di nascita",
-            "email": "Email",
-            "first_name": "Nome",
-            "gbr_specific": {
-                "postcode": "Codice postale",
-                "town": "Città\/comune"
-            },
-            "last_name": "Cognome",
-            "line1": "Indirizzo 1",
-            "line2": "Indirizzo 2",
-            "line3": "Indirizzo 3",
-            "mobile_number": "Numero di cellulare",
-            "nationality": "Nazionalità",
-            "pan": "Numero di conto permanente (PAN)",
-            "postcode": "Codice postale",
-            "ssn": "Numero di previdenza sociale (SSN)",
-            "town": "Comune",
-            "usa_specific": {
-                "line1_helper_text": "Indirizzo, ad esempio 200 Albert Street",
-                "line2_helper_text": "Appartamento, suite, unità ecc.",
-                "postcode": "Zip code",
-                "state": "Stato"
-            }
-        },
-        "field_optional": "(facoltativo)",
-        "field_validation": {
-            "gbr_specific": {
-                "required_postcode": "Inserire il codice postale",
-                "too_long_postcode": "Il codice postale è troppo lungo",
-                "too_short_postcode": "Il codice postale è troppo breve"
-            },
-            "invalid": "Verificare che non ci siano simboli o caratteri non validi",
-            "invalid_dob": "Inserire una data di nascita valida",
-            "required_country": "Selezionare un paese",
-            "required_dob": "Inserire la data di nascita",
-            "required_email": "Inserisci la tua email",
-            "required_first_name": "",
-            "required_last_name": "Inserire il cognome",
-            "required_line1": "Inserire l’indirizzo",
-            "required_mobile_number": "Inserisci il tuo numero di cellulare",
-            "required_nationality": "Seleziona un Paese",
-            "required_pan": "Inserisci il tuo PAN",
-            "required_postcode": "Inserire il codice postale",
-            "required_ssn": "Inserisci il tuo SSN",
-            "too_long__line1": "L’indirizzo è troppo lungo",
-            "too_long_first_name": "Il nome è troppo lungo",
-            "too_long_last_name": "Il cognome è troppo lungo",
-            "too_long_postcode": "Il codice postale è troppo lungo",
-            "too_long_town": "",
-            "too_short_first_name": "Il nome è troppo breve",
-            "too_short_last_name": "Il cognome è troppo breve",
-            "too_short_postcode": "Il codice postale è troppo breve",
-            "usa_specific": {
-                "required_state": "Selezionare uno stato"
-            },
-            "valid_email": "Inserisci un’email valida",
-            "valid_mobile_number": "Inserisci un numero di telefono valido",
-            "valid_pan": "Inserisci un PAN valido",
-            "valid_ssn": "Inserisci un SSN valido"
-        },
-        "personal_information_title": "Aggiungere i dati personali",
-        "prompt": {
-            "details_timeout": "Ricomincia",
-            "header_timeout": "Sembra che ci sia voluto troppo tempo"
-        }
-    },
-    "retry_feedback": {
-        "button_primary": "Riprova"
-    },
-    "retry_feedback_id_expired": {
-        "subtitle": "Riprova con un documento d’identità valido e assicurati chele informazioni siano ben leggibili",
-        "title": "Il documento è scaduto"
-    },
-    "retry_feedback_id_generic": {
-        "subtitle": "Riprova con un documento d’identità valido e assicurati che le informazioni siano ben leggibili",
-        "title": "Si è verificato un problema con il tuo documento"
-    },
-    "retry_feedback_id_unaccepted": {
-        "subtitle": "Riprova con un documento d’identità valido e assicurati che le informazioni siano ben leggibili",
-        "title": "Documento non accettato"
-    },
-    "retry_feedback_selfie_generic": {
-        "subtitle": "Riprova e assicurati che il volto sia visibile e ben illuminato",
-        "title": "Si è verificato un problema con il selfie"
+      "body_id_back": "Scatta una foto del retro della tua carta",
+      "body_id_front": "Scatta una foto del fronte della tua carta",
+      "body_license_back": "Scatta una foto del retro della tua patente",
+      "body_license_front": "Scatta una foto del fronte della tua patente",
+      "body_passport": "Scatta una foto del fronte della pagina con foto del tuo passaporto",
+      "body_selfie": "Scatta un selfie del tuo viso"
     },
     "selfie_capture": {
-        "alert": {
-            "camera_inactive": {
-                "detail": "Controlla che sia collegata e funzionante. In alternativa puoi <fallback>continuare la verifica dal tuo telefono<\/fallback>.",
-                "detail_no_fallback": "Assicurati che il dispositivo abbia una fotocamera funzionante",
-                "title": "La fotocamera non funziona?"
-            },
-            "camera_not_working": {
-                "detail": "Potrebbe non essere collegata. <fallback>Prova a utilizzare il telefono<\/fallback>.",
-                "detail_no_fallback": "Assicurati che la fotocamera del dispositivo sia funzionante",
-                "title": "Fotocamera non funzionante"
-            },
-            "timeout": {
-                "detail": "Ricorda di premere il pulsante quando hai finito. <fallback>Ripeti le azioni del video<\/fallback>",
-                "title": "Sembra che ci sia voluto troppo tempo"
-            }
+      "alert": {
+        "camera_inactive": {
+          "detail": "Oppure scatta una foto con la <fallback>modalità fotocamera base</fallback>"
         },
-        "body": "Tieni il viso nell’ovale",
-        "button_accessibility": "Scatta una foto",
-        "button_primary": "Inizia a scansionare il viso",
-        "frame_accessibility": "Vista dalla fotocamera",
-        "title": "Tieni il viso nell’ovale"
-    },
-    "selfie_confirmation": {
-        "image_accessibility": "Foto del tuo viso",
-        "subtitle": "Assicurati che il viso sia visibile per intero",
-        "title": "Controlla il selfie"
-    },
-    "selfie_intro": {
-        "button_primary": "Continua",
-        "list_accessibility": "Consigli per un buon selfie",
-        "list_item_face_forward": "Guarda in avanti e assicurati che gli occhi siano ben visibili",
-        "list_item_no_glasses": "Togliti gli occhiali, se necessario",
-        "subtitle": "Lo confronteremo con il tuo documento",
-        "title": "Scatta un selfie"
-    },
-    "sms_sent": {
-        "info": "Consigli",
-        "info_link_expire": "Il tuo link scadrà tra un’ora",
-        "info_link_window": "Tieni aperta questa finestra mentre usi il telefono",
-        "link": "Invia nuovo link",
-        "subtitle": "Abbiamo inviato un link sicuro a %{number}",
-        "subtitle_minutes": "La ricezione potrebbe richiedere qualche minuto",
-        "title": "Controlla il telefono"
-    },
-    "switch_phone": {
-        "info": "Consigli",
-        "info_link_expire": "Il link inviato al tuo telefono scadrà tra un’ora",
-        "info_link_refresh": "Non ricaricare la pagina",
-        "info_link_window": "Tieni aperta questa finestra mentre usi il telefono",
-        "link": "Annulla",
-        "subtitle": "Quando avrai terminato ti porteremo al passaggio successivo",
-        "title": "Collegato al tuo telefono"
+        "camera_not_working": {
+          "detail": "Oppure scatta una foto con la <fallback>modalità fotocamera base</fallback>"
+        }
+      }
     },
     "upload_guide": {
-        "button_primary": "Carica foto",
-        "image_detail_blur_alt": "Esempio di un documento sfocato",
-        "image_detail_blur_label": "Tutti i dettagli devono essere nitidi, senza sfocature",
-        "image_detail_cutoff_label": "Mostra tutti i dettagli, incluse le 2 righe inferiori",
-        "image_detail_glare_label": "Allontanati dalla luce diretta per evitare riflessi",
-        "image_detail_good_label": "La foto deve mostrare chiaramente il tuo documento",
-        "subtitle": "Non sono ammesse scansioni e fotocopie",
-        "title": "Invia la pagina con foto del passaporto"
-    },
-    "user_consent": {
-        "button_primary": "Accept",
-        "button_secondary": "Do not accept",
-        "prompt": {
-            "button_primary": "Review again",
-            "button_secondary": "Yes, don’t verify me",
-            "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
-            "no_consent_title": "Are you sure?"
-        }
-    },
-    "user_consent_load_fail": {
-        "button_primary": "Reload screen",
-        "detail": "Check that your connection is stable, then try again",
-        "title": "Content failed to load"
-    },
-    "video_capture": {
-        "body": "Tieni il viso nell’ovale",
-        "body_record": "Quando è tutto pronto, premi il pulsante",
-        "body_stop": "Premi \"stop\" quando hai finito",
-        "button_primary_finish": "Termina registrazione",
-        "button_primary_next": "Avanti",
-        "button_primary_start": "Inizia a registrare",
-        "button_record_accessibility": "Inizia a registrare",
-        "frame_accessibility": "Vista dalla fotocamera",
-        "header": {
-            "challenge_digit_instructions": "Pronuncia ciascun numero ad alta voce",
-            "challenge_turn_forward": "poi guarda in avanti",
-            "challenge_turn_left": "Gira la testa a sinistra",
-            "challenge_turn_right": "Gira la testa a destra"
-        },
-        "prompt": {
-            "header_timeout": "Sembra che ci sia voluto troppo tempo"
-        }
-    },
-    "video_confirmation": {
-        "body": "Il tuo video è stato registrato",
-        "button_primary": "Carica video",
-        "button_secondary": "Registra un altro video",
-        "title": "Controlla il video",
-        "video_accessibility": "Guarda il video registrato"
-    },
-    "video_intro": {
-        "button_primary": "Registra video",
-        "list_accessibility": "Azioni per registrare un video selfie",
-        "list_item_actions": "Hai 20 secondi per terminare",
-        "list_item_speak": "Muoviti o parla seguendo le istruzioni",
-        "title": "Registra un video"
-    },
-    "welcome": {
-        "doc_video_subtitle": "L’operazione richiederà pochi minuti",
-        "list_header_doc_video": "Usa il dispositivo per registrare:",
-        "list_header_webcam": "Usa la webcam o il telefono per fotografare:",
-        "list_item_doc": "il tuo documento d’identità",
-        "list_item_doc_video_timeout": "La registrazione ha un limite di <timeout><\/timeout> secondi",
-        "list_item_poa": "la tua prova dell'indirizzo",
-        "list_item_selfie": "il tuo viso",
-        "next_button": "Seleziona documento",
-        "start_workflow_button": "Inizia verifica",
-        "subtitle": "L’operazione richiederà pochi minuti",
-        "title": "Verifica la tua identità"
-    },
-    "workflow_complete": {
-        "pass": {
-            "description": "",
-            "title": ""
-        },
-        "reject": {
-            "description": "",
-            "title": ""
-        }
-    },
-    "workflow_erros": {
-        "generic_title": "",
-        "no_workflow_run_id": "",
-        "reload_app": "",
-        "task_not_completed": "",
-        "task_not_retrieved": "",
-        "task_not_supported": ""
+      "button_primary": "Scatta una foto",
+      "title": "Pagina con foto del passaporto"
     }
+  },
+  "outro": {
+    "body": "Ora abbiamo tutto quello che ci serve per iniziare a verificare la tua identità",
+    "body_government_letter": "Invia l’intera pagina del documento per un risultato ottimale",
+    "title": "Grazie"
+  },
+  "permission": {
+    "body_both": "Impossibile verificare la tua identità senza usare sia la fotocamera che il microfono",
+    "body_cam": "Impossibile verificare la tua identità senza la fotocamera",
+    "button_primary_both": "Abilita entrambi",
+    "button_primary_cam": "Abilita la fotocamera",
+    "subtitle_both": "Per continuare è necessario abilitare l’accesso a entrambi quando richiesto",
+    "subtitle_cam": "Per continuare è necessario abilitare l’accesso alla fotocamera quando richiesto",
+    "title_both": "Consenti l’accesso alla fotocamera e al microfono",
+    "title_cam": "Consenti l’accesso alla fotocamera"
+  },
+  "permission_recovery": {
+    "button_primary": "Ricarica",
+    "info": "Ripristino",
+    "list_header_both": "Segui questi passaggi per ripristinare l’accesso alla entrambi:",
+    "list_header_cam": "Segui questi passaggi per ripristinare l’accesso alla fotocamera:",
+    "list_item_action_cam": "Ricarica la pagina per riavviare il processo di verifica dell’identità",
+    "list_item_how_to_both": "Consenti l’accesso alla fotocamera e al microfono dalle impostazioni del browser",
+    "list_item_how_to_cam": "Consenti l’accesso alla fotocamera dalle impostazioni del browser",
+    "subtitle_both": "Ripristina l’accesso alla fotocamera e al microfono per registrare un video e completare il processo di verifica",
+    "subtitle_cam": "Ripristina l’accesso alla fotocamera per continuare la verifica",
+    "subtitle_cam_old": "Ripristina l’accesso alla fotocamera per continuare il processo di verifica",
+    "title_both": "Accesso alla fotocamera e al microfono negato",
+    "title_cam": "Accesso alla fotocamera negato"
+  },
+  "photo_upload": {
+    "body_bank_statement": "Invia l'intera pagina del documento per un risultato ottimale",
+    "body_benefits_letter": "Invia l'intera pagina del documento per un risultato ottimale",
+    "body_bill": "Invia l'intera pagina del documento per un risultato ottimale",
+    "body_id_back": "Carica il retro della carta d’identità dal tuo computer",
+    "body_id_front": "Carica il fronte della carta d’identità dal tuo computer",
+    "body_license_back": "Carica il retro della patente dal tuo computer",
+    "body_license_front": "Carica il fronte della patente dal tuo computer",
+    "body_passport": "Carica la pagina con foto del passaporto dal tuo computer",
+    "body_selfie": "Carica un selfie dal tuo computer",
+    "body_tax_letter": "Invia l'intera pagina del documento per un risultato ottimale",
+    "button_take_photo": "Scatta foto",
+    "button_upload": "Carica",
+    "title_selfie": "Selfie"
+  },
+  "poa_cancel": "Annulla",
+  "poa_err_invalid_file": {
+    "message": "Seleziona un altro file.",
+    "ok": "OK",
+    "title": "File non valido"
+  },
+  "poa_guidance": {
+    "button_primary": "Continua",
+    "instructions": {
+      "address": "Indirizzo attuale",
+      "full_name": "Nome e cognome",
+      "issue_date": "Data di emissione o periodo di riepilogo",
+      "label": "Riporta l'intero documento assicurandoti che mostri chiaramente:",
+      "logo": "Logo"
+    },
+    "subtitle_bank_statement": "Deve essere stato emesso negli <strong>ultimi 3 mesi</strong>",
+    "subtitle_benefits_letter": "Deve essere stata emessa negli <strong>ultimi 12 mesi</strong>",
+    "subtitle_bill": "Deve essere stato emesso negli <strong>ultimi 3 mesi</strong>",
+    "subtitle_tax_letter": "Deve essere stata emessa negli <strong>ultimi 12 mesi</strong>"
+  },
+  "poa_intro": {
+    "button_primary": "Inizia la verifica",
+    "list_matches_signup": "<strong>Corrisponde</strong> all'indirizzo utilizzato per la registrazione",
+    "list_most_recent": "È il tuo documento più <strong>recente</strong>",
+    "list_shows_address": "Mostra il tuo indirizzo <strong>attuale</strong>",
+    "subtitle": "Ti servirà un documento che:",
+    "title": "Verifichiamo il tuo indirizzo"
+  },
+  "profile_data": {
+    "address_title": "Aggiungere l’indirizzo",
+    "button_continue": "Continua",
+    "components": {
+      "country_select": {
+        "placeholder": "Selezionare un paese"
+      },
+      "nationality_select": {
+        "placeholder": "Seleziona un Paese"
+      },
+      "pan": {
+        "placeholder": "ABCDE1234F"
+      },
+      "ssn": {
+        "placeholder": "123-45-6789"
+      },
+      "state_select": {
+        "placeholder": "Selezionare uno stato"
+      }
+    },
+    "country_of_residence_title": "Il tuo paese di residenza",
+    "field_labels": {
+      "country": "Paese",
+      "dob": "Data di nascita",
+      "email": "Email",
+      "first_name": "Nome",
+      "gbr_specific": {
+        "postcode": "Codice postale",
+        "town": "Città/comune"
+      },
+      "last_name": "Cognome",
+      "line1": "Indirizzo 1",
+      "line2": "Indirizzo 2",
+      "line3": "Indirizzo 3",
+      "mobile_number": "Numero di cellulare",
+      "nationality": "Nazionalità",
+      "pan": "Numero di conto permanente (PAN)",
+      "postcode": "Codice postale",
+      "ssn": "Numero di previdenza sociale (SSN)",
+      "town": "Comune",
+      "usa_specific": {
+        "line1_helper_text": "Indirizzo, ad esempio 200 Albert Street",
+        "line2_helper_text": "Appartamento, suite, unità ecc.",
+        "postcode": "Zip code",
+        "state": "Stato"
+      }
+    },
+    "field_optional": "(facoltativo)",
+    "field_validation": {
+      "gbr_specific": {
+        "required_postcode": "Inserire il codice postale",
+        "too_long_postcode": "Il codice postale è troppo lungo",
+        "too_short_postcode": "Il codice postale è troppo breve"
+      },
+      "invalid": "Verificare che non ci siano simboli o caratteri non validi",
+      "invalid_dob": "Inserire una data di nascita valida",
+      "required_country": "Selezionare un paese",
+      "required_dob": "Inserire la data di nascita",
+      "required_email": "Inserisci la tua email",
+      "required_first_name": "",
+      "required_last_name": "Inserire il cognome",
+      "required_line1": "Inserire l’indirizzo",
+      "required_mobile_number": "Inserisci il tuo numero di cellulare",
+      "required_nationality": "Seleziona un Paese",
+      "required_pan": "Inserisci il tuo PAN",
+      "required_postcode": "Inserire il codice postale",
+      "required_ssn": "Inserisci il tuo SSN",
+      "too_long__line1": "L’indirizzo è troppo lungo",
+      "too_long_first_name": "Il nome è troppo lungo",
+      "too_long_last_name": "Il cognome è troppo lungo",
+      "too_long_postcode": "Il codice postale è troppo lungo",
+      "too_long_town": "",
+      "too_short_first_name": "Il nome è troppo breve",
+      "too_short_last_name": "Il cognome è troppo breve",
+      "too_short_postcode": "Il codice postale è troppo breve",
+      "usa_specific": {
+        "required_state": "Selezionare uno stato"
+      },
+      "valid_email": "Inserisci un’email valida",
+      "valid_mobile_number": "Inserisci un numero di telefono valido",
+      "valid_pan": "Inserisci un PAN valido",
+      "valid_ssn": "Inserisci un SSN valido"
+    },
+    "personal_information_title": "Aggiungere i dati personali",
+    "prompt": {
+      "details_timeout": "Ricomincia",
+      "header_timeout": "Sembra che ci sia voluto troppo tempo"
+    }
+  },
+  "retry_feedback": {
+    "button_primary": "Riprova"
+  },
+  "retry_feedback_id_expired": {
+    "subtitle": "Riprova con un documento d’identità valido e assicurati chele informazioni siano ben leggibili",
+    "title": "Il documento è scaduto"
+  },
+  "retry_feedback_id_generic": {
+    "subtitle": "Riprova con un documento d’identità valido e assicurati che le informazioni siano ben leggibili",
+    "title": "Si è verificato un problema con il tuo documento"
+  },
+  "retry_feedback_id_unaccepted": {
+    "subtitle": "Riprova con un documento d’identità valido e assicurati che le informazioni siano ben leggibili",
+    "title": "Documento non accettato"
+  },
+  "retry_feedback_selfie_generic": {
+    "subtitle": "Riprova e assicurati che il volto sia visibile e ben illuminato",
+    "title": "Si è verificato un problema con il selfie"
+  },
+  "selfie_capture": {
+    "alert": {
+      "camera_inactive": {
+        "detail": "Controlla che sia collegata e funzionante. In alternativa puoi <fallback>continuare la verifica dal tuo telefono</fallback>.",
+        "detail_no_fallback": "Assicurati che il dispositivo abbia una fotocamera funzionante",
+        "title": "La fotocamera non funziona?"
+      },
+      "camera_not_working": {
+        "detail": "Potrebbe non essere collegata. <fallback>Prova a utilizzare il telefono</fallback>.",
+        "detail_no_fallback": "Assicurati che la fotocamera del dispositivo sia funzionante",
+        "title": "Fotocamera non funzionante"
+      },
+      "timeout": {
+        "detail": "Ricorda di premere il pulsante quando hai finito. <fallback>Ripeti le azioni del video</fallback>",
+        "title": "Sembra che ci sia voluto troppo tempo"
+      }
+    },
+    "body": "Tieni il viso nell’ovale",
+    "button_accessibility": "Scatta una foto",
+    "button_primary": "Inizia a scansionare il viso",
+    "frame_accessibility": "Vista dalla fotocamera",
+    "title": "Tieni il viso nell’ovale"
+  },
+  "selfie_confirmation": {
+    "image_accessibility": "Foto del tuo viso",
+    "subtitle": "Assicurati che il viso sia visibile per intero",
+    "title": "Controlla il selfie"
+  },
+  "selfie_intro": {
+    "button_primary": "Continua",
+    "list_accessibility": "Consigli per un buon selfie",
+    "list_item_face_forward": "Guarda in avanti e assicurati che gli occhi siano ben visibili",
+    "list_item_no_glasses": "Togliti gli occhiali, se necessario",
+    "subtitle": "Lo confronteremo con il tuo documento",
+    "title": "Scatta un selfie"
+  },
+  "sms_sent": {
+    "info": "Consigli",
+    "info_link_expire": "Il tuo link scadrà tra un’ora",
+    "info_link_window": "Tieni aperta questa finestra mentre usi il telefono",
+    "link": "Invia nuovo link",
+    "subtitle": "Abbiamo inviato un link sicuro a %{number}",
+    "subtitle_minutes": "La ricezione potrebbe richiedere qualche minuto",
+    "title": "Controlla il telefono"
+  },
+  "switch_phone": {
+    "info": "Consigli",
+    "info_link_expire": "Il link inviato al tuo telefono scadrà tra un’ora",
+    "info_link_refresh": "Non ricaricare la pagina",
+    "info_link_window": "Tieni aperta questa finestra mentre usi il telefono",
+    "link": "Annulla",
+    "subtitle": "Quando avrai terminato ti porteremo al passaggio successivo",
+    "title": "Collegato al tuo telefono"
+  },
+  "upload_guide": {
+    "button_primary": "Carica foto",
+    "image_detail_blur_alt": "Esempio di un documento sfocato",
+    "image_detail_blur_label": "Tutti i dettagli devono essere nitidi, senza sfocature",
+    "image_detail_cutoff_label": "Mostra tutti i dettagli, incluse le 2 righe inferiori",
+    "image_detail_glare_label": "Allontanati dalla luce diretta per evitare riflessi",
+    "image_detail_good_label": "La foto deve mostrare chiaramente il tuo documento",
+    "subtitle": "Non sono ammesse scansioni e fotocopie",
+    "title": "Invia la pagina con foto del passaporto"
+  },
+  "user_consent": {
+    "button_primary": "Accept",
+    "button_secondary": "Do not accept",
+    "prompt": {
+      "button_primary": "Review again",
+      "button_secondary": "Yes, don’t verify me",
+      "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
+      "no_consent_title": "Are you sure?"
+    }
+  },
+  "user_consent_load_fail": {
+    "button_primary": "Reload screen",
+    "detail": "Check that your connection is stable, then try again",
+    "title": "Content failed to load"
+  },
+  "video_capture": {
+    "body": "Tieni il viso nell’ovale",
+    "body_record": "Quando è tutto pronto, premi il pulsante",
+    "body_stop": "Premi \"stop\" quando hai finito",
+    "button_primary_finish": "Termina registrazione",
+    "button_primary_next": "Avanti",
+    "button_primary_start": "Inizia a registrare",
+    "button_record_accessibility": "Inizia a registrare",
+    "frame_accessibility": "Vista dalla fotocamera",
+    "header": {
+      "challenge_digit_instructions": "Pronuncia ciascun numero ad alta voce",
+      "challenge_turn_forward": "poi guarda in avanti",
+      "challenge_turn_left": "Gira la testa a sinistra",
+      "challenge_turn_right": "Gira la testa a destra"
+    },
+    "prompt": {
+      "header_timeout": "Sembra che ci sia voluto troppo tempo"
+    }
+  },
+  "video_confirmation": {
+    "body": "Il tuo video è stato registrato",
+    "button_primary": "Carica video",
+    "button_secondary": "Registra un altro video",
+    "title": "Controlla il video",
+    "video_accessibility": "Guarda il video registrato"
+  },
+  "video_intro": {
+    "button_primary": "Registra video",
+    "list_accessibility": "Azioni per registrare un video selfie",
+    "list_item_actions": "Hai 20 secondi per terminare",
+    "list_item_speak": "Muoviti o parla seguendo le istruzioni",
+    "title": "Registra un video"
+  },
+  "welcome": {
+    "doc_video_subtitle": "L’operazione richiederà pochi minuti",
+    "list_header_doc_video": "Usa il dispositivo per registrare:",
+    "list_header_webcam": "Usa la webcam o il telefono per fotografare:",
+    "list_item_doc": "il tuo documento d’identità",
+    "list_item_doc_video_timeout": "La registrazione ha un limite di <timeout></timeout> secondi",
+    "list_item_poa": "la tua prova dell'indirizzo",
+    "list_item_selfie": "il tuo viso",
+    "next_button": "Seleziona documento",
+    "start_workflow_button": "Inizia verifica",
+    "subtitle": "L’operazione richiederà pochi minuti",
+    "title": "Verifica la tua identità"
+  },
+  "workflow_complete": {
+    "pass": {
+      "description": "",
+      "title": ""
+    },
+    "reject": {
+      "description": "",
+      "title": ""
+    }
+  },
+  "workflow_erros": {
+    "generic_title": "",
+    "no_workflow_run_id": "",
+    "reload_app": "",
+    "task_not_completed": "",
+    "task_not_retrieved": "",
+    "task_not_supported": ""
+  }
 }

--- a/src/locales/nl_NL/nl_NL.json
+++ b/src/locales/nl_NL/nl_NL.json
@@ -1,678 +1,678 @@
 {
-    "avc_confirmation": {
-        "button_primary_upload": "Opname uploaden",
-        "subtitle": "Er is met succes een video van uw gezicht opgenomen",
-        "title": "Opname voltooid"
+  "avc_confirmation": {
+    "button_primary_upload": "Opname uploaden",
+    "subtitle": "Er is met succes een video van uw gezicht opgenomen",
+    "title": "Opname voltooid"
+  },
+  "avc_connection_error": {
+    "button_primary_reload": "Instructies herladen",
+    "button_primary_retry_upload": "Upload opnieuw proberen",
+    "button_secondary_restart_recording": "Opname opnieuw starten",
+    "subtitle": "Controleer of u een stabiele verbinding heeft en probeer het daarna opnieuw",
+    "title": "Verbindingsfout"
+  },
+  "avc_face_alignment": {
+    "feedback_move_back": "Ga naar achteren",
+    "feedback_move_closer": "Kom dichterbij",
+    "feedback_no_face_detected": "Gezicht niet gedetecteerd",
+    "feedback_not_centered": "Gezicht niet gecentreerd",
+    "title": "Plaats uw gezicht in het kader"
+  },
+  "avc_face_capture": {
+    "alert": {
+      "timeout_body": "U heeft 15 seconden om de opname te maken",
+      "timeout_button_primary": "Probeer opnieuw",
+      "timeout_title": "Sorry, we moeten de opname opnieuw starten",
+      "too_fast_body": "Probeer het opnieuw en draai uw hoofd dit keer langzamer",
+      "too_fast_button_primary": "Probeer opnieuw",
+      "too_fast_title": "U heeft uw hoofd te snel gedraaid"
     },
-    "avc_connection_error": {
-        "button_primary_reload": "Instructies herladen",
-        "button_primary_retry_upload": "Upload opnieuw proberen",
-        "button_secondary_restart_recording": "Opname opnieuw starten",
-        "subtitle": "Controleer of u een stabiele verbinding heeft en probeer het daarna opnieuw",
-        "title": "Verbindingsfout"
+    "title": "Draai uw hoofd langzaam naar beide kanten",
+    "title_completed": "Opname voltooid"
+  },
+  "avc_intro": {
+    "button_primary_ready": "Ik ben klaar",
+    "disclaimer": "Wees u er bewust van dat we uw gezicht en achtergrond zullen opnemen",
+    "list_item_one": "Plaats eerst uw gezicht in het kader",
+    "list_item_two": "Draai uw hoofd dan langzaam naar beide kanten",
+    "subtitle": "Dit is om te bevestigen dat u een echt persoon bent",
+    "title": "Neem een video op"
+  },
+  "avc_no_face_detected": {
+    "button_primary_restart": "Opname opnieuw starten",
+    "list_item_eyes": "Zorg ervoor dat uw ogen duidelijk zichtbaar zijn",
+    "list_item_face": "Zorg ervoor dat u alleen uw gezicht laat zien, we hoeven uw identiteitsbewijs niet te zien",
+    "list_item_lighting": "Zorg dat u in een goed verlichte ruimte bent",
+    "list_item_mask": "Zorg ervoor dat u maskers of andere voorwerpen die uw gezicht bedekken afzet. Een bril mag wel.",
+    "title": "We kunnen uw gezicht niet detecteren"
+  },
+  "avc_uploading": {
+    "title": "Uploaden"
+  },
+  "country_select": {
+    "alert": {
+      "another_doc": "Documenten uit dat land worden momenteel niet ondersteund - <fallback>probeer een ander documenttype</fallback>"
     },
-    "avc_face_alignment": {
-        "feedback_move_back": "Ga naar achteren",
-        "feedback_move_closer": "Kom dichterbij",
-        "feedback_no_face_detected": "Gezicht niet gedetecteerd",
-        "feedback_not_centered": "Gezicht niet gecentreerd",
-        "title": "Plaats uw gezicht in het kader"
+    "alert_dropdown": {
+      "country_not_found": "Land niet gevonden"
     },
-    "avc_face_capture": {
-        "alert": {
-            "timeout_body": "U heeft 15 seconden om de opname te maken",
-            "timeout_button_primary": "Probeer opnieuw",
-            "timeout_title": "Sorry, we moeten de opname opnieuw starten",
-            "too_fast_body": "Probeer het opnieuw en draai uw hoofd dit keer langzamer",
-            "too_fast_button_primary": "Probeer opnieuw",
-            "too_fast_title": "U heeft uw hoofd te snel gedraaid"
-        },
-        "title": "Draai uw hoofd langzaam naar beide kanten",
-        "title_completed": "Opname voltooid"
+    "button_primary": "Verzend document",
+    "poa_alert": {
+      "country_not_found": "Excuses daarvoor. We werken eraan om meer landen te ondersteunen.",
+      "intro": "Kunt u uw land niet vinden?"
     },
-    "avc_intro": {
-        "button_primary_ready": "Ik ben klaar",
-        "disclaimer": "Wees u er bewust van dat we uw gezicht en achtergrond zullen opnemen",
-        "list_item_one": "Plaats eerst uw gezicht in het kader",
-        "list_item_two": "Draai uw hoofd dan langzaam naar beide kanten",
-        "subtitle": "Dit is om te bevestigen dat u een echt persoon bent",
-        "title": "Neem een video op"
+    "search": {
+      "accessibility": "Selecteer land",
+      "input_placeholder": "bijv. Nederland",
+      "label": "Zoek een land"
     },
-    "avc_no_face_detected": {
-        "button_primary_restart": "Opname opnieuw starten",
-        "list_item_eyes": "Zorg ervoor dat uw ogen duidelijk zichtbaar zijn",
-        "list_item_face": "Zorg ervoor dat u alleen uw gezicht laat zien, we hoeven uw identiteitsbewijs niet te zien",
-        "list_item_lighting": "Zorg dat u in een goed verlichte ruimte bent",
-        "list_item_mask": "Zorg ervoor dat u maskers of andere voorwerpen die uw gezicht bedekken afzet. Een bril mag wel.",
-        "title": "We kunnen uw gezicht niet detecteren"
+    "title": "Selecteer land van uitgifte"
+  },
+  "cross_device_checklist": {
+    "button_primary": "Verificatie verzenden",
+    "info": "Tips",
+    "list_item_doc_multiple": "Documenten",
+    "list_item_doc_one": "Document",
+    "list_item_poa": "Adresbewijs",
+    "list_item_selfie": "Selfie",
+    "list_item_video": "Filmpje",
+    "subtitle": "Hier ziet u alles wat u geüpload hebt:",
+    "title": "Eén laatste stap"
+  },
+  "cross_device_error_desktop": {
+    "subtitle": "De link werkt alleen op een mobiel apparaat",
+    "title": "Er is iets misgegaan"
+  },
+  "cross_device_error_restart": {
+    "subtitle": "U moet uw verificatie opnieuw starten op uw computer",
+    "title": "Er is iets misgegaan"
+  },
+  "cross_device_intro": {
+    "button_primary": "Ontvang veilige link",
+    "list_accessibility": "Vereiste stappen om de verificatie op uw mobiele telefoon voort te zetten",
+    "list_item_finish": "Kom hier terug om het verzenden af te ronden",
+    "list_item_open_link": "Open de link en voer de taken uit",
+    "list_item_send_phone": "Stuur een veilige link naar uw telefoon",
+    "subtitle": "Hier ziet u hoe dat moet:",
+    "title": "Ga door op uw telefoon"
+  },
+  "cross_device_return": {
+    "body": "Het kan een paar seconden duren voordat uw computer de update verwerkt",
+    "subtitle": "U kunt nu terug naar uw computer om door te gaan",
+    "title": "Uploaden gelukt"
+  },
+  "cross_device_session_linked": {
+    "button_primary": "Doorgaan",
+    "info": "Nogmaals controleren",
+    "list_item_desktop_open": "Het venster op uw desktop blijft open",
+    "list_item_sent_by_you": "Deze link is door u verstuurd - vraag om advies als u denkt dat het hier gaat om fraude",
+    "subtitle": "Ga door met de verificatie",
+    "title": "Mobiele sessie gekoppeld aan uw computer"
+  },
+  "doc_capture": {
+    "button_primary": "Start scannen van document",
+    "detail": {
+      "folded_doc_front": "Leg uw document plat, inclusief alle binnenste pagina's (moeten uw foto bevatten)"
     },
-    "avc_uploading": {
-        "title": "Uploaden"
+    "header_folded_doc_front": "Zijde profielfoto",
+    "prompt": {
+      "button_card": "Plastic kaart",
+      "button_paper": "Papieren document",
+      "title_id": "Wat voor type identiteitskaart hebt u?",
+      "title_license": "Wat voor type rijbewijs hebt u?"
+    }
+  },
+  "doc_confirmation": {
+    "alert": {
+      "blur_detail": "Zorg dat alles helder zichtbaar is",
+      "blur_title": "Onscherpe foto gedetecteerd",
+      "crop_detail": "Zorg dat het volledige document zichtbaar is",
+      "crop_title": "Afgesneden afbeelding gedetecteerd",
+      "glare_detail": "Ga niet in direct zonlicht staan",
+      "glare_title": "Schittering gedetecteerd",
+      "no_doc_detail": "Zorg dat het volledig in het kader geplaatst is",
+      "no_doc_title": "Document niet gedetecteerd"
     },
-    "country_select": {
-        "alert": {
-            "another_doc": "Documenten uit dat land worden momenteel niet ondersteund - <fallback>probeer een ander documenttype<\/fallback>"
-        },
-        "alert_dropdown": {
-            "country_not_found": "Land niet gevonden"
-        },
-        "button_primary": "Verzend document",
-        "poa_alert": {
-            "country_not_found": "Excuses daarvoor. We werken eraan om meer landen te ondersteunen.",
-            "intro": "Kunt u uw land niet vinden?"
-        },
-        "search": {
-            "accessibility": "Selecteer land",
-            "input_placeholder": "bijv. Nederland",
-            "label": "Zoek een land"
-        },
-        "title": "Selecteer land van uitgifte"
+    "body": "Zorg ervoor dat u de volledige documentpagina heeft geüpload, en dat de details duidelijk en zonder wazigheid of spiegeling te lezen zijn",
+    "body_bank_statement": "Zorg ervoor dat u de volledige documentpagina heeft geüpload, en dat de details duidelijk en zonder wazigheid of spiegeling te lezen zijn",
+    "body_benefits_letter": "Zorg ervoor dat u de volledige documentpagina heeft geüpload, en dat de details duidelijk en zonder wazigheid of spiegeling te lezen zijn",
+    "body_bill": "Zorg ervoor dat u de volledige documentpagina heeft geüpload, en dat de details duidelijk en zonder wazigheid of spiegeling te lezen zijn",
+    "body_id": "Controleer of uw gegevens goed en volledig zichtbaar zijn",
+    "body_image_medium": "Het duurt langer u te verifiëren als we deze niet kunnen lezen",
+    "body_image_poor": "Om u gemakkelijk te kunnen verifiëren, hebben we een betere foto nodig",
+    "body_license": "Controleer of uw gegevens goed en volledig zichtbaar zijn",
+    "body_passport": "Controleer of uw gegevens goed en volledig zichtbaar zijn",
+    "body_permit": "Controleer of uw gegevens goed en volledig zichtbaar zijn",
+    "body_tax_letter": "Zorg ervoor dat u de volledige documentpagina heeft geüpload, en dat de details duidelijk en zonder wazigheid of spiegeling te lezen zijn",
+    "button_close": "Sluiten",
+    "button_primary_redo": "Opnieuw uitvoeren",
+    "button_primary_upload": "Uploaden",
+    "button_primary_upload_anyway": "Toch uploaden",
+    "button_secondary_redo": "Opnieuw uitvoeren",
+    "button_zoom": "Vergroot afbeelding",
+    "image_accessibility": "Foto van uw document",
+    "title": "Controleer uw afbeelding"
+  },
+  "doc_multi_frame_capture": {
+    "capture_progress_title": "Document scannen",
+    "instructions_title_back": "Plaats de achterkant van uw document in het kader",
+    "instructions_title_front": "Plaats de voorkant van uw document in het kader"
+  },
+  "doc_select": {
+    "button_bank_statement": "Afschriften van de bank of bouwvereniging",
+    "button_bank_statement_non_uk": "Bankafschrift",
+    "button_benefits_letter": "Brief voordelen",
+    "button_benefits_letter_detail": "Door de overheid toegestane uitkeringen voor huishoudens, bv. uitkering voor werkzoekenden, huursubsidie, belastingkredieten",
+    "button_bill": "Energierekening",
+    "button_bill_detail": "Gas, elektriciteit, water, vaste telefoonlijn of breedband",
+    "button_government_letter": "Brief van de overheid",
+    "button_government_letter_detail": "Alle brieven van de overheid, bv. uitkeringsrechten, stembrieven, belastingbrieven, enz",
+    "button_id": "Identiteitskaart",
+    "button_id_detail": "Voor- en achterkant",
+    "button_license": "Rijbewijs",
+    "button_license_detail": "Voor- en achterkant",
+    "button_passport": "Paspoort",
+    "button_passport_detail": "Fotopagina",
+    "button_permit": "Verblijfsvergunning",
+    "button_permit_detail": "Voor- en achterkant",
+    "button_tax_letter": "Brief gemeentelijke belastingen",
+    "extra_estatements_ok": "Elektronische afschriften geaccepteerd",
+    "extra_no_mobile": "Sorry, geen rekening voor mobiele telefoon",
+    "list_accessibility": "Document die u kunt gebruiken voor het verifiëren van uw identiteit",
+    "pill": "snelst",
+    "section": {
+      "header_country": "Land van uitgifte",
+      "header_doc_type": "Geaccepteerde documenten",
+      "input_country_not_found": "Geen resultaten",
+      "input_placeholder_country": "Selecteer land van uitgifte"
     },
-    "cross_device_checklist": {
-        "button_primary": "Verificatie verzenden",
-        "info": "Tips",
-        "list_item_doc_multiple": "Documenten",
-        "list_item_doc_one": "Document",
-        "list_item_poa": "Adresbewijs",
-        "list_item_selfie": "Selfie",
-        "list_item_video": "Filmpje",
-        "subtitle": "Hier ziet u alles wat u geüpload hebt:",
-        "title": "Eén laatste stap"
+    "subtitle": "Het moet een officieel identiteitsbewijs met foto zijn",
+    "subtitle_country": "Selecteer het land van uitgifte om te zien welke documenten we accepteren",
+    "subtitle_entire_page": "Hele pagina",
+    "subtitle_front_back": "Voor-en achterkant",
+    "subtitle_photo_page": "Fotopagina",
+    "subtitle_poa": "Dit zijn de meest waarschijnlijke documenten waaruit uw huidige adres blijkt",
+    "title": "Kies uw document",
+    "title_poa": "Kies een %{country} document"
+  },
+  "doc_submit": {
+    "button_link_upload": "of upload een foto - geen scans of kopieën",
+    "button_primary": "Ga door op telefoon",
+    "subtitle": "Neem een foto met uw telefoon",
+    "title_bank_statement": "Afschrift indienen",
+    "title_benefits_letter": "Brief indienen",
+    "title_bill": "Factuur indienen",
+    "title_government_letter": "Brief van de overheid",
+    "title_id_back": "Verzend identiteitskaart (achterkant)",
+    "title_id_front": "Verzend identiteitskaart (voorkant)",
+    "title_license_back": "Verzend rijbewijs (achterkant)",
+    "title_license_front": "Verzend rijbewijs (voorkant)",
+    "title_passport": "Verstuur de fotopagina van uw paspoort",
+    "title_permit_back": "Verzend verblijfsvergunning (achterkant)",
+    "title_permit_front": "Verzend verblijfsvergunning (voorkant)",
+    "title_tax_letter": "Brief indienen"
+  },
+  "doc_video_capture": {
+    "button_primary_fallback": "Volgende stap",
+    "button_primary_fallback_end": "Voltooi opname",
+    "detail_step2": "Zorg dat het document altijd volledig zichtbaar is",
+    "header": "Houd uw document vast en plaats de voorkant in het kader",
+    "header_paper_doc_step2": "Draai uw document langzaam om, zodat de buitenste pagina's zichtbaar worden",
+    "header_passport": "Houd uw paspoort vast en plaats de fotopagina in het kader",
+    "header_passport_progress": "Houd het stil",
+    "header_step1": "Houd het nu stil",
+    "header_step2": "Draai uw document langzaam om, zodat de achterkant zichtbaar wordt",
+    "prompt": {
+      "detail_timeout": "Opnemen video is beperkt tot <timeout></timeout> seconden. <fallback>Probeer opnieuw</fallback>"
     },
-    "cross_device_error_desktop": {
-        "subtitle": "De link werkt alleen op een mobiel apparaat",
-        "title": "Er is iets misgegaan"
+    "stepper": "Stap <step></step> van <total></total>",
+    "success_accessibility": "Gelukt"
+  },
+  "doc_video_confirmation": {
+    "button_secondary": "Video weergeven",
+    "title": "Controleer uw filmpje"
+  },
+  "error_unsupported_browser": {
+    "subtitle_android": "Start het proces opnieuw op de laatste versie Google Chrome",
+    "subtitle_ios": "Start het proces opnieuw op de laatste versie van Safari",
+    "title_android": "Browser wordt niet ondersteund",
+    "title_ios": "Browser wordt niet ondersteund"
+  },
+  "generic": {
+    "accessibility": {
+      "close_sdk_screen": "Sluit het scherm voor de verificatie van uw identiteit",
+      "dismiss_alert": "Melding negeren"
     },
-    "cross_device_error_restart": {
-        "subtitle": "U moet uw verificatie opnieuw starten op uw computer",
-        "title": "Er is iets misgegaan"
+    "back": "terug",
+    "close": "sluiten",
+    "errors": {
+      "expired_token": {
+        "instruction": "Probeer het opnieuw",
+        "message": "Uw token is verlopen"
+      },
+      "geoblocked_error": {
+        "instruction": "Het spijt ons, we kunnen niet verdergaan, omdat uw huidige locatie niet ondersteund wordt",
+        "message": "Service niet beschikbaar"
+      },
+      "interrupted_flow_error": {
+        "instruction": "Start het proces opnieuw vanaf een ander apparaat",
+        "message": "Camera niet gedetecteerd"
+      },
+      "invalid_size": {
+        "instruction": "Moet kleiner zijn dan 10 MB",
+        "message": "Bestandsgrootte overschreden."
+      },
+      "invalid_type": {
+        "instruction": "Probeer het met een ander bestandstype",
+        "message": "Bestand niet geüpload."
+      },
+      "lazy_loading": {
+        "message": "Er is een fout opgetreden bij het laden van de component"
+      },
+      "multiple_faces": {
+        "instruction": "Alleen uw gezicht mag zichtbaar zijn in de selfie",
+        "message": "Meerdere gezichten gevonden"
+      },
+      "no_face": {
+        "instruction": "Zorg dat uw gezicht zichtbaar is",
+        "message": "Gezicht niet gedetecteerd"
+      },
+      "request_error": {
+        "instruction": "Probeer het nog eens",
+        "message": "Er is iets misgegaan"
+      },
+      "sms_failed": {
+        "instruction": "Kopieer de link naar uw telefoon",
+        "message": "Er is iets misgegaan"
+      },
+      "sms_overuse": {
+        "instruction": "Kopieer de link naar uw telefoon",
+        "message": "Teveel mislukte pogingen"
+      },
+      "unsupported_file": {
+        "instruction": "Probeer het met een .JPG- of .PNG-bestand",
+        "message": "Bestandstype wordt niet ondersteund"
+      }
     },
-    "cross_device_intro": {
-        "button_primary": "Ontvang veilige link",
-        "list_accessibility": "Vereiste stappen om de verificatie op uw mobiele telefoon voort te zetten",
-        "list_item_finish": "Kom hier terug om het verzenden af te ronden",
-        "list_item_open_link": "Open de link en voer de taken uit",
-        "list_item_send_phone": "Stuur een veilige link naar uw telefoon",
-        "subtitle": "Hier ziet u hoe dat moet:",
-        "title": "Ga door op uw telefoon"
-    },
-    "cross_device_return": {
-        "body": "Het kan een paar seconden duren voordat uw computer de update verwerkt",
-        "subtitle": "U kunt nu terug naar uw computer om door te gaan",
-        "title": "Uploaden gelukt"
-    },
-    "cross_device_session_linked": {
-        "button_primary": "Doorgaan",
-        "info": "Nogmaals controleren",
-        "list_item_desktop_open": "Het venster op uw desktop blijft open",
-        "list_item_sent_by_you": "Deze link is door u verstuurd - vraag om advies als u denkt dat het hier gaat om fraude",
-        "subtitle": "Ga door met de verificatie",
-        "title": "Mobiele sessie gekoppeld aan uw computer"
-    },
-    "doc_capture": {
-        "button_primary": "Start scannen van document",
-        "detail": {
-            "folded_doc_front": "Leg uw document plat, inclusief alle binnenste pagina's (moeten uw foto bevatten)"
-        },
-        "header_folded_doc_front": "Zijde profielfoto",
-        "prompt": {
-            "button_card": "Plastic kaart",
-            "button_paper": "Papieren document",
-            "title_id": "Wat voor type identiteitskaart hebt u?",
-            "title_license": "Wat voor type rijbewijs hebt u?"
-        }
-    },
-    "doc_confirmation": {
-        "alert": {
-            "blur_detail": "Zorg dat alles helder zichtbaar is",
-            "blur_title": "Onscherpe foto gedetecteerd",
-            "crop_detail": "Zorg dat het volledige document zichtbaar is",
-            "crop_title": "Afgesneden afbeelding gedetecteerd",
-            "glare_detail": "Ga niet in direct zonlicht staan",
-            "glare_title": "Schittering gedetecteerd",
-            "no_doc_detail": "Zorg dat het volledig in het kader geplaatst is",
-            "no_doc_title": "Document niet gedetecteerd"
-        },
-        "body": "Zorg ervoor dat u de volledige documentpagina heeft geüpload, en dat de details duidelijk en zonder wazigheid of spiegeling te lezen zijn",
-        "body_bank_statement": "Zorg ervoor dat u de volledige documentpagina heeft geüpload, en dat de details duidelijk en zonder wazigheid of spiegeling te lezen zijn",
-        "body_benefits_letter": "Zorg ervoor dat u de volledige documentpagina heeft geüpload, en dat de details duidelijk en zonder wazigheid of spiegeling te lezen zijn",
-        "body_bill": "Zorg ervoor dat u de volledige documentpagina heeft geüpload, en dat de details duidelijk en zonder wazigheid of spiegeling te lezen zijn",
-        "body_id": "Controleer of uw gegevens goed en volledig zichtbaar zijn",
-        "body_image_medium": "Het duurt langer u te verifiëren als we deze niet kunnen lezen",
-        "body_image_poor": "Om u gemakkelijk te kunnen verifiëren, hebben we een betere foto nodig",
-        "body_license": "Controleer of uw gegevens goed en volledig zichtbaar zijn",
-        "body_passport": "Controleer of uw gegevens goed en volledig zichtbaar zijn",
-        "body_permit": "Controleer of uw gegevens goed en volledig zichtbaar zijn",
-        "body_tax_letter": "Zorg ervoor dat u de volledige documentpagina heeft geüpload, en dat de details duidelijk en zonder wazigheid of spiegeling te lezen zijn",
-        "button_close": "Sluiten",
-        "button_primary_redo": "Opnieuw uitvoeren",
-        "button_primary_upload": "Uploaden",
-        "button_primary_upload_anyway": "Toch uploaden",
-        "button_secondary_redo": "Opnieuw uitvoeren",
-        "button_zoom": "Vergroot afbeelding",
-        "image_accessibility": "Foto van uw document",
-        "title": "Controleer uw afbeelding"
-    },
-    "doc_multi_frame_capture": {
-        "capture_progress_title": "Document scannen",
-        "instructions_title_back": "Plaats de achterkant van uw document in het kader",
-        "instructions_title_front": "Plaats de voorkant van uw document in het kader"
-    },
-    "doc_select": {
-        "button_bank_statement": "Afschriften van de bank of bouwvereniging",
-        "button_bank_statement_non_uk": "Bankafschrift",
-        "button_benefits_letter": "Brief voordelen",
-        "button_benefits_letter_detail": "Door de overheid toegestane uitkeringen voor huishoudens, bv. uitkering voor werkzoekenden, huursubsidie, belastingkredieten",
-        "button_bill": "Energierekening",
-        "button_bill_detail": "Gas, elektriciteit, water, vaste telefoonlijn of breedband",
-        "button_government_letter": "Brief van de overheid",
-        "button_government_letter_detail": "Alle brieven van de overheid, bv. uitkeringsrechten, stembrieven, belastingbrieven, enz",
-        "button_id": "Identiteitskaart",
-        "button_id_detail": "Voor- en achterkant",
-        "button_license": "Rijbewijs",
-        "button_license_detail": "Voor- en achterkant",
-        "button_passport": "Paspoort",
-        "button_passport_detail": "Fotopagina",
-        "button_permit": "Verblijfsvergunning",
-        "button_permit_detail": "Voor- en achterkant",
-        "button_tax_letter": "Brief gemeentelijke belastingen",
-        "extra_estatements_ok": "Elektronische afschriften geaccepteerd",
-        "extra_no_mobile": "Sorry, geen rekening voor mobiele telefoon",
-        "list_accessibility": "Document die u kunt gebruiken voor het verifiëren van uw identiteit",
-        "pill": "snelst",
-        "section": {
-            "header_country": "Land van uitgifte",
-            "header_doc_type": "Geaccepteerde documenten",
-            "input_country_not_found": "Geen resultaten",
-            "input_placeholder_country": "Selecteer land van uitgifte"
-        },
-        "subtitle": "Het moet een officieel identiteitsbewijs met foto zijn",
-        "subtitle_country": "Selecteer het land van uitgifte om te zien welke documenten we accepteren",
-        "subtitle_entire_page": "Hele pagina",
-        "subtitle_front_back": "Voor-en achterkant",
-        "subtitle_photo_page": "Fotopagina",
-        "subtitle_poa": "Dit zijn de meest waarschijnlijke documenten waaruit uw huidige adres blijkt",
-        "title": "Kies uw document",
-        "title_poa": "Kies een %{country} document"
-    },
-    "doc_submit": {
-        "button_link_upload": "of upload een foto - geen scans of kopieën",
-        "button_primary": "Ga door op telefoon",
-        "subtitle": "Neem een foto met uw telefoon",
-        "title_bank_statement": "Afschrift indienen",
-        "title_benefits_letter": "Brief indienen",
-        "title_bill": "Factuur indienen",
-        "title_government_letter": "Brief van de overheid",
-        "title_id_back": "Verzend identiteitskaart (achterkant)",
-        "title_id_front": "Verzend identiteitskaart (voorkant)",
-        "title_license_back": "Verzend rijbewijs (achterkant)",
-        "title_license_front": "Verzend rijbewijs (voorkant)",
-        "title_passport": "Verstuur de fotopagina van uw paspoort",
-        "title_permit_back": "Verzend verblijfsvergunning (achterkant)",
-        "title_permit_front": "Verzend verblijfsvergunning (voorkant)",
-        "title_tax_letter": "Brief indienen"
-    },
-    "doc_video_capture": {
-        "button_primary_fallback": "Volgende stap",
-        "button_primary_fallback_end": "Voltooi opname",
-        "detail_step2": "Zorg dat het document altijd volledig zichtbaar is",
-        "header": "Houd uw document vast en plaats de voorkant in het kader",
-        "header_paper_doc_step2": "Draai uw document langzaam om, zodat de buitenste pagina's zichtbaar worden",
-        "header_passport": "Houd uw paspoort vast en plaats de fotopagina in het kader",
-        "header_passport_progress": "Houd het stil",
-        "header_step1": "Houd het nu stil",
-        "header_step2": "Draai uw document langzaam om, zodat de achterkant zichtbaar wordt",
-        "prompt": {
-            "detail_timeout": "Opnemen video is beperkt tot <timeout><\/timeout> seconden. <fallback>Probeer opnieuw<\/fallback>"
-        },
-        "stepper": "Stap <step><\/step> van <total><\/total>",
-        "success_accessibility": "Gelukt"
-    },
-    "doc_video_confirmation": {
-        "button_secondary": "Video weergeven",
-        "title": "Controleer uw filmpje"
-    },
-    "error_unsupported_browser": {
-        "subtitle_android": "Start het proces opnieuw op de laatste versie Google Chrome",
-        "subtitle_ios": "Start het proces opnieuw op de laatste versie van Safari",
-        "title_android": "Browser wordt niet ondersteund",
-        "title_ios": "Browser wordt niet ondersteund"
-    },
-    "generic": {
-        "accessibility": {
-            "close_sdk_screen": "Sluit het scherm voor de verificatie van uw identiteit",
-            "dismiss_alert": "Melding negeren"
-        },
-        "back": "terug",
-        "close": "sluiten",
-        "errors": {
-            "expired_token": {
-                "instruction": "Probeer het opnieuw",
-                "message": "Uw token is verlopen"
-            },
-            "geoblocked_error": {
-                "instruction": "Het spijt ons, we kunnen niet verdergaan, omdat uw huidige locatie niet ondersteund wordt",
-                "message": "Service niet beschikbaar"
-            },
-            "interrupted_flow_error": {
-                "instruction": "Start het proces opnieuw vanaf een ander apparaat",
-                "message": "Camera niet gedetecteerd"
-            },
-            "invalid_size": {
-                "instruction": "Moet kleiner zijn dan 10 MB",
-                "message": "Bestandsgrootte overschreden."
-            },
-            "invalid_type": {
-                "instruction": "Probeer het met een ander bestandstype",
-                "message": "Bestand niet geüpload."
-            },
-            "lazy_loading": {
-                "message": "Er is een fout opgetreden bij het laden van de component"
-            },
-            "multiple_faces": {
-                "instruction": "Alleen uw gezicht mag zichtbaar zijn in de selfie",
-                "message": "Meerdere gezichten gevonden"
-            },
-            "no_face": {
-                "instruction": "Zorg dat uw gezicht zichtbaar is",
-                "message": "Gezicht niet gedetecteerd"
-            },
-            "request_error": {
-                "instruction": "Probeer het nog eens",
-                "message": "Er is iets misgegaan"
-            },
-            "sms_failed": {
-                "instruction": "Kopieer de link naar uw telefoon",
-                "message": "Er is iets misgegaan"
-            },
-            "sms_overuse": {
-                "instruction": "Kopieer de link naar uw telefoon",
-                "message": "Teveel mislukte pogingen"
-            },
-            "unsupported_file": {
-                "instruction": "Probeer het met een .JPG- of .PNG-bestand",
-                "message": "Bestandstype wordt niet ondersteund"
-            }
-        },
-        "lazy_load_placeholder": "Bezig met laden...",
-        "loading": "Bezig met laden"
-    },
-    "get_link": {
-        "alert_wrong_number": "Controleer of uw nummer juist is",
-        "button_copied": "Gekopieerd",
-        "button_copy": "Kopiëren",
-        "button_submit": "Verstuur link",
-        "info_qr_how": "Hoe kunt u een QR-code scannen",
-        "info_qr_how_list_item_camera": "Richt de camera van uw telefoon op de QR-code",
-        "info_qr_how_list_item_download": "Als het niet werkt, download dan een QR-scan vanuit Google Play of de App Store",
-        "link_divider": "of kies een alternatieve methode",
-        "link_qr": "Scan QR-code",
-        "link_sms": "Ontvang een link via sms",
-        "link_url": "Kopieer link",
-        "loader_sending": "Versturen",
-        "number_field_input_placeholder": "Voer mobiele nummer in",
-        "number_field_label": "Voer uw mobiele nummer in:",
-        "subtitle_qr": "Scan de QR-code met uw telefoon",
-        "subtitle_sms": "Stuur deze eenmalige link naar uw telefoon",
-        "subtitle_url": "Stuur deze eenmalige link naar uw telefoon",
-        "title": "Ontvang uw veilige link",
-        "url_field_label": "Kopieer de link naar uw mobiele telefoon"
-    },
-    "livenessV2": {
-        "error_reload_instructions": "Instructies herladen",
-        "intro_note_no1": "Eerst, plaats uw gezicht in het frame",
-        "intro_note_no2": "Draai uw hoofd dan langzaam naar beide kanten",
-        "intro_ready_button": "Wees er bewust van dat we uw gezicht en achtergrond zullen opnemen",
-        "intro_subtitle": "Dit is om te verifiëren dat u een echte persoon bent",
-        "intro_warning": "Wees er bewust van dat we uw gezicht en achtergrond zullen opnemen",
-        "success_main_button": "Verificatie indienen",
-        "success_title": "Dat is alles wat we nodig hebben om uw identiteit te verifiëren"
-    },
-    "mobilePhrases": {
-        "photo_upload": {
-            "body_id_back": "Neem een foto van de achterkant van uw kaart",
-            "body_id_front": "Neem een foto van de voorkant van uw kaart",
-            "body_license_back": "Neem een foto van de achterkant van uw rijbewijs",
-            "body_license_front": "Neem een foto van de voorkant van uw rijbewijs",
-            "body_passport": "Neem een foto van de fotopagina van uw paspoort",
-            "body_selfie": "Neem een selfie van uw gezicht"
-        },
-        "selfie_capture": {
-            "alert": {
-                "camera_inactive": {
-                    "detail": "Neem in plaats daarvan een foto met de <fallback>basismodus van de camera<\/fallback>"
-                },
-                "camera_not_working": {
-                    "detail": "Neem in plaats daarvan een foto met de <fallback>basismodus van de camera<\/fallback>"
-                }
-            }
-        },
-        "upload_guide": {
-            "button_primary": "Neem een foto",
-            "title": "Plaats de fotopagina van uw document in het kader"
-        }
-    },
-    "outro": {
-        "body": "Daarom moeten we uw identiteit verifiëren",
-        "body_government_letter": "Verstrek de hele documentpagina voor de beste resultaten",
-        "title": "Dank u"
-    },
-    "permission": {
-        "body_both": "We kunnen u niet verifiëren zonder uw camera en microfoon te gebruiken",
-        "body_cam": "We kunnen u niet verifiëren zonder camera",
-        "button_primary_both": "Allebei inschakelen",
-        "button_primary_cam": "Camera inschakelen",
-        "subtitle_both": "Als u daarom gevraagd wordt, moet u toegang tot zowel de camera als de microfoon inschakelen om door te gaan",
-        "subtitle_cam": "Als u daarom gevraagd wordt, moet u toegang tot de camera inschakelen om door te gaan",
-        "title_both": "Sta toegang toe tot camera en microfoon",
-        "title_cam": "Toegang tot camera toestaan"
-    },
-    "permission_recovery": {
-        "button_primary": "Verversen",
-        "info": "Herstellen",
-        "list_header_both": "Volg deze stappen om de toegang voor beide te herstellen:",
-        "list_header_cam": "Volg deze stappen om toegang tot de camera te herstellen:",
-        "list_item_action_cam": "Ververs deze pagina om het proces voor de verificatie van uw identiteit opnieuw te starten",
-        "list_item_how_to_both": "Verleen via uw browserinstellingen toegang tot uw camera en microfoon",
-        "list_item_how_to_cam": "Schakel toegang tot uw camera in vanuit de browserinstellingen",
-        "subtitle_both": "Herstel toegang tot de camera en de microfoon om een filmpje op te nemen en de verificatie van uw gezicht te voltooien",
-        "subtitle_cam": "Herstel de cameratoegang om uw verificatie voort te zetten",
-        "subtitle_cam_old": "Herstel toegang tot de camera om door te gaan met de verificatie van uw gezicht",
-        "title_both": "Toegang tot camera en microfoon geweigerd",
-        "title_cam": "Toegang tot camera is geweigerd"
-    },
+    "lazy_load_placeholder": "Bezig met laden...",
+    "loading": "Bezig met laden"
+  },
+  "get_link": {
+    "alert_wrong_number": "Controleer of uw nummer juist is",
+    "button_copied": "Gekopieerd",
+    "button_copy": "Kopiëren",
+    "button_submit": "Verstuur link",
+    "info_qr_how": "Hoe kunt u een QR-code scannen",
+    "info_qr_how_list_item_camera": "Richt de camera van uw telefoon op de QR-code",
+    "info_qr_how_list_item_download": "Als het niet werkt, download dan een QR-scan vanuit Google Play of de App Store",
+    "link_divider": "of kies een alternatieve methode",
+    "link_qr": "Scan QR-code",
+    "link_sms": "Ontvang een link via sms",
+    "link_url": "Kopieer link",
+    "loader_sending": "Versturen",
+    "number_field_input_placeholder": "Voer mobiele nummer in",
+    "number_field_label": "Voer uw mobiele nummer in:",
+    "subtitle_qr": "Scan de QR-code met uw telefoon",
+    "subtitle_sms": "Stuur deze eenmalige link naar uw telefoon",
+    "subtitle_url": "Stuur deze eenmalige link naar uw telefoon",
+    "title": "Ontvang uw veilige link",
+    "url_field_label": "Kopieer de link naar uw mobiele telefoon"
+  },
+  "livenessV2": {
+    "error_reload_instructions": "Instructies herladen",
+    "intro_note_no1": "Eerst, plaats uw gezicht in het frame",
+    "intro_note_no2": "Draai uw hoofd dan langzaam naar beide kanten",
+    "intro_ready_button": "Wees er bewust van dat we uw gezicht en achtergrond zullen opnemen",
+    "intro_subtitle": "Dit is om te verifiëren dat u een echte persoon bent",
+    "intro_warning": "Wees er bewust van dat we uw gezicht en achtergrond zullen opnemen",
+    "success_main_button": "Verificatie indienen",
+    "success_title": "Dat is alles wat we nodig hebben om uw identiteit te verifiëren"
+  },
+  "mobilePhrases": {
     "photo_upload": {
-        "body_bank_statement": "Verstrek de hele documentpagina voor de beste resultaten",
-        "body_benefits_letter": "Verstrek de hele documentpagina voor de beste resultaten",
-        "body_bill": "Verstrek de hele documentpagina voor de beste resultaten",
-        "body_id_back": "Upload de achterkant van uw kaart vanaf uw computer",
-        "body_id_front": "Upload de voorkant van uw kaart vanaf uw computer",
-        "body_license_back": "Upload de achterkant van uw rijbewijs vanaf uw computer",
-        "body_license_front": "Upload de voorkant van uw rijbewijs vanaf uw computer",
-        "body_passport": "Upload de fotopagina van uw paspoort vanaf uw computer",
-        "body_selfie": "Upload een selfie vanaf uw computer",
-        "body_tax_letter": "Geef de hele documentpagina voor de beste resultaten",
-        "button_take_photo": "Neem een foto",
-        "button_upload": "Uploaden",
-        "title_selfie": "Selfie"
-    },
-    "poa_cancel": "Annuleren",
-    "poa_err_invalid_file": {
-        "message": "Kies een ander bestand.",
-        "ok": "OKÉ",
-        "title": "Ongeldig bestand"
-    },
-    "poa_guidance": {
-        "button_primary": "Doorgaan",
-        "instructions": {
-            "address": "Huidig adres",
-            "full_name": "Volledige naam",
-            "issue_date": "Afgiftedatum of samenvattende periode",
-            "label": "Leg het hele document vast en zorg ervoor dat het duidelijk te zien is:",
-            "logo": "Logo"
-        },
-        "subtitle_bank_statement": "Moet in de <strong>laatste 3 maanden<\/strong> zijn afgegeven",
-        "subtitle_benefits_letter": "Moet in de <strong>laatste 12 maanden<\/strong> zijn afgegeven",
-        "subtitle_bill": "Moet in de <strong>laatste 3 maanden<\/strong> zijn afgegeven",
-        "subtitle_tax_letter": "Moet in de <strong>laatste 12 maanden<\/strong> zijn afgegeven"
-    },
-    "poa_intro": {
-        "button_primary": "Start verificatie",
-        "list_matches_signup": "<strong>Komt overeen<\/strong> met het adres dat u bij de registratie heeft gebruikt",
-        "list_most_recent": "Is uw meest <strong>recente<\/strong> document",
-        "list_shows_address": "Toont uw <strong>huidige<\/strong> adres",
-        "subtitle": "U heeft een document nodig dat:",
-        "title": "Laten we uw adres verifiëren"
-    },
-    "profile_data": {
-        "address_title": "Voeg uw adres toe",
-        "button_continue": "Doorgaan",
-        "components": {
-            "country_select": {
-                "placeholder": "Selecteer een land"
-            },
-            "nationality_select": {
-                "placeholder": "Selecteer een land"
-            },
-            "pan": {
-                "placeholder": "ABCDE1234F"
-            },
-            "ssn": {
-                "placeholder": "123-45-6789"
-            },
-            "state_select": {
-                "placeholder": "Selecteer een staat"
-            }
-        },
-        "country_of_residence_title": "Uw land van verblijf",
-        "field_labels": {
-            "country": "Land",
-            "dob": "Geboortedatum",
-            "email": "E-mailadres",
-            "first_name": "Voornaam",
-            "gbr_specific": {
-                "postcode": "Postcode",
-                "town": "Stad\/Dorp"
-            },
-            "last_name": "Achternaam",
-            "line1": "Adresregel 1",
-            "line2": "Adresregel 2",
-            "line3": "Adresregel 3",
-            "mobile_number": "Mobiel nummer",
-            "nationality": "Nationaliteit",
-            "pan": "Permanent account number (PAN)",
-            "postcode": "Postcode",
-            "ssn": "Sociale Zekerheidsnummer (SSN)",
-            "town": "Stad",
-            "usa_specific": {
-                "line1_helper_text": "Adres, bijvoorbeeld: 200 Albertstraat",
-                "line2_helper_text": "Appartement, suite, eenheid, enz.",
-                "postcode": "Zip code (VS)",
-                "state": "Staat"
-            }
-        },
-        "field_optional": "(optioneel)",
-        "field_validation": {
-            "gbr_specific": {
-                "required_postcode": "Voer uw postcode in",
-                "too_long_postcode": "Postcode is te lang",
-                "too_short_postcode": "Postcode is te kort"
-            },
-            "invalid": "Controleer op ongeldige tekens of symbolen",
-            "invalid_dob": "Voer een geldig geboortedatum in",
-            "required_country": "Selecteer een land",
-            "required_dob": "Voer uw geboortedatum in",
-            "required_email": "Voer uw e-mailadres in",
-            "required_first_name": "",
-            "required_last_name": "Voer uw achternaam in",
-            "required_line1": "Voer uw adres in",
-            "required_mobile_number": "Voer uw mobiele nummer in",
-            "required_nationality": "Selecteer een land",
-            "required_pan": "Voer uw PAN in",
-            "required_postcode": "Voer uw postcode in",
-            "required_ssn": "Voer uw SSN in",
-            "too_long__line1": "Adresregel is te lang",
-            "too_long_first_name": "Voornaam is te lang",
-            "too_long_last_name": "Achternaam is te lang",
-            "too_long_postcode": "Postcode is te lang",
-            "too_long_town": "",
-            "too_short_first_name": "Voornaam is te kort",
-            "too_short_last_name": "Achternaam is te kort",
-            "too_short_postcode": "Postcode is te kort",
-            "usa_specific": {
-                "required_state": "Selecteer een staat"
-            },
-            "valid_email": "Voer een geldig e-mailadres in",
-            "valid_mobile_number": "Voer een geldig mobiel nummer in",
-            "valid_pan": "Voer een geldig PAN in",
-            "valid_ssn": "Voer een geldig SSN in"
-        },
-        "personal_information_title": "Voeg uw persoonlijke informatie toe",
-        "prompt": {
-            "details_timeout": "Start opnieuw",
-            "header_timeout": "Het lijkt erop dat het te lang duurde"
-        }
-    },
-    "retry_feedback": {
-        "button_primary": "Probeer het opnieuw"
-    },
-    "retry_feedback_id_expired": {
-        "subtitle": "Probeer het opnieuw met een geldig identiteitsbewijs met foto en zorg ervoor dat uw gegevens duidelijk leesbaar zijn",
-        "title": "Uw document is verlopen"
-    },
-    "retry_feedback_id_generic": {
-        "subtitle": "Probeer het opnieuw met een geldig identiteitsbewijs met foto en zorg ervoor dat uw gegevens duidelijk leesbaar zijn",
-        "title": "Er is iets misgegaan met uw document"
-    },
-    "retry_feedback_id_unaccepted": {
-        "subtitle": "Probeer het opnieuw met een geldig identiteitsbewijs met foto en zorg ervoor dat uw gegevens duidelijk leesbaar zijn",
-        "title": "Niet-geaccepteerd document"
-    },
-    "retry_feedback_selfie_generic": {
-        "subtitle": "Probeer het opnieuw en zorg ervoor dat uw gezicht goed zichtbaar en verlicht is",
-        "title": "Er is iets misgegaan met uw selfie"
+      "body_id_back": "Neem een foto van de achterkant van uw kaart",
+      "body_id_front": "Neem een foto van de voorkant van uw kaart",
+      "body_license_back": "Neem een foto van de achterkant van uw rijbewijs",
+      "body_license_front": "Neem een foto van de voorkant van uw rijbewijs",
+      "body_passport": "Neem een foto van de fotopagina van uw paspoort",
+      "body_selfie": "Neem een selfie van uw gezicht"
     },
     "selfie_capture": {
-        "alert": {
-            "camera_inactive": {
-                "detail": "Controleer dat deze verbinding heeft en werkt. U kunt <fallback>het verificatieproces ook op uw mobiele telefoon voortzetten<\/fallback>",
-                "detail_no_fallback": "Zorg dat de camera op uw apparaat werkt",
-                "title": "Doet uw camera het niet?"
-            },
-            "camera_not_working": {
-                "detail": "Hij is mogelijk losgekoppeld. <fallback>Probeer het met uw telefoon<\/fallback>.",
-                "detail_no_fallback": "Zorg dat de camera op uw apparaat werkt",
-                "title": "Camera doet het niet"
-            },
-            "timeout": {
-                "detail": "Vergeet niet op de knop te drukken als u klaar bent. <fallback>Herhaal de stappen voor het opnemen van een filmpje<\/fallback>",
-                "title": "Het lijkt erop dat het te lang duurde"
-            }
+      "alert": {
+        "camera_inactive": {
+          "detail": "Neem in plaats daarvan een foto met de <fallback>basismodus van de camera</fallback>"
         },
-        "body": "Houd uw gezicht binnen de ovaal",
-        "button_accessibility": "Neem een foto",
-        "button_primary": "Start een gezichtsscan",
-        "frame_accessibility": "Waargave vanaf camera",
-        "title": "Houd uw gezicht binnen de ovaal"
-    },
-    "selfie_confirmation": {
-        "image_accessibility": "Foto van uw gezicht",
-        "subtitle": "Zorg dat uw volledige gezicht zichtbaar is",
-        "title": "Controleer uw selfie"
-    },
-    "selfie_intro": {
-        "button_primary": "Doorgaan",
-        "list_accessibility": "Tips voor een goede selfie",
-        "list_item_face_forward": "Kijk recht vooruit en zorg dat uw ogen goed te zien zijn",
-        "list_item_no_glasses": "Zet uw bril af indien nodig",
-        "subtitle": "We vergelijken deze met uw document",
-        "title": "Neem een selfie"
-    },
-    "sms_sent": {
-        "info": "Tips",
-        "info_link_expire": "Uw link verloopt over een uur",
-        "info_link_window": "Houd dit venster open als u uw mobiele telefoon gebruikt",
-        "link": "Stuur link opnieuw",
-        "subtitle": "We hebben een beveiligde link gestuurd naar %{number}",
-        "subtitle_minutes": "Het kan een paar minuten duren voordat u deze ontvangt",
-        "title": "Check uw mobiele telefoon"
-    },
-    "switch_phone": {
-        "info": "Tips",
-        "info_link_expire": "Uw mobiele link verloopt over een uur",
-        "info_link_refresh": "Ververs deze pagina niet",
-        "info_link_window": "Houd dit venster open als u uw mobiele telefoon gebruikt",
-        "link": "Annuleren",
-        "subtitle": "Zodra u klaar bent, leiden we u naar de volgende stap",
-        "title": "Verbonden met uw mobiele telefoon"
+        "camera_not_working": {
+          "detail": "Neem in plaats daarvan een foto met de <fallback>basismodus van de camera</fallback>"
+        }
+      }
     },
     "upload_guide": {
-        "button_primary": "Upload foto",
-        "image_detail_blur_alt": "Voorbeeld van een wazig document",
-        "image_detail_blur_label": "Alle details moeten scherp zijn - niets wazig",
-        "image_detail_cutoff_label": "Toon alle details - waaronder de onderste 2 regels",
-        "image_detail_glare_label": "Ga niet in direct zonlicht staan - geen glans",
-        "image_detail_good_label": "De foto moet uw document duidelijk weergeven",
-        "subtitle": "Scans en fotokopiën worden niet geaccepteerd",
-        "title": "Upload de fotopagina van uw paspoort"
-    },
-    "user_consent": {
-        "button_primary": "Accept",
-        "button_secondary": "Do not accept",
-        "prompt": {
-            "button_primary": "Review again",
-            "button_secondary": "Yes, don’t verify me",
-            "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
-            "no_consent_title": "Are you sure?"
-        }
-    },
-    "user_consent_load_fail": {
-        "button_primary": "Reload screen",
-        "detail": "Check that your connection is stable, then try again",
-        "title": "Content failed to load"
-    },
-    "video_capture": {
-        "body": "Houd uw gezicht binnen de ovaal",
-        "body_record": "Druk op de knop als u klaar bent",
-        "body_stop": "Druk op Stop als u klaar bent",
-        "button_primary_finish": "Voltooi opname",
-        "button_primary_next": "Volgende stap",
-        "button_primary_start": "Start met opnemen",
-        "button_record_accessibility": "Start met opnemen",
-        "frame_accessibility": "Waargave vanaf camera",
-        "header": {
-            "challenge_digit_instructions": "Spreek elk cijfer hardop uit",
-            "challenge_turn_forward": "en kijk rechtuit",
-            "challenge_turn_left": "Draai uw hoofd naar links",
-            "challenge_turn_right": "Draai uw hoofd naar rechts"
-        },
-        "prompt": {
-            "header_timeout": "Het lijkt erop dat het te lang duurde"
-        }
-    },
-    "video_confirmation": {
-        "body": "Uw filmpje is opgenomen",
-        "button_primary": "Upload filmpje",
-        "button_secondary": "Neem filmpje opnieuw op",
-        "title": "Controleer uw filmpje",
-        "video_accessibility": "Speel uw opgenomen filmpje opnieuw af"
-    },
-    "video_intro": {
-        "button_primary": "Maak een filmpje",
-        "list_accessibility": "Acties om een selfievideo op te nemen",
-        "list_item_actions": "U hebt 20 seconden om af te ronden",
-        "list_item_speak": "Volg de instructies voor bewegen en spreken",
-        "title": "Maak een filmpje"
-    },
-    "welcome": {
-        "doc_video_subtitle": "Dat duurt maar een paar minuten",
-        "list_header_doc_video": "Gebruik uw apparaat om op te nemen:",
-        "list_header_webcam": "Gebruik uw webcam of telefoon om te fotograferen:",
-        "list_item_doc": "uw identiteitsbewijs",
-        "list_item_doc_video_timeout": "Opnemen is beperkt tot <timeout><\/timeout> seconden",
-        "list_item_poa": "uw adresbewijs",
-        "list_item_selfie": "uw gezicht",
-        "next_button": "Kies een document",
-        "start_workflow_button": "Start verificatie",
-        "subtitle": "Dat duurt maar een paar minuten",
-        "title": "Verifieer uw identiteit"
-    },
-    "workflow_complete": {
-        "pass": {
-            "description": "",
-            "title": ""
-        },
-        "reject": {
-            "description": "",
-            "title": ""
-        }
-    },
-    "workflow_erros": {
-        "generic_title": "",
-        "no_workflow_run_id": "",
-        "reload_app": "",
-        "task_not_completed": "",
-        "task_not_retrieved": "",
-        "task_not_supported": ""
+      "button_primary": "Neem een foto",
+      "title": "Plaats de fotopagina van uw document in het kader"
     }
+  },
+  "outro": {
+    "body": "Daarom moeten we uw identiteit verifiëren",
+    "body_government_letter": "Verstrek de hele documentpagina voor de beste resultaten",
+    "title": "Dank u"
+  },
+  "permission": {
+    "body_both": "We kunnen u niet verifiëren zonder uw camera en microfoon te gebruiken",
+    "body_cam": "We kunnen u niet verifiëren zonder camera",
+    "button_primary_both": "Allebei inschakelen",
+    "button_primary_cam": "Camera inschakelen",
+    "subtitle_both": "Als u daarom gevraagd wordt, moet u toegang tot zowel de camera als de microfoon inschakelen om door te gaan",
+    "subtitle_cam": "Als u daarom gevraagd wordt, moet u toegang tot de camera inschakelen om door te gaan",
+    "title_both": "Sta toegang toe tot camera en microfoon",
+    "title_cam": "Toegang tot camera toestaan"
+  },
+  "permission_recovery": {
+    "button_primary": "Verversen",
+    "info": "Herstellen",
+    "list_header_both": "Volg deze stappen om de toegang voor beide te herstellen:",
+    "list_header_cam": "Volg deze stappen om toegang tot de camera te herstellen:",
+    "list_item_action_cam": "Ververs deze pagina om het proces voor de verificatie van uw identiteit opnieuw te starten",
+    "list_item_how_to_both": "Verleen via uw browserinstellingen toegang tot uw camera en microfoon",
+    "list_item_how_to_cam": "Schakel toegang tot uw camera in vanuit de browserinstellingen",
+    "subtitle_both": "Herstel toegang tot de camera en de microfoon om een filmpje op te nemen en de verificatie van uw gezicht te voltooien",
+    "subtitle_cam": "Herstel de cameratoegang om uw verificatie voort te zetten",
+    "subtitle_cam_old": "Herstel toegang tot de camera om door te gaan met de verificatie van uw gezicht",
+    "title_both": "Toegang tot camera en microfoon geweigerd",
+    "title_cam": "Toegang tot camera is geweigerd"
+  },
+  "photo_upload": {
+    "body_bank_statement": "Verstrek de hele documentpagina voor de beste resultaten",
+    "body_benefits_letter": "Verstrek de hele documentpagina voor de beste resultaten",
+    "body_bill": "Verstrek de hele documentpagina voor de beste resultaten",
+    "body_id_back": "Upload de achterkant van uw kaart vanaf uw computer",
+    "body_id_front": "Upload de voorkant van uw kaart vanaf uw computer",
+    "body_license_back": "Upload de achterkant van uw rijbewijs vanaf uw computer",
+    "body_license_front": "Upload de voorkant van uw rijbewijs vanaf uw computer",
+    "body_passport": "Upload de fotopagina van uw paspoort vanaf uw computer",
+    "body_selfie": "Upload een selfie vanaf uw computer",
+    "body_tax_letter": "Geef de hele documentpagina voor de beste resultaten",
+    "button_take_photo": "Neem een foto",
+    "button_upload": "Uploaden",
+    "title_selfie": "Selfie"
+  },
+  "poa_cancel": "Annuleren",
+  "poa_err_invalid_file": {
+    "message": "Kies een ander bestand.",
+    "ok": "OKÉ",
+    "title": "Ongeldig bestand"
+  },
+  "poa_guidance": {
+    "button_primary": "Doorgaan",
+    "instructions": {
+      "address": "Huidig adres",
+      "full_name": "Volledige naam",
+      "issue_date": "Afgiftedatum of samenvattende periode",
+      "label": "Leg het hele document vast en zorg ervoor dat het duidelijk te zien is:",
+      "logo": "Logo"
+    },
+    "subtitle_bank_statement": "Moet in de <strong>laatste 3 maanden</strong> zijn afgegeven",
+    "subtitle_benefits_letter": "Moet in de <strong>laatste 12 maanden</strong> zijn afgegeven",
+    "subtitle_bill": "Moet in de <strong>laatste 3 maanden</strong> zijn afgegeven",
+    "subtitle_tax_letter": "Moet in de <strong>laatste 12 maanden</strong> zijn afgegeven"
+  },
+  "poa_intro": {
+    "button_primary": "Start verificatie",
+    "list_matches_signup": "<strong>Komt overeen</strong> met het adres dat u bij de registratie heeft gebruikt",
+    "list_most_recent": "Is uw meest <strong>recente</strong> document",
+    "list_shows_address": "Toont uw <strong>huidige</strong> adres",
+    "subtitle": "U heeft een document nodig dat:",
+    "title": "Laten we uw adres verifiëren"
+  },
+  "profile_data": {
+    "address_title": "Voeg uw adres toe",
+    "button_continue": "Doorgaan",
+    "components": {
+      "country_select": {
+        "placeholder": "Selecteer een land"
+      },
+      "nationality_select": {
+        "placeholder": "Selecteer een land"
+      },
+      "pan": {
+        "placeholder": "ABCDE1234F"
+      },
+      "ssn": {
+        "placeholder": "123-45-6789"
+      },
+      "state_select": {
+        "placeholder": "Selecteer een staat"
+      }
+    },
+    "country_of_residence_title": "Uw land van verblijf",
+    "field_labels": {
+      "country": "Land",
+      "dob": "Geboortedatum",
+      "email": "E-mailadres",
+      "first_name": "Voornaam",
+      "gbr_specific": {
+        "postcode": "Postcode",
+        "town": "Stad/Dorp"
+      },
+      "last_name": "Achternaam",
+      "line1": "Adresregel 1",
+      "line2": "Adresregel 2",
+      "line3": "Adresregel 3",
+      "mobile_number": "Mobiel nummer",
+      "nationality": "Nationaliteit",
+      "pan": "Permanent account number (PAN)",
+      "postcode": "Postcode",
+      "ssn": "Sociale Zekerheidsnummer (SSN)",
+      "town": "Stad",
+      "usa_specific": {
+        "line1_helper_text": "Adres, bijvoorbeeld: 200 Albertstraat",
+        "line2_helper_text": "Appartement, suite, eenheid, enz.",
+        "postcode": "Zip code (VS)",
+        "state": "Staat"
+      }
+    },
+    "field_optional": "(optioneel)",
+    "field_validation": {
+      "gbr_specific": {
+        "required_postcode": "Voer uw postcode in",
+        "too_long_postcode": "Postcode is te lang",
+        "too_short_postcode": "Postcode is te kort"
+      },
+      "invalid": "Controleer op ongeldige tekens of symbolen",
+      "invalid_dob": "Voer een geldig geboortedatum in",
+      "required_country": "Selecteer een land",
+      "required_dob": "Voer uw geboortedatum in",
+      "required_email": "Voer uw e-mailadres in",
+      "required_first_name": "",
+      "required_last_name": "Voer uw achternaam in",
+      "required_line1": "Voer uw adres in",
+      "required_mobile_number": "Voer uw mobiele nummer in",
+      "required_nationality": "Selecteer een land",
+      "required_pan": "Voer uw PAN in",
+      "required_postcode": "Voer uw postcode in",
+      "required_ssn": "Voer uw SSN in",
+      "too_long__line1": "Adresregel is te lang",
+      "too_long_first_name": "Voornaam is te lang",
+      "too_long_last_name": "Achternaam is te lang",
+      "too_long_postcode": "Postcode is te lang",
+      "too_long_town": "",
+      "too_short_first_name": "Voornaam is te kort",
+      "too_short_last_name": "Achternaam is te kort",
+      "too_short_postcode": "Postcode is te kort",
+      "usa_specific": {
+        "required_state": "Selecteer een staat"
+      },
+      "valid_email": "Voer een geldig e-mailadres in",
+      "valid_mobile_number": "Voer een geldig mobiel nummer in",
+      "valid_pan": "Voer een geldig PAN in",
+      "valid_ssn": "Voer een geldig SSN in"
+    },
+    "personal_information_title": "Voeg uw persoonlijke informatie toe",
+    "prompt": {
+      "details_timeout": "Start opnieuw",
+      "header_timeout": "Het lijkt erop dat het te lang duurde"
+    }
+  },
+  "retry_feedback": {
+    "button_primary": "Probeer het opnieuw"
+  },
+  "retry_feedback_id_expired": {
+    "subtitle": "Probeer het opnieuw met een geldig identiteitsbewijs met foto en zorg ervoor dat uw gegevens duidelijk leesbaar zijn",
+    "title": "Uw document is verlopen"
+  },
+  "retry_feedback_id_generic": {
+    "subtitle": "Probeer het opnieuw met een geldig identiteitsbewijs met foto en zorg ervoor dat uw gegevens duidelijk leesbaar zijn",
+    "title": "Er is iets misgegaan met uw document"
+  },
+  "retry_feedback_id_unaccepted": {
+    "subtitle": "Probeer het opnieuw met een geldig identiteitsbewijs met foto en zorg ervoor dat uw gegevens duidelijk leesbaar zijn",
+    "title": "Niet-geaccepteerd document"
+  },
+  "retry_feedback_selfie_generic": {
+    "subtitle": "Probeer het opnieuw en zorg ervoor dat uw gezicht goed zichtbaar en verlicht is",
+    "title": "Er is iets misgegaan met uw selfie"
+  },
+  "selfie_capture": {
+    "alert": {
+      "camera_inactive": {
+        "detail": "Controleer dat deze verbinding heeft en werkt. U kunt <fallback>het verificatieproces ook op uw mobiele telefoon voortzetten</fallback>",
+        "detail_no_fallback": "Zorg dat de camera op uw apparaat werkt",
+        "title": "Doet uw camera het niet?"
+      },
+      "camera_not_working": {
+        "detail": "Hij is mogelijk losgekoppeld. <fallback>Probeer het met uw telefoon</fallback>.",
+        "detail_no_fallback": "Zorg dat de camera op uw apparaat werkt",
+        "title": "Camera doet het niet"
+      },
+      "timeout": {
+        "detail": "Vergeet niet op de knop te drukken als u klaar bent. <fallback>Herhaal de stappen voor het opnemen van een filmpje</fallback>",
+        "title": "Het lijkt erop dat het te lang duurde"
+      }
+    },
+    "body": "Houd uw gezicht binnen de ovaal",
+    "button_accessibility": "Neem een foto",
+    "button_primary": "Start een gezichtsscan",
+    "frame_accessibility": "Waargave vanaf camera",
+    "title": "Houd uw gezicht binnen de ovaal"
+  },
+  "selfie_confirmation": {
+    "image_accessibility": "Foto van uw gezicht",
+    "subtitle": "Zorg dat uw volledige gezicht zichtbaar is",
+    "title": "Controleer uw selfie"
+  },
+  "selfie_intro": {
+    "button_primary": "Doorgaan",
+    "list_accessibility": "Tips voor een goede selfie",
+    "list_item_face_forward": "Kijk recht vooruit en zorg dat uw ogen goed te zien zijn",
+    "list_item_no_glasses": "Zet uw bril af indien nodig",
+    "subtitle": "We vergelijken deze met uw document",
+    "title": "Neem een selfie"
+  },
+  "sms_sent": {
+    "info": "Tips",
+    "info_link_expire": "Uw link verloopt over een uur",
+    "info_link_window": "Houd dit venster open als u uw mobiele telefoon gebruikt",
+    "link": "Stuur link opnieuw",
+    "subtitle": "We hebben een beveiligde link gestuurd naar %{number}",
+    "subtitle_minutes": "Het kan een paar minuten duren voordat u deze ontvangt",
+    "title": "Check uw mobiele telefoon"
+  },
+  "switch_phone": {
+    "info": "Tips",
+    "info_link_expire": "Uw mobiele link verloopt over een uur",
+    "info_link_refresh": "Ververs deze pagina niet",
+    "info_link_window": "Houd dit venster open als u uw mobiele telefoon gebruikt",
+    "link": "Annuleren",
+    "subtitle": "Zodra u klaar bent, leiden we u naar de volgende stap",
+    "title": "Verbonden met uw mobiele telefoon"
+  },
+  "upload_guide": {
+    "button_primary": "Upload foto",
+    "image_detail_blur_alt": "Voorbeeld van een wazig document",
+    "image_detail_blur_label": "Alle details moeten scherp zijn - niets wazig",
+    "image_detail_cutoff_label": "Toon alle details - waaronder de onderste 2 regels",
+    "image_detail_glare_label": "Ga niet in direct zonlicht staan - geen glans",
+    "image_detail_good_label": "De foto moet uw document duidelijk weergeven",
+    "subtitle": "Scans en fotokopiën worden niet geaccepteerd",
+    "title": "Upload de fotopagina van uw paspoort"
+  },
+  "user_consent": {
+    "button_primary": "Accept",
+    "button_secondary": "Do not accept",
+    "prompt": {
+      "button_primary": "Review again",
+      "button_secondary": "Yes, don’t verify me",
+      "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
+      "no_consent_title": "Are you sure?"
+    }
+  },
+  "user_consent_load_fail": {
+    "button_primary": "Reload screen",
+    "detail": "Check that your connection is stable, then try again",
+    "title": "Content failed to load"
+  },
+  "video_capture": {
+    "body": "Houd uw gezicht binnen de ovaal",
+    "body_record": "Druk op de knop als u klaar bent",
+    "body_stop": "Druk op Stop als u klaar bent",
+    "button_primary_finish": "Voltooi opname",
+    "button_primary_next": "Volgende stap",
+    "button_primary_start": "Start met opnemen",
+    "button_record_accessibility": "Start met opnemen",
+    "frame_accessibility": "Waargave vanaf camera",
+    "header": {
+      "challenge_digit_instructions": "Spreek elk cijfer hardop uit",
+      "challenge_turn_forward": "en kijk rechtuit",
+      "challenge_turn_left": "Draai uw hoofd naar links",
+      "challenge_turn_right": "Draai uw hoofd naar rechts"
+    },
+    "prompt": {
+      "header_timeout": "Het lijkt erop dat het te lang duurde"
+    }
+  },
+  "video_confirmation": {
+    "body": "Uw filmpje is opgenomen",
+    "button_primary": "Upload filmpje",
+    "button_secondary": "Neem filmpje opnieuw op",
+    "title": "Controleer uw filmpje",
+    "video_accessibility": "Speel uw opgenomen filmpje opnieuw af"
+  },
+  "video_intro": {
+    "button_primary": "Maak een filmpje",
+    "list_accessibility": "Acties om een selfievideo op te nemen",
+    "list_item_actions": "U hebt 20 seconden om af te ronden",
+    "list_item_speak": "Volg de instructies voor bewegen en spreken",
+    "title": "Maak een filmpje"
+  },
+  "welcome": {
+    "doc_video_subtitle": "Dat duurt maar een paar minuten",
+    "list_header_doc_video": "Gebruik uw apparaat om op te nemen:",
+    "list_header_webcam": "Gebruik uw webcam of telefoon om te fotograferen:",
+    "list_item_doc": "uw identiteitsbewijs",
+    "list_item_doc_video_timeout": "Opnemen is beperkt tot <timeout></timeout> seconden",
+    "list_item_poa": "uw adresbewijs",
+    "list_item_selfie": "uw gezicht",
+    "next_button": "Kies een document",
+    "start_workflow_button": "Start verificatie",
+    "subtitle": "Dat duurt maar een paar minuten",
+    "title": "Verifieer uw identiteit"
+  },
+  "workflow_complete": {
+    "pass": {
+      "description": "",
+      "title": ""
+    },
+    "reject": {
+      "description": "",
+      "title": ""
+    }
+  },
+  "workflow_erros": {
+    "generic_title": "",
+    "no_workflow_run_id": "",
+    "reload_app": "",
+    "task_not_completed": "",
+    "task_not_retrieved": "",
+    "task_not_supported": ""
+  }
 }

--- a/src/locales/pl_PL/pl_PL.json
+++ b/src/locales/pl_PL/pl_PL.json
@@ -1,678 +1,678 @@
 {
-    "avc_confirmation": {
-        "button_primary_upload": "Prześlij nagranie",
-        "subtitle": "Udało się nagrać film wideo przedstawiający Twoją twarz",
-        "title": "Nagrywanie zakończone"
+  "avc_confirmation": {
+    "button_primary_upload": "Prześlij nagranie",
+    "subtitle": "Udało się nagrać film wideo przedstawiający Twoją twarz",
+    "title": "Nagrywanie zakończone"
+  },
+  "avc_connection_error": {
+    "button_primary_reload": "Uruchom ponownie instrukcję",
+    "button_primary_retry_upload": "Ponów próbę wysłania",
+    "button_secondary_restart_recording": "Uruchom nagrywanie ponownie",
+    "subtitle": "Sprawdź, czy połączenie z internetem jest stabilne, a następnie spróbuj ponownie",
+    "title": "Błąd połączenia"
+  },
+  "avc_face_alignment": {
+    "feedback_move_back": "Odsuń się",
+    "feedback_move_closer": "Zbliż się do ekranu",
+    "feedback_no_face_detected": "Nie wykryto twarzy",
+    "feedback_not_centered": "Twarz nie wyśrodkowana",
+    "title": "Ustaw twarz w kadrze"
+  },
+  "avc_face_capture": {
+    "alert": {
+      "timeout_body": "Masz maksymalnie 15 sekund na dokończenie nagrania",
+      "timeout_button_primary": "Ponów próbę",
+      "timeout_title": "Przepraszamy, musimy ponownie rozpocząć nagrywanie.",
+      "too_fast_body": "Spróbuj ponownie i tym razem wolniej obracaj głowę",
+      "too_fast_button_primary": "Ponów próbę",
+      "too_fast_title": "Obracasz głowę zbyt szybko"
     },
-    "avc_connection_error": {
-        "button_primary_reload": "Uruchom ponownie instrukcję",
-        "button_primary_retry_upload": "Ponów próbę wysłania",
-        "button_secondary_restart_recording": "Uruchom nagrywanie ponownie",
-        "subtitle": "Sprawdź, czy połączenie z internetem jest stabilne, a następnie spróbuj ponownie",
-        "title": "Błąd połączenia"
+    "title": "Powoli obróć głowę w obie strony",
+    "title_completed": "Nagrywanie zakończone"
+  },
+  "avc_intro": {
+    "button_primary_ready": "Gotowe",
+    "disclaimer": "Pamiętaj, że nagramy Twoją twarz razem z tłem",
+    "list_item_one": "Najpierw ustaw twarz w ramce",
+    "list_item_two": "Następnie powoli obróć głowę w obie strony",
+    "subtitle": "Ma to na celu sprawdzenie, czy naprawdę jesteś człowiekiem",
+    "title": "Nagraj wideo"
+  },
+  "avc_no_face_detected": {
+    "button_primary_restart": "Uruchom nagrywanie ponownie",
+    "list_item_eyes": "Upewnij się, że oczy są dobrze widoczne",
+    "list_item_face": "Upewnij się, że pokazujesz tylko swoją twarz, nie musimy widzieć Twojego dowodu tożsamości",
+    "list_item_lighting": "Upewnij się, że jesteś w miejscu z dobrym oświetleniem",
+    "list_item_mask": "Pamiętaj, aby zdjąć maski lub inne przedmioty zakrywające twarz. Okulary są akceptowane",
+    "title": "Nie możemy wykryć twojej twarzy"
+  },
+  "avc_uploading": {
+    "title": "Przesyłanie"
+  },
+  "country_select": {
+    "alert": {
+      "another_doc": "Dokumenty z tego kraju nie są obecnie obsługiwane - <fallback>spróbuj użyć innego typu dokumentu</fallback>"
     },
-    "avc_face_alignment": {
-        "feedback_move_back": "Odsuń się",
-        "feedback_move_closer": "Zbliż się do ekranu",
-        "feedback_no_face_detected": "Nie wykryto twarzy",
-        "feedback_not_centered": "Twarz nie wyśrodkowana",
-        "title": "Ustaw twarz w kadrze"
+    "alert_dropdown": {
+      "country_not_found": "Nie znaleziono kraju"
     },
-    "avc_face_capture": {
-        "alert": {
-            "timeout_body": "Masz maksymalnie 15 sekund na dokończenie nagrania",
-            "timeout_button_primary": "Ponów próbę",
-            "timeout_title": "Przepraszamy, musimy ponownie rozpocząć nagrywanie.",
-            "too_fast_body": "Spróbuj ponownie i tym razem wolniej obracaj głowę",
-            "too_fast_button_primary": "Ponów próbę",
-            "too_fast_title": "Obracasz głowę zbyt szybko"
-        },
-        "title": "Powoli obróć głowę w obie strony",
-        "title_completed": "Nagrywanie zakończone"
+    "button_primary": "Złóż dokument",
+    "poa_alert": {
+      "country_not_found": "Przepraszamy za to. Pracujemy nad wsparciem dla większej liczby krajów.",
+      "intro": "Nie możesz znaleźć swojego kraju?"
     },
-    "avc_intro": {
-        "button_primary_ready": "Gotowe",
-        "disclaimer": "Pamiętaj, że nagramy Twoją twarz razem z tłem",
-        "list_item_one": "Najpierw ustaw twarz w ramce",
-        "list_item_two": "Następnie powoli obróć głowę w obie strony",
-        "subtitle": "Ma to na celu sprawdzenie, czy naprawdę jesteś człowiekiem",
-        "title": "Nagraj wideo"
+    "search": {
+      "accessibility": "Wybierz kraj",
+      "input_placeholder": "np. Stany Zjednoczone",
+      "label": "Wyszukaj kraj"
     },
-    "avc_no_face_detected": {
-        "button_primary_restart": "Uruchom nagrywanie ponownie",
-        "list_item_eyes": "Upewnij się, że oczy są dobrze widoczne",
-        "list_item_face": "Upewnij się, że pokazujesz tylko swoją twarz, nie musimy widzieć Twojego dowodu tożsamości",
-        "list_item_lighting": "Upewnij się, że jesteś w miejscu z dobrym oświetleniem",
-        "list_item_mask": "Pamiętaj, aby zdjąć maski lub inne przedmioty zakrywające twarz. Okulary są akceptowane",
-        "title": "Nie możemy wykryć twojej twarzy"
+    "title": "Wybierz kraj wydania"
+  },
+  "cross_device_checklist": {
+    "button_primary": "Zgłoś weryfikację",
+    "info": "Porady",
+    "list_item_doc_multiple": "Dokumenty",
+    "list_item_doc_one": "Dokument",
+    "list_item_poa": "Potwierdzenie adresu zamieszkania",
+    "list_item_selfie": "Selfie",
+    "list_item_video": "Wideo",
+    "subtitle": "Oto wszystko, co przesłałeś:",
+    "title": "Ostatni krok"
+  },
+  "cross_device_error_desktop": {
+    "subtitle": "Łącze działa tylko na urządzeniach mobilnych",
+    "title": "Coś poszło nie tak"
+  },
+  "cross_device_error_restart": {
+    "subtitle": "Konieczne będzie ponowne uruchomienie weryfikacji na komputerze",
+    "title": "Coś poszło nie tak"
+  },
+  "cross_device_intro": {
+    "button_primary": "Pobierz bezpieczne łącze",
+    "list_accessibility": "Kroki wymagane do kontynuowania weryfikacji na telefonie komórkowym",
+    "list_item_finish": "Wróć tutaj, aby zakończyć przesyłanie",
+    "list_item_open_link": "Otwórz łącze i wykonaj zadania",
+    "list_item_send_phone": "Wyślij bezpieczne łącze na swój telefon",
+    "subtitle": "Oto jak to zrobić:",
+    "title": "Kontynuuj na telefonie"
+  },
+  "cross_device_return": {
+    "body": "Aktualizacja komputera może potrwać kilka sekund.",
+    "subtitle": "Teraz można powrócić do komputera i kontynuować pracę",
+    "title": "Udane przesyłanie plików"
+  },
+  "cross_device_session_linked": {
+    "button_primary": "Kontynuuj",
+    "info": "Sprawdź ponownie",
+    "list_item_desktop_open": "Okno pulpitu pozostaje otwarte",
+    "list_item_sent_by_you": "To łącze zostało wysłane przez Ciebie - jeśli uważasz, że to może być oszustwo, zwróć się o poradę",
+    "subtitle": "Kontynuuj weryfikację",
+    "title": "Sesja mobilna połączona z komputerem"
+  },
+  "doc_capture": {
+    "button_primary": "Rozpocznij skanowanie dokumentu",
+    "detail": {
+      "folded_doc_front": "Ułóż dokument płasko, także wszystkie wewnętrzne strony (muszą zawierać Twoje zdjęcie)"
     },
-    "avc_uploading": {
-        "title": "Przesyłanie"
+    "header_folded_doc_front": "Strona zdjęcia profilowego",
+    "prompt": {
+      "button_card": "Karta plastikowa",
+      "button_paper": "Dokument papierowy",
+      "title_id": "Jaki rodzaj dowodu osobistego posiadasz?",
+      "title_license": "Jaki rodzaj prawa jazdy posiadasz?"
+    }
+  },
+  "doc_confirmation": {
+    "alert": {
+      "blur_detail": "Upewnij się, że wszystko jest jasne",
+      "blur_title": "Wykryto nieostre zdjęcie",
+      "crop_detail": "Upewnij się, że widoczny jest cały dokument",
+      "crop_title": "Wykryto odcięty obraz",
+      "glare_detail": "Odsuń się od bezpośredniego źródła światła",
+      "glare_title": "Wykryte odblaski",
+      "no_doc_detail": "Upewnij się, że w pełni mieści się w ramce",
+      "no_doc_title": "Dokument nie został wykryty"
     },
-    "country_select": {
-        "alert": {
-            "another_doc": "Dokumenty z tego kraju nie są obecnie obsługiwane - <fallback>spróbuj użyć innego typu dokumentu<\/fallback>"
-        },
-        "alert_dropdown": {
-            "country_not_found": "Nie znaleziono kraju"
-        },
-        "button_primary": "Złóż dokument",
-        "poa_alert": {
-            "country_not_found": "Przepraszamy za to. Pracujemy nad wsparciem dla większej liczby krajów.",
-            "intro": "Nie możesz znaleźć swojego kraju?"
-        },
-        "search": {
-            "accessibility": "Wybierz kraj",
-            "input_placeholder": "np. Stany Zjednoczone",
-            "label": "Wyszukaj kraj"
-        },
-        "title": "Wybierz kraj wydania"
+    "body": "Upewnij się, że załadowana jest cała strona dokumentu, a szczegóły są czytelne, bez rozmyć i odblasków",
+    "body_bank_statement": "Upewnij się, że załadowana jest cała strona dokumentu, a szczegóły są czytelne, bez rozmyć i odblasków",
+    "body_benefits_letter": "Upewnij się, że załadowana jest cała strona dokumentu, a szczegóły są czytelne, bez rozmyć i odblasków",
+    "body_bill": "Upewnij się, że załadowana jest cała strona dokumentu, a szczegóły są czytelne, bez rozmyć i odblasków",
+    "body_id": "Upewnij się, że Twoje dane są wyraźne i niezasłonięte",
+    "body_image_medium": "Weryfikacja użytkownika będzie trwała dłużej, jeśli nie będziemy mogli go odczytać.",
+    "body_image_poor": "Aby sprawnie zweryfikować tożsamość, potrzebujemy lepszego zdjęcia",
+    "body_license": "Upewnij się, że Twoje dane są wyraźne i niezasłonięte",
+    "body_passport": "Upewnij się, że Twoje dane są wyraźne i niezasłonięte",
+    "body_permit": "Upewnij się, że Twoje dane są wyraźne i niezasłonięte",
+    "body_tax_letter": "Upewnij się, że załadowana jest cała strona dokumentu, a szczegóły są czytelne, bez rozmyć i odblasków",
+    "button_close": "Zamknij",
+    "button_primary_redo": "Ponów",
+    "button_primary_upload": "Prześlij",
+    "button_primary_upload_anyway": "Prześlij mimo wszystko",
+    "button_secondary_redo": "Ponów",
+    "button_zoom": "Powiększ obraz",
+    "image_accessibility": "Zdjęcie Twojego dokumentu",
+    "title": "Sprawdź obraz"
+  },
+  "doc_multi_frame_capture": {
+    "capture_progress_title": "Skanowanie dokumentu",
+    "instructions_title_back": "Umieść tylną stronę dokumentu w ramce",
+    "instructions_title_front": "Umieść przednią część dokumentu w ramce"
+  },
+  "doc_select": {
+    "button_bank_statement": "Wyciąg z banku lub spółdzielni budowlanej",
+    "button_bank_statement_non_uk": "Wyciąg bankowy",
+    "button_benefits_letter": "List dotyczący korzyści",
+    "button_benefits_letter_detail": "Zasiłki dla gospodarstw domowych zatwierdzone przez rząd, np. zasiłek dla poszukujących pracy, zasiłek mieszkaniowy, ulgi podatkowe",
+    "button_bill": "Rachunek za usługi komunalne",
+    "button_bill_detail": "Gaz, prąd, woda, telefon stacjonarny lub łącze szerokopasmowe",
+    "button_government_letter": "Pismo rządowe",
+    "button_government_letter_detail": "Wszelkie pisma wydawane przez rząd, np. pisma dotyczące świadczeń, głosowania, podatków itp.",
+    "button_id": "Dowód osobisty",
+    "button_id_detail": "Przód i tył",
+    "button_license": "Prawo jazdy",
+    "button_license_detail": "Przód i tył",
+    "button_passport": "Paszport",
+    "button_passport_detail": "Strona ze zdjęciem",
+    "button_permit": "Zezwolenie na pobyt",
+    "button_permit_detail": "Przód i tył",
+    "button_tax_letter": "List dotyczący podatku lokalnego",
+    "extra_estatements_ok": "Dokumenty elektroniczne są akceptowane",
+    "extra_no_mobile": "Niestety nie uwzględniamy rachunków za mobilne usługi telekomunikacyjne",
+    "list_accessibility": "Dokumenty, które można wykorzystać do weryfikacji tożsamości",
+    "pill": "najszybszy",
+    "section": {
+      "header_country": "Kraj wydania",
+      "header_doc_type": "Zaakceptowane dokumenty",
+      "input_country_not_found": "Brak wyników",
+      "input_placeholder_country": "Wybierz kraj wydania"
     },
-    "cross_device_checklist": {
-        "button_primary": "Zgłoś weryfikację",
-        "info": "Porady",
-        "list_item_doc_multiple": "Dokumenty",
-        "list_item_doc_one": "Dokument",
-        "list_item_poa": "Potwierdzenie adresu zamieszkania",
-        "list_item_selfie": "Selfie",
-        "list_item_video": "Wideo",
-        "subtitle": "Oto wszystko, co przesłałeś:",
-        "title": "Ostatni krok"
+    "subtitle": "Musi to być oficjalny dokument tożsamości ze zdjęciem",
+    "subtitle_country": "Wybierz kraj wydania, aby zobaczyć, jakie dokumenty akceptujemy",
+    "subtitle_entire_page": "Cała strona",
+    "subtitle_front_back": "Przód i tył",
+    "subtitle_photo_page": "Strona ze zdjęciem",
+    "subtitle_poa": "Są to dokumenty, które najprawdopodobniej pokazują Twój aktualny adres zamieszkania",
+    "title": "Wybierz swój dokument",
+    "title_poa": "Wybierz dokument z kraju %{country}"
+  },
+  "doc_submit": {
+    "button_link_upload": "lub prześlij zdjęcie — bez skanów i kserokopii",
+    "button_primary": "Kontynuuj na telefonie",
+    "subtitle": "Zrób zdjęcie telefonem",
+    "title_bank_statement": "Złóż dokument",
+    "title_benefits_letter": "Zgłoś list",
+    "title_bill": "Prześlij rachunek",
+    "title_government_letter": "Pismo rządowe",
+    "title_id_back": "Prześlij dowód osobisty (tył)",
+    "title_id_front": "Prześlij dowód tożsamości (przód)",
+    "title_license_back": "Prześlij dokument (tył)",
+    "title_license_front": "Prześlij dokument (przód)",
+    "title_passport": "Złóż stronę ze zdjęciem paszportowym",
+    "title_permit_back": "Złóż dokument pobytowy (z powrotem)",
+    "title_permit_front": "Przedłożyć dokument pobytowy (przedni)",
+    "title_tax_letter": "Prześlij list"
+  },
+  "doc_video_capture": {
+    "button_primary_fallback": "Następny krok",
+    "button_primary_fallback_end": "Zakończ nagrywanie",
+    "detail_step2": "Zachowuj pełną widoczność dokumentu przez cały czas",
+    "header": "Trzymając dokument w ręku, trzymaj przednią stronę w ramce.",
+    "header_paper_doc_step2": "Powoli odwróć dokument, aby pokazać zewnętrzne strony.",
+    "header_passport": "Trzymając paszport, umieść stronę ze zdjęciem w ramce",
+    "header_passport_progress": "Nie ruszaj się",
+    "header_step1": "Teraz nie ruszaj się",
+    "header_step2": "Powoli odwróć dokument, aby pokazać jego tylną stronę",
+    "prompt": {
+      "detail_timeout": "Czas nagrywania wideo jest ograniczony do <timeout></timeout> s. <fallback>Rozpocznij ponownie</fallback>"
     },
-    "cross_device_error_desktop": {
-        "subtitle": "Łącze działa tylko na urządzeniach mobilnych",
-        "title": "Coś poszło nie tak"
+    "stepper": "Krok <step></step> z <total></total>",
+    "success_accessibility": "Powodzenie!"
+  },
+  "doc_video_confirmation": {
+    "button_secondary": "Podgląd wideo",
+    "title": "Sprawdź swój film"
+  },
+  "error_unsupported_browser": {
+    "subtitle_android": "Uruchom ponownie proces w najnowszej wersji Google Chrome",
+    "subtitle_ios": "Uruchom ponownie proces w najnowszej wersji Safari",
+    "title_android": "Nieobsługiwana przeglądarka",
+    "title_ios": "Nieobsługiwana przeglądarka"
+  },
+  "generic": {
+    "accessibility": {
+      "close_sdk_screen": "Zamknij ekran weryfikacji tożsamości",
+      "dismiss_alert": "Usunięcie wpisu"
     },
-    "cross_device_error_restart": {
-        "subtitle": "Konieczne będzie ponowne uruchomienie weryfikacji na komputerze",
-        "title": "Coś poszło nie tak"
+    "back": "wstecz",
+    "close": "zamknij",
+    "errors": {
+      "expired_token": {
+        "instruction": "Spróbuj ponownie",
+        "message": "Twój token wygasł"
+      },
+      "geoblocked_error": {
+        "instruction": "Wygląda na to, że nie możemy kontynuować, ponieważ Twoja bieżąca lokalizacja nie jest obsługiwana",
+        "message": "Usługa niedostępna"
+      },
+      "interrupted_flow_error": {
+        "instruction": "Uruchom ponownie proces na innym urządzeniu",
+        "message": "Aparat nie został wykryty"
+      },
+      "invalid_size": {
+        "instruction": "Plik nie może przekraczać 10 MB",
+        "message": "Przekroczony rozmiar pliku."
+      },
+      "invalid_type": {
+        "instruction": "Spróbuj użyć innego typu pliku.",
+        "message": "Plik nie został przesłany."
+      },
+      "lazy_loading": {
+        "message": "Wystąpił błąd podczas ładowania komponentu"
+      },
+      "multiple_faces": {
+        "instruction": "Na selfie powinna być tylko Twoja twarz",
+        "message": "Znaleziono wiele twarzy"
+      },
+      "no_face": {
+        "instruction": "Upewnij się, że twoja twarz jest widoczna",
+        "message": "Nie wykryto twarzy"
+      },
+      "request_error": {
+        "instruction": "Spróbuj ponownie",
+        "message": "Coś poszło nie tak"
+      },
+      "sms_failed": {
+        "instruction": "Skopiuj łącze do telefonu",
+        "message": "Coś poszło nie tak"
+      },
+      "sms_overuse": {
+        "instruction": "Skopiuj łącze do telefonu",
+        "message": "Zbyt wiele nieudanych prób"
+      },
+      "unsupported_file": {
+        "instruction": "Spróbuj użyć pliku JPG lub PNG",
+        "message": "Nieobsługiwany typ pliku"
+      }
     },
-    "cross_device_intro": {
-        "button_primary": "Pobierz bezpieczne łącze",
-        "list_accessibility": "Kroki wymagane do kontynuowania weryfikacji na telefonie komórkowym",
-        "list_item_finish": "Wróć tutaj, aby zakończyć przesyłanie",
-        "list_item_open_link": "Otwórz łącze i wykonaj zadania",
-        "list_item_send_phone": "Wyślij bezpieczne łącze na swój telefon",
-        "subtitle": "Oto jak to zrobić:",
-        "title": "Kontynuuj na telefonie"
-    },
-    "cross_device_return": {
-        "body": "Aktualizacja komputera może potrwać kilka sekund.",
-        "subtitle": "Teraz można powrócić do komputera i kontynuować pracę",
-        "title": "Udane przesyłanie plików"
-    },
-    "cross_device_session_linked": {
-        "button_primary": "Kontynuuj",
-        "info": "Sprawdź ponownie",
-        "list_item_desktop_open": "Okno pulpitu pozostaje otwarte",
-        "list_item_sent_by_you": "To łącze zostało wysłane przez Ciebie - jeśli uważasz, że to może być oszustwo, zwróć się o poradę",
-        "subtitle": "Kontynuuj weryfikację",
-        "title": "Sesja mobilna połączona z komputerem"
-    },
-    "doc_capture": {
-        "button_primary": "Rozpocznij skanowanie dokumentu",
-        "detail": {
-            "folded_doc_front": "Ułóż dokument płasko, także wszystkie wewnętrzne strony (muszą zawierać Twoje zdjęcie)"
-        },
-        "header_folded_doc_front": "Strona zdjęcia profilowego",
-        "prompt": {
-            "button_card": "Karta plastikowa",
-            "button_paper": "Dokument papierowy",
-            "title_id": "Jaki rodzaj dowodu osobistego posiadasz?",
-            "title_license": "Jaki rodzaj prawa jazdy posiadasz?"
-        }
-    },
-    "doc_confirmation": {
-        "alert": {
-            "blur_detail": "Upewnij się, że wszystko jest jasne",
-            "blur_title": "Wykryto nieostre zdjęcie",
-            "crop_detail": "Upewnij się, że widoczny jest cały dokument",
-            "crop_title": "Wykryto odcięty obraz",
-            "glare_detail": "Odsuń się od bezpośredniego źródła światła",
-            "glare_title": "Wykryte odblaski",
-            "no_doc_detail": "Upewnij się, że w pełni mieści się w ramce",
-            "no_doc_title": "Dokument nie został wykryty"
-        },
-        "body": "Upewnij się, że załadowana jest cała strona dokumentu, a szczegóły są czytelne, bez rozmyć i odblasków",
-        "body_bank_statement": "Upewnij się, że załadowana jest cała strona dokumentu, a szczegóły są czytelne, bez rozmyć i odblasków",
-        "body_benefits_letter": "Upewnij się, że załadowana jest cała strona dokumentu, a szczegóły są czytelne, bez rozmyć i odblasków",
-        "body_bill": "Upewnij się, że załadowana jest cała strona dokumentu, a szczegóły są czytelne, bez rozmyć i odblasków",
-        "body_id": "Upewnij się, że Twoje dane są wyraźne i niezasłonięte",
-        "body_image_medium": "Weryfikacja użytkownika będzie trwała dłużej, jeśli nie będziemy mogli go odczytać.",
-        "body_image_poor": "Aby sprawnie zweryfikować tożsamość, potrzebujemy lepszego zdjęcia",
-        "body_license": "Upewnij się, że Twoje dane są wyraźne i niezasłonięte",
-        "body_passport": "Upewnij się, że Twoje dane są wyraźne i niezasłonięte",
-        "body_permit": "Upewnij się, że Twoje dane są wyraźne i niezasłonięte",
-        "body_tax_letter": "Upewnij się, że załadowana jest cała strona dokumentu, a szczegóły są czytelne, bez rozmyć i odblasków",
-        "button_close": "Zamknij",
-        "button_primary_redo": "Ponów",
-        "button_primary_upload": "Prześlij",
-        "button_primary_upload_anyway": "Prześlij mimo wszystko",
-        "button_secondary_redo": "Ponów",
-        "button_zoom": "Powiększ obraz",
-        "image_accessibility": "Zdjęcie Twojego dokumentu",
-        "title": "Sprawdź obraz"
-    },
-    "doc_multi_frame_capture": {
-        "capture_progress_title": "Skanowanie dokumentu",
-        "instructions_title_back": "Umieść tylną stronę dokumentu w ramce",
-        "instructions_title_front": "Umieść przednią część dokumentu w ramce"
-    },
-    "doc_select": {
-        "button_bank_statement": "Wyciąg z banku lub spółdzielni budowlanej",
-        "button_bank_statement_non_uk": "Wyciąg bankowy",
-        "button_benefits_letter": "List dotyczący korzyści",
-        "button_benefits_letter_detail": "Zasiłki dla gospodarstw domowych zatwierdzone przez rząd, np. zasiłek dla poszukujących pracy, zasiłek mieszkaniowy, ulgi podatkowe",
-        "button_bill": "Rachunek za usługi komunalne",
-        "button_bill_detail": "Gaz, prąd, woda, telefon stacjonarny lub łącze szerokopasmowe",
-        "button_government_letter": "Pismo rządowe",
-        "button_government_letter_detail": "Wszelkie pisma wydawane przez rząd, np. pisma dotyczące świadczeń, głosowania, podatków itp.",
-        "button_id": "Dowód osobisty",
-        "button_id_detail": "Przód i tył",
-        "button_license": "Prawo jazdy",
-        "button_license_detail": "Przód i tył",
-        "button_passport": "Paszport",
-        "button_passport_detail": "Strona ze zdjęciem",
-        "button_permit": "Zezwolenie na pobyt",
-        "button_permit_detail": "Przód i tył",
-        "button_tax_letter": "List dotyczący podatku lokalnego",
-        "extra_estatements_ok": "Dokumenty elektroniczne są akceptowane",
-        "extra_no_mobile": "Niestety nie uwzględniamy rachunków za mobilne usługi telekomunikacyjne",
-        "list_accessibility": "Dokumenty, które można wykorzystać do weryfikacji tożsamości",
-        "pill": "najszybszy",
-        "section": {
-            "header_country": "Kraj wydania",
-            "header_doc_type": "Zaakceptowane dokumenty",
-            "input_country_not_found": "Brak wyników",
-            "input_placeholder_country": "Wybierz kraj wydania"
-        },
-        "subtitle": "Musi to być oficjalny dokument tożsamości ze zdjęciem",
-        "subtitle_country": "Wybierz kraj wydania, aby zobaczyć, jakie dokumenty akceptujemy",
-        "subtitle_entire_page": "Cała strona",
-        "subtitle_front_back": "Przód i tył",
-        "subtitle_photo_page": "Strona ze zdjęciem",
-        "subtitle_poa": "Są to dokumenty, które najprawdopodobniej pokazują Twój aktualny adres zamieszkania",
-        "title": "Wybierz swój dokument",
-        "title_poa": "Wybierz dokument z kraju %{country}"
-    },
-    "doc_submit": {
-        "button_link_upload": "lub prześlij zdjęcie — bez skanów i kserokopii",
-        "button_primary": "Kontynuuj na telefonie",
-        "subtitle": "Zrób zdjęcie telefonem",
-        "title_bank_statement": "Złóż dokument",
-        "title_benefits_letter": "Zgłoś list",
-        "title_bill": "Prześlij rachunek",
-        "title_government_letter": "Pismo rządowe",
-        "title_id_back": "Prześlij dowód osobisty (tył)",
-        "title_id_front": "Prześlij dowód tożsamości (przód)",
-        "title_license_back": "Prześlij dokument (tył)",
-        "title_license_front": "Prześlij dokument (przód)",
-        "title_passport": "Złóż stronę ze zdjęciem paszportowym",
-        "title_permit_back": "Złóż dokument pobytowy (z powrotem)",
-        "title_permit_front": "Przedłożyć dokument pobytowy (przedni)",
-        "title_tax_letter": "Prześlij list"
-    },
-    "doc_video_capture": {
-        "button_primary_fallback": "Następny krok",
-        "button_primary_fallback_end": "Zakończ nagrywanie",
-        "detail_step2": "Zachowuj pełną widoczność dokumentu przez cały czas",
-        "header": "Trzymając dokument w ręku, trzymaj przednią stronę w ramce.",
-        "header_paper_doc_step2": "Powoli odwróć dokument, aby pokazać zewnętrzne strony.",
-        "header_passport": "Trzymając paszport, umieść stronę ze zdjęciem w ramce",
-        "header_passport_progress": "Nie ruszaj się",
-        "header_step1": "Teraz nie ruszaj się",
-        "header_step2": "Powoli odwróć dokument, aby pokazać jego tylną stronę",
-        "prompt": {
-            "detail_timeout": "Czas nagrywania wideo jest ograniczony do <timeout><\/timeout> s. <fallback>Rozpocznij ponownie<\/fallback>"
-        },
-        "stepper": "Krok <step><\/step> z <total><\/total>",
-        "success_accessibility": "Powodzenie!"
-    },
-    "doc_video_confirmation": {
-        "button_secondary": "Podgląd wideo",
-        "title": "Sprawdź swój film"
-    },
-    "error_unsupported_browser": {
-        "subtitle_android": "Uruchom ponownie proces w najnowszej wersji Google Chrome",
-        "subtitle_ios": "Uruchom ponownie proces w najnowszej wersji Safari",
-        "title_android": "Nieobsługiwana przeglądarka",
-        "title_ios": "Nieobsługiwana przeglądarka"
-    },
-    "generic": {
-        "accessibility": {
-            "close_sdk_screen": "Zamknij ekran weryfikacji tożsamości",
-            "dismiss_alert": "Usunięcie wpisu"
-        },
-        "back": "wstecz",
-        "close": "zamknij",
-        "errors": {
-            "expired_token": {
-                "instruction": "Spróbuj ponownie",
-                "message": "Twój token wygasł"
-            },
-            "geoblocked_error": {
-                "instruction": "Wygląda na to, że nie możemy kontynuować, ponieważ Twoja bieżąca lokalizacja nie jest obsługiwana",
-                "message": "Usługa niedostępna"
-            },
-            "interrupted_flow_error": {
-                "instruction": "Uruchom ponownie proces na innym urządzeniu",
-                "message": "Aparat nie został wykryty"
-            },
-            "invalid_size": {
-                "instruction": "Plik nie może przekraczać 10 MB",
-                "message": "Przekroczony rozmiar pliku."
-            },
-            "invalid_type": {
-                "instruction": "Spróbuj użyć innego typu pliku.",
-                "message": "Plik nie został przesłany."
-            },
-            "lazy_loading": {
-                "message": "Wystąpił błąd podczas ładowania komponentu"
-            },
-            "multiple_faces": {
-                "instruction": "Na selfie powinna być tylko Twoja twarz",
-                "message": "Znaleziono wiele twarzy"
-            },
-            "no_face": {
-                "instruction": "Upewnij się, że twoja twarz jest widoczna",
-                "message": "Nie wykryto twarzy"
-            },
-            "request_error": {
-                "instruction": "Spróbuj ponownie",
-                "message": "Coś poszło nie tak"
-            },
-            "sms_failed": {
-                "instruction": "Skopiuj łącze do telefonu",
-                "message": "Coś poszło nie tak"
-            },
-            "sms_overuse": {
-                "instruction": "Skopiuj łącze do telefonu",
-                "message": "Zbyt wiele nieudanych prób"
-            },
-            "unsupported_file": {
-                "instruction": "Spróbuj użyć pliku JPG lub PNG",
-                "message": "Nieobsługiwany typ pliku"
-            }
-        },
-        "lazy_load_placeholder": "Ładowanie...",
-        "loading": "Ładowanie"
-    },
-    "get_link": {
-        "alert_wrong_number": "Sprawdź, czy Twój numer jest poprawny",
-        "button_copied": "Skopiowano",
-        "button_copy": "Kopia",
-        "button_submit": "Wyślij łącze",
-        "info_qr_how": "Jak zeskanować kod QR",
-        "info_qr_how_list_item_camera": "Skieruj aparat telefonu na kod QR",
-        "info_qr_how_list_item_download": "Jeśli to nie zadziała, pobierz skaner kodów QR z Google Play lub App Store",
-        "link_divider": "lub wybrać metodę alternatywną",
-        "link_qr": "Zeskanuj kod QR",
-        "link_sms": "Pobierz łącze przez SMS",
-        "link_url": "Link do kopiowania",
-        "loader_sending": "Wysyłanie",
-        "number_field_input_placeholder": "Wpisz numer telefonu komórkowego",
-        "number_field_label": "Wpisz swój numer telefonu komórkowego:",
-        "subtitle_qr": "Zeskanuj kod QR za pomocą telefonu",
-        "subtitle_sms": "Wyślij to jednorazowe łącze na swój telefon",
-        "subtitle_url": "Wyślij to jednorazowe łącze na swój telefon",
-        "title": "Uzyskaj bezpieczne łącze",
-        "url_field_label": "Skopiuj łącze do przeglądarki mobilnej"
-    },
-    "livenessV2": {
-        "error_reload_instructions": "Uruchom ponownie instrukcję",
-        "intro_note_no1": "Najpierw ustaw twarz w ramce",
-        "intro_note_no2": "Następnie powoli obróć głowę w obie strony",
-        "intro_ready_button": "Pamiętaj, że nagramy Twoją twarz razem z tłem",
-        "intro_subtitle": "Ma to na celu sprawdzenie, czy naprawdę jesteś człowiekiem",
-        "intro_warning": "Pamiętaj, że nagramy Twoją twarz razem z tłem",
-        "success_main_button": "Prześlij do weryfikacji",
-        "success_title": "To wszystko, czego potrzebujemy, aby zacząć weryfikować Twoją tożsamość"
-    },
-    "mobilePhrases": {
-        "photo_upload": {
-            "body_id_back": "Zrób zdjęcie tylnej strony karty",
-            "body_id_front": "Zrób zdjęcie awersu karty",
-            "body_license_back": "Zrób zdjęcie odwrotnej strony swojego prawa jazdy",
-            "body_license_front": "Zrób zdjęcie przedniej strony prawa jazdy",
-            "body_passport": "Zrób zdjęcie strony ze zdjęciem paszportowym",
-            "body_selfie": "Zrób selfie pokazujące Twoją twarz"
-        },
-        "selfie_capture": {
-            "alert": {
-                "camera_inactive": {
-                    "detail": "Zamiast tego wykonaj zdjęcie, korzystając z <fallback>podstawowego trybu pracy aparatu<\/fallback> "
-                },
-                "camera_not_working": {
-                    "detail": "Zamiast tego wykonaj zdjęcie, korzystając z <fallback>podstawowego trybu pracy aparatu<\/fallback> "
-                }
-            }
-        },
-        "upload_guide": {
-            "button_primary": "Zrób zdjęcie",
-            "title": "Prześlij stronę ze zdjęciem paszportowym"
-        }
-    },
-    "outro": {
-        "body": "To wszystko, czego potrzebujemy, aby rozpocząć weryfikację Twojej tożsamości",
-        "body_government_letter": "Podaj całą stronę dokumentu, aby uzyskać najlepsze wyniki",
-        "title": "Dziękuję"
-    },
-    "permission": {
-        "body_both": "Nie możemy dokonać weryfikacji bez użycia aparatu ani mikrofonu",
-        "body_cam": "Nie możemy Cię zweryfikować bez użycia aparatu",
-        "button_primary_both": "Włącz oba",
-        "button_primary_cam": "Włącz aparat",
-        "subtitle_both": "Po wyświetleniu monitu, aby kontynuować, włączyć dostęp do obu urządzeń",
-        "subtitle_cam": "Aby kontynuować, po wyświetleniu monitu należy włączyć dostęp do aparatu",
-        "title_both": "Zezwól na dostęp do kamery i mikrofonu",
-        "title_cam": "Zezwól na dostęp do aparatu"
-    },
-    "permission_recovery": {
-        "button_primary": "Odśwież",
-        "info": "Przywróć",
-        "list_header_both": "Wykonaj poniższe kroki, aby przywrócić dostęp do obu urządzeń:",
-        "list_header_cam": "Wykonaj poniższe kroki, aby przywrócić dostęp do aparatu:",
-        "list_item_action_cam": "Odśwież tę stronę, aby ponownie rozpocząć proces weryfikacji tożsamości",
-        "list_item_how_to_both": "Udziel dostępu do aparatu i mikrofonu w ustawieniach przeglądarki",
-        "list_item_how_to_cam": "Zezwalaj na dostęp do aparatu w ustawieniach przeglądarki",
-        "subtitle_both": "Odzyskaj dostęp do aparatu i mikrofonu, aby nagrać film i zakończyć proces weryfikacji",
-        "subtitle_cam": "Przywróć dostęp do aparatu, aby kontynuować weryfikację",
-        "subtitle_cam_old": "Odzyskaj dostęp do aparatu, aby kontynuować weryfikację twarzy",
-        "title_both": "Odmowa dostępu do aparatu i mikrofonu",
-        "title_cam": "Odmowa dostępu do aparatu"
-    },
+    "lazy_load_placeholder": "Ładowanie...",
+    "loading": "Ładowanie"
+  },
+  "get_link": {
+    "alert_wrong_number": "Sprawdź, czy Twój numer jest poprawny",
+    "button_copied": "Skopiowano",
+    "button_copy": "Kopia",
+    "button_submit": "Wyślij łącze",
+    "info_qr_how": "Jak zeskanować kod QR",
+    "info_qr_how_list_item_camera": "Skieruj aparat telefonu na kod QR",
+    "info_qr_how_list_item_download": "Jeśli to nie zadziała, pobierz skaner kodów QR z Google Play lub App Store",
+    "link_divider": "lub wybrać metodę alternatywną",
+    "link_qr": "Zeskanuj kod QR",
+    "link_sms": "Pobierz łącze przez SMS",
+    "link_url": "Link do kopiowania",
+    "loader_sending": "Wysyłanie",
+    "number_field_input_placeholder": "Wpisz numer telefonu komórkowego",
+    "number_field_label": "Wpisz swój numer telefonu komórkowego:",
+    "subtitle_qr": "Zeskanuj kod QR za pomocą telefonu",
+    "subtitle_sms": "Wyślij to jednorazowe łącze na swój telefon",
+    "subtitle_url": "Wyślij to jednorazowe łącze na swój telefon",
+    "title": "Uzyskaj bezpieczne łącze",
+    "url_field_label": "Skopiuj łącze do przeglądarki mobilnej"
+  },
+  "livenessV2": {
+    "error_reload_instructions": "Uruchom ponownie instrukcję",
+    "intro_note_no1": "Najpierw ustaw twarz w ramce",
+    "intro_note_no2": "Następnie powoli obróć głowę w obie strony",
+    "intro_ready_button": "Pamiętaj, że nagramy Twoją twarz razem z tłem",
+    "intro_subtitle": "Ma to na celu sprawdzenie, czy naprawdę jesteś człowiekiem",
+    "intro_warning": "Pamiętaj, że nagramy Twoją twarz razem z tłem",
+    "success_main_button": "Prześlij do weryfikacji",
+    "success_title": "To wszystko, czego potrzebujemy, aby zacząć weryfikować Twoją tożsamość"
+  },
+  "mobilePhrases": {
     "photo_upload": {
-        "body_bank_statement": "Podaj całą stronę dokumentu, aby uzyskać najlepsze wyniki",
-        "body_benefits_letter": "Podaj całą stronę dokumentu, aby uzyskać najlepsze wyniki",
-        "body_bill": "Podaj całą stronę dokumentu, aby uzyskać najlepsze wyniki",
-        "body_id_back": "Prześlij z komputera zdjęcie tylnej strony karty",
-        "body_id_front": "Prześlij przód karty z komputera",
-        "body_license_back": "Prześlij tylną stronę dokumentu ze swojego komputera",
-        "body_license_front": "Prześlij przednią stronę dokumentu z komputera",
-        "body_passport": "Prześlij stronę paszportu ze zdjęciem z komputera",
-        "body_selfie": "Prześlij zdjęcie z komputera",
-        "body_tax_letter": "Podaj całą stronę dokumentu, aby uzyskać najlepsze wyniki",
-        "button_take_photo": "Zrobić zdjęcie",
-        "button_upload": "Prześlij",
-        "title_selfie": "Selfie"
-    },
-    "poa_cancel": "Anuluj",
-    "poa_err_invalid_file": {
-        "message": "Wybierz inny plik.",
-        "ok": "OK",
-        "title": "Nieprawidłowy plik"
-    },
-    "poa_guidance": {
-        "button_primary": "Kontynuuj",
-        "instructions": {
-            "address": "Aktualny adres",
-            "full_name": "Imię i nazwisko",
-            "issue_date": "Data wydania lub okres podsumowania",
-            "label": "Uchwyć cały dokument i upewnij się, że jest on wyraźnie widoczny:",
-            "logo": "Logo"
-        },
-        "subtitle_bank_statement": "Musi być wydany w ciągu <strong>ostatnich 3 miesięcy<\/strong>",
-        "subtitle_benefits_letter": "Musi być wydany w ciągu <strong>ostatnich 12 miesięcy<\/strong>",
-        "subtitle_bill": "Data wydania musi mieścić się w okresie <strong>ostatnich 3 miesięcy<\/strong>",
-        "subtitle_tax_letter": "Musi być wydany w ciągu <strong>ostatnich 12 miesięcy<\/strong>"
-    },
-    "poa_intro": {
-        "button_primary": "Rozpocznij weryfikację",
-        "list_matches_signup": "zawiera adres <strong>zgodny<\/strong> z adresem, który został użyty podczas rejestracji",
-        "list_most_recent": "Czy Twój <strong> najnowszy <\/strong> dokument",
-        "list_shows_address": "zawiera <strong>aktualny<\/strong> adres",
-        "subtitle": "Potrzebny będzie dokument, który:",
-        "title": "Teraz zweryfikujmy Twój adres"
-    },
-    "profile_data": {
-        "address_title": "Dodaj swój adres",
-        "button_continue": "Kontynuuj",
-        "components": {
-            "country_select": {
-                "placeholder": "Wybierz kraj"
-            },
-            "nationality_select": {
-                "placeholder": "Wybierz kraj"
-            },
-            "pan": {
-                "placeholder": "ABCDE1234F"
-            },
-            "ssn": {
-                "placeholder": "123-45-6789"
-            },
-            "state_select": {
-                "placeholder": "Wybierz stan"
-            }
-        },
-        "country_of_residence_title": "Twój kraj zamieszkania",
-        "field_labels": {
-            "country": "Kraj",
-            "dob": "Data urodzenia",
-            "email": "E-mail",
-            "first_name": "Imię",
-            "gbr_specific": {
-                "postcode": "Kod pocztowy",
-                "town": "Miejscowość"
-            },
-            "last_name": "Nazwisko",
-            "line1": "Linia adresu 1",
-            "line2": "Linia adresu 2",
-            "line3": "Linia adresowa 3",
-            "mobile_number": "Numer telefonu komórkowego",
-            "nationality": "Narodowość",
-            "pan": "Stały numer konta (PAN)",
-            "postcode": "Kod pocztowy",
-            "ssn": "Numer ubezpieczenia społecznego (SSN)",
-            "town": "Miejscowość",
-            "usa_specific": {
-                "line1_helper_text": "Adres, na przykład: ul. Alberta 200",
-                "line2_helper_text": "Nr mieszkania, apartamentu, jednostki itp.",
-                "postcode": "Kod pocztowy",
-                "state": "Stan"
-            }
-        },
-        "field_optional": "(opcjonalnie)",
-        "field_validation": {
-            "gbr_specific": {
-                "required_postcode": "Wprowadź swój kod pocztowy",
-                "too_long_postcode": "Kod pocztowy jest zbyt długi",
-                "too_short_postcode": "Kod pocztowy jest zbyt krótki"
-            },
-            "invalid": "Sprawdź, czy w polu nie ma nieprawidłowych znaków lub symboli",
-            "invalid_dob": "Wprowadź prawidłową datę urodzenia",
-            "required_country": "Wybierz kraj",
-            "required_dob": "Wpisz swoją datę urodzenia",
-            "required_email": "Podaj swój adres e-mail",
-            "required_first_name": "Wpisz swoje imię",
-            "required_last_name": "Wpisz swoje nazwisko",
-            "required_line1": "Wpisz adres",
-            "required_mobile_number": "Podaj numer telefonu komórkowego",
-            "required_nationality": "Wybierz kraj",
-            "required_pan": "Podaj swój PAN",
-            "required_postcode": "Wprowadź swój kod pocztowy",
-            "required_ssn": "Podaj swój numer SSN",
-            "too_long__line1": "Wprowadzony adres jest zbyt długi",
-            "too_long_first_name": "Imię jest zbyt długie",
-            "too_long_last_name": "Nazwisko jest zbyt długie",
-            "too_long_postcode": "Kod pocztowy jest zbyt długi",
-            "too_long_town": "Nazwa miejscowości jest zbyt długa",
-            "too_short_first_name": "Imię jest zbyt krótkie",
-            "too_short_last_name": "Nazwisko jest zbyt krótkie",
-            "too_short_postcode": "Kod pocztowy jest zbyt krótki",
-            "usa_specific": {
-                "required_state": "Wybierz stan"
-            },
-            "valid_email": "Podaj poprawny adres e-mail",
-            "valid_mobile_number": "Podaj prawidłowy numer telefonu komórkowego",
-            "valid_pan": "Podaj prawidłowy PAN",
-            "valid_ssn": "Podaj prawidłowy numer SSN"
-        },
-        "personal_information_title": "Dodaj swoje dane osobowe",
-        "prompt": {
-            "details_timeout": "Rozpocznij ponownie",
-            "header_timeout": "Działania zajęły zbyt wiele czasu."
-        }
-    },
-    "retry_feedback": {
-        "button_primary": "Spróbuj ponownie"
-    },
-    "retry_feedback_id_expired": {
-        "subtitle": "Spróbuj ponownie z ważnym dokumentem tożsamości ze zdjęciem i upewnij się, że Twoje dane są wyraźnie widoczne",
-        "title": "Twój dokument stracił ważność"
-    },
-    "retry_feedback_id_generic": {
-        "subtitle": "Spróbuj ponownie z ważnym dokumentem tożsamości ze zdjęciem i upewnij się, że Twoje dane są wyraźnie widoczne",
-        "title": "Wystąpił problem z Twoim dokumentem"
-    },
-    "retry_feedback_id_unaccepted": {
-        "subtitle": "Spróbuj ponownie z ważnym dokumentem tożsamości ze zdjęciem i upewnij się, że Twoje dane są wyraźnie widoczne",
-        "title": "Dokument nie został zaakceptowany"
-    },
-    "retry_feedback_selfie_generic": {
-        "subtitle": "Spróbuj ponownie i upewnij się, że twarz jest widoczna i dobrze oświetlona.",
-        "title": "Wystąpił problem z selfie"
+      "body_id_back": "Zrób zdjęcie tylnej strony karty",
+      "body_id_front": "Zrób zdjęcie awersu karty",
+      "body_license_back": "Zrób zdjęcie odwrotnej strony swojego prawa jazdy",
+      "body_license_front": "Zrób zdjęcie przedniej strony prawa jazdy",
+      "body_passport": "Zrób zdjęcie strony ze zdjęciem paszportowym",
+      "body_selfie": "Zrób selfie pokazujące Twoją twarz"
     },
     "selfie_capture": {
-        "alert": {
-            "camera_inactive": {
-                "detail": "Sprawdź, czy urządzenie jest podłączone i działa. Możesz również <fallback>kontynuować weryfikację w telefonie<\/fallback>",
-                "detail_no_fallback": "Upewnij się, że Twoje urządzenie ma sprawny aparat fotograficzny",
-                "title": "Aparat nie działa?"
-            },
-            "camera_not_working": {
-                "detail": "Urządzenie może być odłączone. <fallback>Spróbuj skorzystać z telefonu<\/fallback>.",
-                "detail_no_fallback": "Upewnij się, że aparat w urządzeniu działa",
-                "title": "Aparat nie działa"
-            },
-            "timeout": {
-                "detail": "Pamiętaj, aby po zakończeniu pracy nacisnąć przycisk. <fallback>Ponowienie czynności dotyczących wideo<\/fallback>",
-                "title": "Wygląda na to, że trwało to zbyt długo"
-            }
+      "alert": {
+        "camera_inactive": {
+          "detail": "Zamiast tego wykonaj zdjęcie, korzystając z <fallback>podstawowego trybu pracy aparatu</fallback> "
         },
-        "body": "Trzymaj twarz w obrębie owalu",
-        "button_accessibility": "",
-        "button_primary": "Rozpocznij skanowanie twarzy",
-        "frame_accessibility": "Widok z aparatu",
-        "title": "Trzymaj twarz w obrębie owalu"
-    },
-    "selfie_confirmation": {
-        "image_accessibility": "Zdjęcie Twojej twarzy",
-        "subtitle": "Upewnij się, że cała twarz jest widoczna",
-        "title": "Sprawdź selfie"
-    },
-    "selfie_intro": {
-        "button_primary": "Kontynuuj",
-        "list_accessibility": "Wskazówki, jak zrobić dobre selfie",
-        "list_item_face_forward": "Ustaw się twarzą na wprost i upewnij się, że oczy są dobrze widoczne.",
-        "list_item_no_glasses": "Zdejmij okulary, jeśli to konieczne",
-        "subtitle": "Porównamy zdjęcie z dokumentem",
-        "title": "Zrób sobie selfie"
-    },
-    "sms_sent": {
-        "info": "Porady",
-        "info_link_expire": "Twój link wygaśnie za godzinę",
-        "info_link_window": "Pozostaw to okno otwarte podczas korzystania z telefonu komórkowego",
-        "link": "Wyślij ponownie łącze",
-        "subtitle": "Wysłaliśmy bezpieczne łącze na numer %{number}",
-        "subtitle_minutes": "Przyjazd może potrwać kilka minut.",
-        "title": "Sprawdź telefon komórkowy"
-    },
-    "switch_phone": {
-        "info": "Porady",
-        "info_link_expire": "Twoje mobilne łącze wygaśnie za godzinę.",
-        "info_link_refresh": "Nie odświeżaj tej strony",
-        "info_link_window": "Pozostaw to okno otwarte podczas korzystania z telefonu komórkowego",
-        "link": "Anuluj",
-        "subtitle": "Po zakończeniu przejdziemy do następnego kroku",
-        "title": "Połączono z telefonem komórkowym"
+        "camera_not_working": {
+          "detail": "Zamiast tego wykonaj zdjęcie, korzystając z <fallback>podstawowego trybu pracy aparatu</fallback> "
+        }
+      }
     },
     "upload_guide": {
-        "button_primary": "Prześlij zdjęcie",
-        "image_detail_blur_alt": "Przykład dokumentu z zamazanym obrazem",
-        "image_detail_blur_label": "Wszystkie szczegóły muszą być wyraźne — nic nie może być zamazane",
-        "image_detail_cutoff_label": "Pokaż wszystkie szczegóły — w tym dolne 2 linie",
-        "image_detail_glare_label": "Odsuń się od bezpośredniego światła — bez odbłysków",
-        "image_detail_good_label": "Na zdjęciu powinien być wyraźnie widoczny dokument",
-        "subtitle": "Skany i kserokopie nie są akceptowane.",
-        "title": "Prześlij stronę ze zdjęciem paszportowym"
-    },
-    "user_consent": {
-        "button_primary": "Accept",
-        "button_secondary": "Do not accept",
-        "prompt": {
-            "button_primary": "Review again",
-            "button_secondary": "Yes, don’t verify me",
-            "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
-            "no_consent_title": "Are you sure?"
-        }
-    },
-    "user_consent_load_fail": {
-        "button_primary": "Reload screen",
-        "detail": "Check that your connection is stable, then try again",
-        "title": "Content failed to load"
-    },
-    "video_capture": {
-        "body": "Trzymaj twarz w obrębie owalu",
-        "body_record": "Naciśnij przycisk, gdy będziesz gotowy(-a)",
-        "body_stop": "Naciśnij przycisk Stop, gdy skończysz",
-        "button_primary_finish": "Zakończ nagrywanie",
-        "button_primary_next": "Następny krok",
-        "button_primary_start": "Rozpocznij nagrywanie",
-        "button_record_accessibility": "Rozpocznij nagrywanie",
-        "frame_accessibility": "Widok z aparatu",
-        "header": {
-            "challenge_digit_instructions": "Wypowiedz na głos każdą cyfrę",
-            "challenge_turn_forward": "skieruj się twarzą do przodu",
-            "challenge_turn_left": "Obróć głowę w lewo",
-            "challenge_turn_right": "Obróć głowę w prawo"
-        },
-        "prompt": {
-            "header_timeout": "Wygląda na to, że trwało to zbyt długo"
-        }
-    },
-    "video_confirmation": {
-        "body": "Twój film został nagrany",
-        "button_primary": "Prześlij wideo",
-        "button_secondary": "Ponownie nagraj wideo",
-        "title": "Sprawdź swój film",
-        "video_accessibility": "Odtwarzanie nagranych filmów wideo"
-    },
-    "video_intro": {
-        "button_primary": "Nagrywanie wideo",
-        "list_accessibility": "Czynności związane z nagrywaniem wideo selfie",
-        "list_item_actions": "Masz 20 sekund na dokończenie",
-        "list_item_speak": "Postępuj zgodnie z instrukcjami, aby się poruszać lub mówić",
-        "title": "Nagraj wideo"
-    },
-    "welcome": {
-        "doc_video_subtitle": "",
-        "list_header_doc_video": "Użyj urządzenia do nagrywania:",
-        "list_header_webcam": "Użyj kamery internetowej lub telefonu do robienia zdjęć:",
-        "list_item_doc": "Twój dokument tożsamości",
-        "list_item_doc_video_timeout": "Czas nagrywania jest ograniczony do <timeout><\/timeout> s.",
-        "list_item_poa": "dokument potwierdzający adres zamieszkania",
-        "list_item_selfie": "Twoja twarz",
-        "next_button": "Wybierz dokument",
-        "start_workflow_button": "Rozpocznij weryfikację",
-        "subtitle": "Powinno to zająć kilka minut.",
-        "title": "Zweryfikuj swoją tożsamość"
-    },
-    "workflow_complete": {
-        "pass": {
-            "description": "Udało nam się pomyślnie zweryfikować Twoją tożsamość",
-            "title": "Przyjęto"
-        },
-        "reject": {
-            "description": "Nie udało nam się zweryfikować Twojej tożsamości",
-            "title": "Odrzucono"
-        }
-    },
-    "workflow_erros": {
-        "generic_title": "Wystąpił błąd serwera!",
-        "no_workflow_run_id": "Identyfikator przepływu pracy nie jest ustawiony.",
-        "reload_app": "Spróbuj ponownie załadować aplikację i spróbuj jeszcze raz.",
-        "task_not_completed": "Nie udało się ukończyć zadania z przepływu pracy.",
-        "task_not_retrieved": "Nie można pobrać zadania z przepływu pracy.",
-        "task_not_supported": "Zadanie nie jest obecnie obsługiwane"
+      "button_primary": "Zrób zdjęcie",
+      "title": "Prześlij stronę ze zdjęciem paszportowym"
     }
+  },
+  "outro": {
+    "body": "To wszystko, czego potrzebujemy, aby rozpocząć weryfikację Twojej tożsamości",
+    "body_government_letter": "Podaj całą stronę dokumentu, aby uzyskać najlepsze wyniki",
+    "title": "Dziękuję"
+  },
+  "permission": {
+    "body_both": "Nie możemy dokonać weryfikacji bez użycia aparatu ani mikrofonu",
+    "body_cam": "Nie możemy Cię zweryfikować bez użycia aparatu",
+    "button_primary_both": "Włącz oba",
+    "button_primary_cam": "Włącz aparat",
+    "subtitle_both": "Po wyświetleniu monitu, aby kontynuować, włączyć dostęp do obu urządzeń",
+    "subtitle_cam": "Aby kontynuować, po wyświetleniu monitu należy włączyć dostęp do aparatu",
+    "title_both": "Zezwól na dostęp do kamery i mikrofonu",
+    "title_cam": "Zezwól na dostęp do aparatu"
+  },
+  "permission_recovery": {
+    "button_primary": "Odśwież",
+    "info": "Przywróć",
+    "list_header_both": "Wykonaj poniższe kroki, aby przywrócić dostęp do obu urządzeń:",
+    "list_header_cam": "Wykonaj poniższe kroki, aby przywrócić dostęp do aparatu:",
+    "list_item_action_cam": "Odśwież tę stronę, aby ponownie rozpocząć proces weryfikacji tożsamości",
+    "list_item_how_to_both": "Udziel dostępu do aparatu i mikrofonu w ustawieniach przeglądarki",
+    "list_item_how_to_cam": "Zezwalaj na dostęp do aparatu w ustawieniach przeglądarki",
+    "subtitle_both": "Odzyskaj dostęp do aparatu i mikrofonu, aby nagrać film i zakończyć proces weryfikacji",
+    "subtitle_cam": "Przywróć dostęp do aparatu, aby kontynuować weryfikację",
+    "subtitle_cam_old": "Odzyskaj dostęp do aparatu, aby kontynuować weryfikację twarzy",
+    "title_both": "Odmowa dostępu do aparatu i mikrofonu",
+    "title_cam": "Odmowa dostępu do aparatu"
+  },
+  "photo_upload": {
+    "body_bank_statement": "Podaj całą stronę dokumentu, aby uzyskać najlepsze wyniki",
+    "body_benefits_letter": "Podaj całą stronę dokumentu, aby uzyskać najlepsze wyniki",
+    "body_bill": "Podaj całą stronę dokumentu, aby uzyskać najlepsze wyniki",
+    "body_id_back": "Prześlij z komputera zdjęcie tylnej strony karty",
+    "body_id_front": "Prześlij przód karty z komputera",
+    "body_license_back": "Prześlij tylną stronę dokumentu ze swojego komputera",
+    "body_license_front": "Prześlij przednią stronę dokumentu z komputera",
+    "body_passport": "Prześlij stronę paszportu ze zdjęciem z komputera",
+    "body_selfie": "Prześlij zdjęcie z komputera",
+    "body_tax_letter": "Podaj całą stronę dokumentu, aby uzyskać najlepsze wyniki",
+    "button_take_photo": "Zrobić zdjęcie",
+    "button_upload": "Prześlij",
+    "title_selfie": "Selfie"
+  },
+  "poa_cancel": "Anuluj",
+  "poa_err_invalid_file": {
+    "message": "Wybierz inny plik.",
+    "ok": "OK",
+    "title": "Nieprawidłowy plik"
+  },
+  "poa_guidance": {
+    "button_primary": "Kontynuuj",
+    "instructions": {
+      "address": "Aktualny adres",
+      "full_name": "Imię i nazwisko",
+      "issue_date": "Data wydania lub okres podsumowania",
+      "label": "Uchwyć cały dokument i upewnij się, że jest on wyraźnie widoczny:",
+      "logo": "Logo"
+    },
+    "subtitle_bank_statement": "Musi być wydany w ciągu <strong>ostatnich 3 miesięcy</strong>",
+    "subtitle_benefits_letter": "Musi być wydany w ciągu <strong>ostatnich 12 miesięcy</strong>",
+    "subtitle_bill": "Data wydania musi mieścić się w okresie <strong>ostatnich 3 miesięcy</strong>",
+    "subtitle_tax_letter": "Musi być wydany w ciągu <strong>ostatnich 12 miesięcy</strong>"
+  },
+  "poa_intro": {
+    "button_primary": "Rozpocznij weryfikację",
+    "list_matches_signup": "zawiera adres <strong>zgodny</strong> z adresem, który został użyty podczas rejestracji",
+    "list_most_recent": "Czy Twój <strong> najnowszy </strong> dokument",
+    "list_shows_address": "zawiera <strong>aktualny</strong> adres",
+    "subtitle": "Potrzebny będzie dokument, który:",
+    "title": "Teraz zweryfikujmy Twój adres"
+  },
+  "profile_data": {
+    "address_title": "Dodaj swój adres",
+    "button_continue": "Kontynuuj",
+    "components": {
+      "country_select": {
+        "placeholder": "Wybierz kraj"
+      },
+      "nationality_select": {
+        "placeholder": "Wybierz kraj"
+      },
+      "pan": {
+        "placeholder": "ABCDE1234F"
+      },
+      "ssn": {
+        "placeholder": "123-45-6789"
+      },
+      "state_select": {
+        "placeholder": "Wybierz stan"
+      }
+    },
+    "country_of_residence_title": "Twój kraj zamieszkania",
+    "field_labels": {
+      "country": "Kraj",
+      "dob": "Data urodzenia",
+      "email": "E-mail",
+      "first_name": "Imię",
+      "gbr_specific": {
+        "postcode": "Kod pocztowy",
+        "town": "Miejscowość"
+      },
+      "last_name": "Nazwisko",
+      "line1": "Linia adresu 1",
+      "line2": "Linia adresu 2",
+      "line3": "Linia adresowa 3",
+      "mobile_number": "Numer telefonu komórkowego",
+      "nationality": "Narodowość",
+      "pan": "Stały numer konta (PAN)",
+      "postcode": "Kod pocztowy",
+      "ssn": "Numer ubezpieczenia społecznego (SSN)",
+      "town": "Miejscowość",
+      "usa_specific": {
+        "line1_helper_text": "Adres, na przykład: ul. Alberta 200",
+        "line2_helper_text": "Nr mieszkania, apartamentu, jednostki itp.",
+        "postcode": "Kod pocztowy",
+        "state": "Stan"
+      }
+    },
+    "field_optional": "(opcjonalnie)",
+    "field_validation": {
+      "gbr_specific": {
+        "required_postcode": "Wprowadź swój kod pocztowy",
+        "too_long_postcode": "Kod pocztowy jest zbyt długi",
+        "too_short_postcode": "Kod pocztowy jest zbyt krótki"
+      },
+      "invalid": "Sprawdź, czy w polu nie ma nieprawidłowych znaków lub symboli",
+      "invalid_dob": "Wprowadź prawidłową datę urodzenia",
+      "required_country": "Wybierz kraj",
+      "required_dob": "Wpisz swoją datę urodzenia",
+      "required_email": "Podaj swój adres e-mail",
+      "required_first_name": "Wpisz swoje imię",
+      "required_last_name": "Wpisz swoje nazwisko",
+      "required_line1": "Wpisz adres",
+      "required_mobile_number": "Podaj numer telefonu komórkowego",
+      "required_nationality": "Wybierz kraj",
+      "required_pan": "Podaj swój PAN",
+      "required_postcode": "Wprowadź swój kod pocztowy",
+      "required_ssn": "Podaj swój numer SSN",
+      "too_long__line1": "Wprowadzony adres jest zbyt długi",
+      "too_long_first_name": "Imię jest zbyt długie",
+      "too_long_last_name": "Nazwisko jest zbyt długie",
+      "too_long_postcode": "Kod pocztowy jest zbyt długi",
+      "too_long_town": "Nazwa miejscowości jest zbyt długa",
+      "too_short_first_name": "Imię jest zbyt krótkie",
+      "too_short_last_name": "Nazwisko jest zbyt krótkie",
+      "too_short_postcode": "Kod pocztowy jest zbyt krótki",
+      "usa_specific": {
+        "required_state": "Wybierz stan"
+      },
+      "valid_email": "Podaj poprawny adres e-mail",
+      "valid_mobile_number": "Podaj prawidłowy numer telefonu komórkowego",
+      "valid_pan": "Podaj prawidłowy PAN",
+      "valid_ssn": "Podaj prawidłowy numer SSN"
+    },
+    "personal_information_title": "Dodaj swoje dane osobowe",
+    "prompt": {
+      "details_timeout": "Rozpocznij ponownie",
+      "header_timeout": "Działania zajęły zbyt wiele czasu."
+    }
+  },
+  "retry_feedback": {
+    "button_primary": "Spróbuj ponownie"
+  },
+  "retry_feedback_id_expired": {
+    "subtitle": "Spróbuj ponownie z ważnym dokumentem tożsamości ze zdjęciem i upewnij się, że Twoje dane są wyraźnie widoczne",
+    "title": "Twój dokument stracił ważność"
+  },
+  "retry_feedback_id_generic": {
+    "subtitle": "Spróbuj ponownie z ważnym dokumentem tożsamości ze zdjęciem i upewnij się, że Twoje dane są wyraźnie widoczne",
+    "title": "Wystąpił problem z Twoim dokumentem"
+  },
+  "retry_feedback_id_unaccepted": {
+    "subtitle": "Spróbuj ponownie z ważnym dokumentem tożsamości ze zdjęciem i upewnij się, że Twoje dane są wyraźnie widoczne",
+    "title": "Dokument nie został zaakceptowany"
+  },
+  "retry_feedback_selfie_generic": {
+    "subtitle": "Spróbuj ponownie i upewnij się, że twarz jest widoczna i dobrze oświetlona.",
+    "title": "Wystąpił problem z selfie"
+  },
+  "selfie_capture": {
+    "alert": {
+      "camera_inactive": {
+        "detail": "Sprawdź, czy urządzenie jest podłączone i działa. Możesz również <fallback>kontynuować weryfikację w telefonie</fallback>",
+        "detail_no_fallback": "Upewnij się, że Twoje urządzenie ma sprawny aparat fotograficzny",
+        "title": "Aparat nie działa?"
+      },
+      "camera_not_working": {
+        "detail": "Urządzenie może być odłączone. <fallback>Spróbuj skorzystać z telefonu</fallback>.",
+        "detail_no_fallback": "Upewnij się, że aparat w urządzeniu działa",
+        "title": "Aparat nie działa"
+      },
+      "timeout": {
+        "detail": "Pamiętaj, aby po zakończeniu pracy nacisnąć przycisk. <fallback>Ponowienie czynności dotyczących wideo</fallback>",
+        "title": "Wygląda na to, że trwało to zbyt długo"
+      }
+    },
+    "body": "Trzymaj twarz w obrębie owalu",
+    "button_accessibility": "",
+    "button_primary": "Rozpocznij skanowanie twarzy",
+    "frame_accessibility": "Widok z aparatu",
+    "title": "Trzymaj twarz w obrębie owalu"
+  },
+  "selfie_confirmation": {
+    "image_accessibility": "Zdjęcie Twojej twarzy",
+    "subtitle": "Upewnij się, że cała twarz jest widoczna",
+    "title": "Sprawdź selfie"
+  },
+  "selfie_intro": {
+    "button_primary": "Kontynuuj",
+    "list_accessibility": "Wskazówki, jak zrobić dobre selfie",
+    "list_item_face_forward": "Ustaw się twarzą na wprost i upewnij się, że oczy są dobrze widoczne.",
+    "list_item_no_glasses": "Zdejmij okulary, jeśli to konieczne",
+    "subtitle": "Porównamy zdjęcie z dokumentem",
+    "title": "Zrób sobie selfie"
+  },
+  "sms_sent": {
+    "info": "Porady",
+    "info_link_expire": "Twój link wygaśnie za godzinę",
+    "info_link_window": "Pozostaw to okno otwarte podczas korzystania z telefonu komórkowego",
+    "link": "Wyślij ponownie łącze",
+    "subtitle": "Wysłaliśmy bezpieczne łącze na numer %{number}",
+    "subtitle_minutes": "Przyjazd może potrwać kilka minut.",
+    "title": "Sprawdź telefon komórkowy"
+  },
+  "switch_phone": {
+    "info": "Porady",
+    "info_link_expire": "Twoje mobilne łącze wygaśnie za godzinę.",
+    "info_link_refresh": "Nie odświeżaj tej strony",
+    "info_link_window": "Pozostaw to okno otwarte podczas korzystania z telefonu komórkowego",
+    "link": "Anuluj",
+    "subtitle": "Po zakończeniu przejdziemy do następnego kroku",
+    "title": "Połączono z telefonem komórkowym"
+  },
+  "upload_guide": {
+    "button_primary": "Prześlij zdjęcie",
+    "image_detail_blur_alt": "Przykład dokumentu z zamazanym obrazem",
+    "image_detail_blur_label": "Wszystkie szczegóły muszą być wyraźne — nic nie może być zamazane",
+    "image_detail_cutoff_label": "Pokaż wszystkie szczegóły — w tym dolne 2 linie",
+    "image_detail_glare_label": "Odsuń się od bezpośredniego światła — bez odbłysków",
+    "image_detail_good_label": "Na zdjęciu powinien być wyraźnie widoczny dokument",
+    "subtitle": "Skany i kserokopie nie są akceptowane.",
+    "title": "Prześlij stronę ze zdjęciem paszportowym"
+  },
+  "user_consent": {
+    "button_primary": "Accept",
+    "button_secondary": "Do not accept",
+    "prompt": {
+      "button_primary": "Review again",
+      "button_secondary": "Yes, don’t verify me",
+      "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
+      "no_consent_title": "Are you sure?"
+    }
+  },
+  "user_consent_load_fail": {
+    "button_primary": "Reload screen",
+    "detail": "Check that your connection is stable, then try again",
+    "title": "Content failed to load"
+  },
+  "video_capture": {
+    "body": "Trzymaj twarz w obrębie owalu",
+    "body_record": "Naciśnij przycisk, gdy będziesz gotowy(-a)",
+    "body_stop": "Naciśnij przycisk Stop, gdy skończysz",
+    "button_primary_finish": "Zakończ nagrywanie",
+    "button_primary_next": "Następny krok",
+    "button_primary_start": "Rozpocznij nagrywanie",
+    "button_record_accessibility": "Rozpocznij nagrywanie",
+    "frame_accessibility": "Widok z aparatu",
+    "header": {
+      "challenge_digit_instructions": "Wypowiedz na głos każdą cyfrę",
+      "challenge_turn_forward": "skieruj się twarzą do przodu",
+      "challenge_turn_left": "Obróć głowę w lewo",
+      "challenge_turn_right": "Obróć głowę w prawo"
+    },
+    "prompt": {
+      "header_timeout": "Wygląda na to, że trwało to zbyt długo"
+    }
+  },
+  "video_confirmation": {
+    "body": "Twój film został nagrany",
+    "button_primary": "Prześlij wideo",
+    "button_secondary": "Ponownie nagraj wideo",
+    "title": "Sprawdź swój film",
+    "video_accessibility": "Odtwarzanie nagranych filmów wideo"
+  },
+  "video_intro": {
+    "button_primary": "Nagrywanie wideo",
+    "list_accessibility": "Czynności związane z nagrywaniem wideo selfie",
+    "list_item_actions": "Masz 20 sekund na dokończenie",
+    "list_item_speak": "Postępuj zgodnie z instrukcjami, aby się poruszać lub mówić",
+    "title": "Nagraj wideo"
+  },
+  "welcome": {
+    "doc_video_subtitle": "",
+    "list_header_doc_video": "Użyj urządzenia do nagrywania:",
+    "list_header_webcam": "Użyj kamery internetowej lub telefonu do robienia zdjęć:",
+    "list_item_doc": "Twój dokument tożsamości",
+    "list_item_doc_video_timeout": "Czas nagrywania jest ograniczony do <timeout></timeout> s.",
+    "list_item_poa": "dokument potwierdzający adres zamieszkania",
+    "list_item_selfie": "Twoja twarz",
+    "next_button": "Wybierz dokument",
+    "start_workflow_button": "Rozpocznij weryfikację",
+    "subtitle": "Powinno to zająć kilka minut.",
+    "title": "Zweryfikuj swoją tożsamość"
+  },
+  "workflow_complete": {
+    "pass": {
+      "description": "Udało nam się pomyślnie zweryfikować Twoją tożsamość",
+      "title": "Przyjęto"
+    },
+    "reject": {
+      "description": "Nie udało nam się zweryfikować Twojej tożsamości",
+      "title": "Odrzucono"
+    }
+  },
+  "workflow_erros": {
+    "generic_title": "Wystąpił błąd serwera!",
+    "no_workflow_run_id": "Identyfikator przepływu pracy nie jest ustawiony.",
+    "reload_app": "Spróbuj ponownie załadować aplikację i spróbuj jeszcze raz.",
+    "task_not_completed": "Nie udało się ukończyć zadania z przepływu pracy.",
+    "task_not_retrieved": "Nie można pobrać zadania z przepływu pracy.",
+    "task_not_supported": "Zadanie nie jest obecnie obsługiwane"
+  }
 }

--- a/src/locales/pt_PT/pt_PT.json
+++ b/src/locales/pt_PT/pt_PT.json
@@ -1,678 +1,678 @@
 {
-    "avc_confirmation": {
-        "button_primary_upload": "Carregar a gravação",
-        "subtitle": "Um vídeo do seu rosto foi gravado com sucesso",
-        "title": "Gravação concluída"
+  "avc_confirmation": {
+    "button_primary_upload": "Carregar a gravação",
+    "subtitle": "Um vídeo do seu rosto foi gravado com sucesso",
+    "title": "Gravação concluída"
+  },
+  "avc_connection_error": {
+    "button_primary_reload": "Recarregar instruções",
+    "button_primary_retry_upload": "Tentar novamente o carregamento",
+    "button_secondary_restart_recording": "Reiniciar a gravação",
+    "subtitle": "Verifique se a sua ligação é estável e tente novamente",
+    "title": "Erro de ligação"
+  },
+  "avc_face_alignment": {
+    "feedback_move_back": "Afaste-se",
+    "feedback_move_closer": "Aproxime-se",
+    "feedback_no_face_detected": "Rosto não detetado",
+    "feedback_not_centered": "Rosto não centrado",
+    "title": "Posicione o seu rosto na moldura"
+  },
+  "avc_face_capture": {
+    "alert": {
+      "timeout_body": "Tem até 15 segundos para completar a gravação",
+      "timeout_button_primary": "Tentar novamente",
+      "timeout_title": "Desculpe, temos de reiniciar a gravação",
+      "too_fast_body": "Tente novamente e rode a sua cabeça mais lentamente",
+      "too_fast_button_primary": "Tentar novamente",
+      "too_fast_title": "Rodou a cabeça demasiado rápido"
     },
-    "avc_connection_error": {
-        "button_primary_reload": "Recarregar instruções",
-        "button_primary_retry_upload": "Tentar novamente o carregamento",
-        "button_secondary_restart_recording": "Reiniciar a gravação",
-        "subtitle": "Verifique se a sua ligação é estável e tente novamente",
-        "title": "Erro de ligação"
+    "title": "Vire a cabeça lentamente para ambos os lados",
+    "title_completed": "Gravação concluída"
+  },
+  "avc_intro": {
+    "button_primary_ready": "Estou pronto",
+    "disclaimer": "Tenha em atenção que iremos gravar o seu rosto e o seu fundo",
+    "list_item_one": "Primeiro, posicione o seu rosto na moldura",
+    "list_item_two": "Depois, vire a cabeça lentamente para ambos os lados",
+    "subtitle": "Isto serve para verificar que é uma pessoa real",
+    "title": "Gravar um vídeo"
+  },
+  "avc_no_face_detected": {
+    "button_primary_restart": "Reiniciar a gravação",
+    "list_item_eyes": "Assegure-se de que os seus olhos estão claramente visíveis",
+    "list_item_face": "Certifique-se de que apenas mostra a sua cara. Não precisamos de ver a sua identificação",
+    "list_item_lighting": "Certifique-se de está num local com boa iluminação",
+    "list_item_mask": "Certifique-se de que remove as máscaras ou outros artigos que cobrem o seu rosto. Os óculos não precisa de retirar",
+    "title": "Não conseguimos detetar o seu rosto"
+  },
+  "avc_uploading": {
+    "title": "Carregamento em curso"
+  },
+  "country_select": {
+    "alert": {
+      "another_doc": "Os documentos desse país não são atualmente suportados — <fallback>tente outro tipo de documento</fallback>"
     },
-    "avc_face_alignment": {
-        "feedback_move_back": "Afaste-se",
-        "feedback_move_closer": "Aproxime-se",
-        "feedback_no_face_detected": "Rosto não detetado",
-        "feedback_not_centered": "Rosto não centrado",
-        "title": "Posicione o seu rosto na moldura"
+    "alert_dropdown": {
+      "country_not_found": "País não encontrado"
     },
-    "avc_face_capture": {
-        "alert": {
-            "timeout_body": "Tem até 15 segundos para completar a gravação",
-            "timeout_button_primary": "Tentar novamente",
-            "timeout_title": "Desculpe, temos de reiniciar a gravação",
-            "too_fast_body": "Tente novamente e rode a sua cabeça mais lentamente",
-            "too_fast_button_primary": "Tentar novamente",
-            "too_fast_title": "Rodou a cabeça demasiado rápido"
-        },
-        "title": "Vire a cabeça lentamente para ambos os lados",
-        "title_completed": "Gravação concluída"
+    "button_primary": "Enviar documento",
+    "poa_alert": {
+      "country_not_found": "Lamentamos. Estamos a trabalhar para suportar mais países.",
+      "intro": "Não consegue encontrar o seu país?"
     },
-    "avc_intro": {
-        "button_primary_ready": "Estou pronto",
-        "disclaimer": "Tenha em atenção que iremos gravar o seu rosto e o seu fundo",
-        "list_item_one": "Primeiro, posicione o seu rosto na moldura",
-        "list_item_two": "Depois, vire a cabeça lentamente para ambos os lados",
-        "subtitle": "Isto serve para verificar que é uma pessoa real",
-        "title": "Gravar um vídeo"
+    "search": {
+      "accessibility": "Selecione o país",
+      "input_placeholder": "por exemplo, Portugal",
+      "label": "Procurar país"
     },
-    "avc_no_face_detected": {
-        "button_primary_restart": "Reiniciar a gravação",
-        "list_item_eyes": "Assegure-se de que os seus olhos estão claramente visíveis",
-        "list_item_face": "Certifique-se de que apenas mostra a sua cara. Não precisamos de ver a sua identificação",
-        "list_item_lighting": "Certifique-se de está num local com boa iluminação",
-        "list_item_mask": "Certifique-se de que remove as máscaras ou outros artigos que cobrem o seu rosto. Os óculos não precisa de retirar",
-        "title": "Não conseguimos detetar o seu rosto"
+    "title": "Selecione o país emissor"
+  },
+  "cross_device_checklist": {
+    "button_primary": "Enviar verificação",
+    "info": "Dicas",
+    "list_item_doc_multiple": "Documentos",
+    "list_item_doc_one": "Documento",
+    "list_item_poa": "Comprovativo de morada",
+    "list_item_selfie": "Selfie",
+    "list_item_video": "Vídeo",
+    "subtitle": "Aqui está tudo o que carregou:",
+    "title": "Um passo final"
+  },
+  "cross_device_error_desktop": {
+    "subtitle": "A ligação só funciona em dispositivos móveis",
+    "title": "Ocorreu um erro"
+  },
+  "cross_device_error_restart": {
+    "subtitle": "Terá de reiniciar a verificação no seu computador",
+    "title": "Ocorreu um erro"
+  },
+  "cross_device_intro": {
+    "button_primary": "Obter ligação segura",
+    "list_accessibility": "Passos necessários para continuar com a verificação no seu telemóvel",
+    "list_item_finish": "Volte aqui para terminar a submissão",
+    "list_item_open_link": "Abra a ligação e conclua as tarefas",
+    "list_item_send_phone": "Enviar uma ligação segura para o seu telefone",
+    "subtitle": "Veja como poderá fazer:",
+    "title": "Continue no seu telefone"
+  },
+  "cross_device_return": {
+    "body": "O seu computador poderá demorar alguns segundos a atualizar",
+    "subtitle": "Já pode regressar ao computador para continuar",
+    "title": "Carregamentos efetuados com sucesso"
+  },
+  "cross_device_session_linked": {
+    "button_primary": "Continuar",
+    "info": "Dupla verificação",
+    "list_item_desktop_open": "A janela do seu ambiente de trabalho permanece aberta",
+    "list_item_sent_by_you": "Esta ligação foi enviada por si — procure ajuda se pensa que isto pode ser um scam",
+    "subtitle": "Continuar com a verificação",
+    "title": "Ligado ao seu computador"
+  },
+  "doc_capture": {
+    "button_primary": "Iniciar digitalização de documento",
+    "detail": {
+      "folded_doc_front": "Coloque o documento de forma plana e inclua todas as páginas interiores (deve conter a sua fotografia)"
     },
-    "avc_uploading": {
-        "title": "Carregamento em curso"
+    "header_folded_doc_front": "Lado da foto do perfil",
+    "prompt": {
+      "button_card": "Cartão de plástico",
+      "button_paper": "Documento em papel",
+      "title_id": "Que tipo de cartão de identidade tem?",
+      "title_license": "Que tipo de carta de condução tem?"
+    }
+  },
+  "doc_confirmation": {
+    "alert": {
+      "blur_detail": "Certifique-se de que tudo está nítido",
+      "blur_title": "Foto desfocada detetada",
+      "crop_detail": "Certifique-se de que o documento é totalmente visível",
+      "crop_title": "Imagem cortada detetada",
+      "glare_detail": "Afaste-se da luz direta",
+      "glare_title": "Encandeamento detetado",
+      "no_doc_detail": "Certifique-se de que está totalmente dentro da moldura",
+      "no_doc_title": "Documento não detetado"
     },
-    "country_select": {
-        "alert": {
-            "another_doc": "Os documentos desse país não são atualmente suportados — <fallback>tente outro tipo de documento<\/fallback>"
-        },
-        "alert_dropdown": {
-            "country_not_found": "País não encontrado"
-        },
-        "button_primary": "Enviar documento",
-        "poa_alert": {
-            "country_not_found": "Lamentamos. Estamos a trabalhar para suportar mais países.",
-            "intro": "Não consegue encontrar o seu país?"
-        },
-        "search": {
-            "accessibility": "Selecione o país",
-            "input_placeholder": "por exemplo, Portugal",
-            "label": "Procurar país"
-        },
-        "title": "Selecione o país emissor"
+    "body": "Certifique-se de que carregou a página inteira do documento e que os detalhes são facilmente legíveis, sem desfoque ou brilho",
+    "body_bank_statement": "Certifique-se de que carregou a página inteira do documento e que os detalhes são facilmente legíveis, sem desfoque ou brilho",
+    "body_benefits_letter": "Certifique-se de que carregou a página inteira do documento e que os detalhes são facilmente legíveis, sem desfoque ou brilho",
+    "body_bill": "Certifique-se de que carregou a página inteira do documento e que os detalhes são facilmente legíveis, sem desfoque ou brilho",
+    "body_id": "Certifique-se de que os seus dados são nítidos e não estão obstruídos",
+    "body_image_medium": "Vamos demorar mais tempo a verificar a sua identidade se não conseguirmos efetuar a leitura",
+    "body_image_poor": "Para confirmar melhor a sua identidade, precisamos de uma fotografia melhor",
+    "body_license": "Certifique-se de que os seus dados são nítidos e não estão obstruídos",
+    "body_passport": "Certifique-se de que os seus dados são nítidos e não estão obstruídos",
+    "body_permit": "Certifique-se de que os seus dados são nítidos e não estão obstruídos",
+    "body_tax_letter": "Certifique-se de que carregou a página inteira do documento e que os detalhes são facilmente legíveis, sem desfoque ou brilho",
+    "button_close": "Fechar",
+    "button_primary_redo": "Refazer",
+    "button_primary_upload": "Carregar",
+    "button_primary_upload_anyway": "Carregar de qualquer forma",
+    "button_secondary_redo": "Refazer",
+    "button_zoom": "Ampliar imagem",
+    "image_accessibility": "Foto do seu documento",
+    "title": "Verifique a sua imagem"
+  },
+  "doc_multi_frame_capture": {
+    "capture_progress_title": "A digitalizar o documento",
+    "instructions_title_back": "Posicione o verso do seu documento na moldura",
+    "instructions_title_front": "Posicione a frente do seu documento na moldura"
+  },
+  "doc_select": {
+    "button_bank_statement": "Extrato bancário ou de uma sociedade de crédito imobiliário",
+    "button_bank_statement_non_uk": "Extrato bancário",
+    "button_benefits_letter": "Declaração de Benefícios",
+    "button_benefits_letter_detail": "Benefícios autorizados pelo governo, p.e. subsídio de desemprego, subsídio de habitação, créditos fiscais",
+    "button_bill": "Fatura de serviço essencial",
+    "button_bill_detail": "Gás, eletricidade, água, telefone fixo ou banda larga",
+    "button_government_letter": "Carta governamental",
+    "button_government_letter_detail": "Qualquer carta emitida pelo governo como, por exemplo, direito a prestações, cartas de voto, cartas fiscais, etc.",
+    "button_id": "Cartão de identidade",
+    "button_id_detail": "Frente e verso",
+    "button_license": "Carta de condução",
+    "button_license_detail": "Frente e verso",
+    "button_passport": "Passaporte",
+    "button_passport_detail": "Página com fotografia",
+    "button_permit": "Autorização de residência",
+    "button_permit_detail": "Frente e verso",
+    "button_tax_letter": "Carta sobre Impostos Municipais",
+    "extra_estatements_ok": "Declarações eletrónicas aceites",
+    "extra_no_mobile": "Desculpe, não entram faturas de telemóvel",
+    "list_accessibility": "Documentos que pode usar para verificar a sua identidade",
+    "pill": "o mais rápido",
+    "section": {
+      "header_country": "País emissor",
+      "header_doc_type": "Documentos aceitos",
+      "input_country_not_found": "Sem resultados",
+      "input_placeholder_country": "Selecione o país emissor"
     },
-    "cross_device_checklist": {
-        "button_primary": "Enviar verificação",
-        "info": "Dicas",
-        "list_item_doc_multiple": "Documentos",
-        "list_item_doc_one": "Documento",
-        "list_item_poa": "Comprovativo de morada",
-        "list_item_selfie": "Selfie",
-        "list_item_video": "Vídeo",
-        "subtitle": "Aqui está tudo o que carregou:",
-        "title": "Um passo final"
+    "subtitle": "Deve ser uma identificação oficial com fotografia",
+    "subtitle_country": "Selecione o país emissor para ver quais documentos aceitamos",
+    "subtitle_entire_page": "Página inteira",
+    "subtitle_front_back": "Frente e verso",
+    "subtitle_photo_page": "Página de fotos",
+    "subtitle_poa": "Estes são os documentos que deverão apresentar a sua morada atual",
+    "title": "Escolha o seu documento",
+    "title_poa": "Selecione um documento de %{country}"
+  },
+  "doc_submit": {
+    "button_link_upload": "ou carregar foto – digitalizações ou fotocópias não são permitidas",
+    "button_primary": "Continue no telefone",
+    "subtitle": "Tire uma foto com o seu telefone",
+    "title_bank_statement": "Enviar declaração",
+    "title_benefits_letter": "Enviar carta",
+    "title_bill": "Enviar fatura",
+    "title_government_letter": "Carta governamental",
+    "title_id_back": "Submeter cartão de identidade (verso)",
+    "title_id_front": "Submeter cartão de identidade (frente)",
+    "title_license_back": "Submeter carta (verso)",
+    "title_license_front": "Submeter carta (frente)",
+    "title_passport": "Submeta a página com fotografia do passaporte",
+    "title_permit_back": "Enviar autorização de residência (verso)",
+    "title_permit_front": "Enviar autorização de residência (frente)",
+    "title_tax_letter": "Enviar carta"
+  },
+  "doc_video_capture": {
+    "button_primary_fallback": "Próximo passo",
+    "button_primary_fallback_end": "Acabar gravação",
+    "detail_step2": "Mantenha o documento sempre totalmente visível",
+    "header": "Segurando no documento, mantenha o lado frontal dentro da moldura",
+    "header_paper_doc_step2": "Vire lentamente o seu documento para mostrar as páginas exteriores",
+    "header_passport": "Segurando no passaporte, mantenha a página da fotografia dentro da moldura",
+    "header_passport_progress": "Mantenha o documento imóvel",
+    "header_step1": "Agora, mantenha o documento imóvel",
+    "header_step2": "Vire lentamente o seu documento para mostrar o verso",
+    "prompt": {
+      "detail_timeout": "A gravação de vídeo está limitada a <timeout></timeout> segundos. <fallback>Comece novamente</fallback>"
     },
-    "cross_device_error_desktop": {
-        "subtitle": "A ligação só funciona em dispositivos móveis",
-        "title": "Ocorreu um erro"
+    "stepper": "Passo <step></step> de <total></total>",
+    "success_accessibility": "Sucesso"
+  },
+  "doc_video_confirmation": {
+    "button_secondary": "Pré-visualizar vídeo",
+    "title": "Verifique o seu vídeo"
+  },
+  "error_unsupported_browser": {
+    "subtitle_android": "Reiniciar o processo na versão mais recente do Google Chrome",
+    "subtitle_ios": "Reiniciar o processo na versão mais recente do Safari",
+    "title_android": "Navegador não suportado",
+    "title_ios": "Navegador não suportado"
+  },
+  "generic": {
+    "accessibility": {
+      "close_sdk_screen": "Escolher ecrã de verificação da identidade",
+      "dismiss_alert": "Ignorar alerta"
     },
-    "cross_device_error_restart": {
-        "subtitle": "Terá de reiniciar a verificação no seu computador",
-        "title": "Ocorreu um erro"
+    "back": "voltar",
+    "close": "fechar",
+    "errors": {
+      "expired_token": {
+        "instruction": "Tente novamente",
+        "message": "O seu token está caducado"
+      },
+      "geoblocked_error": {
+        "instruction": "Lamentamos, parece que não conseguimos avançar mais porque a sua localização atual não é suportada",
+        "message": "Serviço indisponível"
+      },
+      "interrupted_flow_error": {
+        "instruction": "Reiniciar o processo num dispositivo diferente",
+        "message": "Câmara não detetada"
+      },
+      "invalid_size": {
+        "instruction": "Deverá ter menos de 10MB.",
+        "message": "Tamanho de ficheiro excedido."
+      },
+      "invalid_type": {
+        "instruction": "Tente usar outro tipo de ficheiro.",
+        "message": "Ficheiro não carregado."
+      },
+      "lazy_loading": {
+        "message": "Ocorreu um erro ao carregar o componente"
+      },
+      "multiple_faces": {
+        "instruction": "Só a sua cara pode estar na fotografia de si",
+        "message": "Múltiplas faces encontradas"
+      },
+      "no_face": {
+        "instruction": "Certifique-se de que o seu rosto está visível",
+        "message": "Rosto não detetado"
+      },
+      "request_error": {
+        "instruction": "Tente novamente",
+        "message": "Ocorreu um erro"
+      },
+      "sms_failed": {
+        "instruction": "Copie a ligação para o seu telefone",
+        "message": "Ocorreu um erro"
+      },
+      "sms_overuse": {
+        "instruction": "Copie a ligação para o seu telefone",
+        "message": "Demasiadas tentativas falhadas"
+      },
+      "unsupported_file": {
+        "instruction": "Tente usar um ficheiro JPG ou PNG",
+        "message": "Tipo de ficheiro não suportado"
+      }
     },
-    "cross_device_intro": {
-        "button_primary": "Obter ligação segura",
-        "list_accessibility": "Passos necessários para continuar com a verificação no seu telemóvel",
-        "list_item_finish": "Volte aqui para terminar a submissão",
-        "list_item_open_link": "Abra a ligação e conclua as tarefas",
-        "list_item_send_phone": "Enviar uma ligação segura para o seu telefone",
-        "subtitle": "Veja como poderá fazer:",
-        "title": "Continue no seu telefone"
-    },
-    "cross_device_return": {
-        "body": "O seu computador poderá demorar alguns segundos a atualizar",
-        "subtitle": "Já pode regressar ao computador para continuar",
-        "title": "Carregamentos efetuados com sucesso"
-    },
-    "cross_device_session_linked": {
-        "button_primary": "Continuar",
-        "info": "Dupla verificação",
-        "list_item_desktop_open": "A janela do seu ambiente de trabalho permanece aberta",
-        "list_item_sent_by_you": "Esta ligação foi enviada por si — procure ajuda se pensa que isto pode ser um scam",
-        "subtitle": "Continuar com a verificação",
-        "title": "Ligado ao seu computador"
-    },
-    "doc_capture": {
-        "button_primary": "Iniciar digitalização de documento",
-        "detail": {
-            "folded_doc_front": "Coloque o documento de forma plana e inclua todas as páginas interiores (deve conter a sua fotografia)"
-        },
-        "header_folded_doc_front": "Lado da foto do perfil",
-        "prompt": {
-            "button_card": "Cartão de plástico",
-            "button_paper": "Documento em papel",
-            "title_id": "Que tipo de cartão de identidade tem?",
-            "title_license": "Que tipo de carta de condução tem?"
-        }
-    },
-    "doc_confirmation": {
-        "alert": {
-            "blur_detail": "Certifique-se de que tudo está nítido",
-            "blur_title": "Foto desfocada detetada",
-            "crop_detail": "Certifique-se de que o documento é totalmente visível",
-            "crop_title": "Imagem cortada detetada",
-            "glare_detail": "Afaste-se da luz direta",
-            "glare_title": "Encandeamento detetado",
-            "no_doc_detail": "Certifique-se de que está totalmente dentro da moldura",
-            "no_doc_title": "Documento não detetado"
-        },
-        "body": "Certifique-se de que carregou a página inteira do documento e que os detalhes são facilmente legíveis, sem desfoque ou brilho",
-        "body_bank_statement": "Certifique-se de que carregou a página inteira do documento e que os detalhes são facilmente legíveis, sem desfoque ou brilho",
-        "body_benefits_letter": "Certifique-se de que carregou a página inteira do documento e que os detalhes são facilmente legíveis, sem desfoque ou brilho",
-        "body_bill": "Certifique-se de que carregou a página inteira do documento e que os detalhes são facilmente legíveis, sem desfoque ou brilho",
-        "body_id": "Certifique-se de que os seus dados são nítidos e não estão obstruídos",
-        "body_image_medium": "Vamos demorar mais tempo a verificar a sua identidade se não conseguirmos efetuar a leitura",
-        "body_image_poor": "Para confirmar melhor a sua identidade, precisamos de uma fotografia melhor",
-        "body_license": "Certifique-se de que os seus dados são nítidos e não estão obstruídos",
-        "body_passport": "Certifique-se de que os seus dados são nítidos e não estão obstruídos",
-        "body_permit": "Certifique-se de que os seus dados são nítidos e não estão obstruídos",
-        "body_tax_letter": "Certifique-se de que carregou a página inteira do documento e que os detalhes são facilmente legíveis, sem desfoque ou brilho",
-        "button_close": "Fechar",
-        "button_primary_redo": "Refazer",
-        "button_primary_upload": "Carregar",
-        "button_primary_upload_anyway": "Carregar de qualquer forma",
-        "button_secondary_redo": "Refazer",
-        "button_zoom": "Ampliar imagem",
-        "image_accessibility": "Foto do seu documento",
-        "title": "Verifique a sua imagem"
-    },
-    "doc_multi_frame_capture": {
-        "capture_progress_title": "A digitalizar o documento",
-        "instructions_title_back": "Posicione o verso do seu documento na moldura",
-        "instructions_title_front": "Posicione a frente do seu documento na moldura"
-    },
-    "doc_select": {
-        "button_bank_statement": "Extrato bancário ou de uma sociedade de crédito imobiliário",
-        "button_bank_statement_non_uk": "Extrato bancário",
-        "button_benefits_letter": "Declaração de Benefícios",
-        "button_benefits_letter_detail": "Benefícios autorizados pelo governo, p.e. subsídio de desemprego, subsídio de habitação, créditos fiscais",
-        "button_bill": "Fatura de serviço essencial",
-        "button_bill_detail": "Gás, eletricidade, água, telefone fixo ou banda larga",
-        "button_government_letter": "Carta governamental",
-        "button_government_letter_detail": "Qualquer carta emitida pelo governo como, por exemplo, direito a prestações, cartas de voto, cartas fiscais, etc.",
-        "button_id": "Cartão de identidade",
-        "button_id_detail": "Frente e verso",
-        "button_license": "Carta de condução",
-        "button_license_detail": "Frente e verso",
-        "button_passport": "Passaporte",
-        "button_passport_detail": "Página com fotografia",
-        "button_permit": "Autorização de residência",
-        "button_permit_detail": "Frente e verso",
-        "button_tax_letter": "Carta sobre Impostos Municipais",
-        "extra_estatements_ok": "Declarações eletrónicas aceites",
-        "extra_no_mobile": "Desculpe, não entram faturas de telemóvel",
-        "list_accessibility": "Documentos que pode usar para verificar a sua identidade",
-        "pill": "o mais rápido",
-        "section": {
-            "header_country": "País emissor",
-            "header_doc_type": "Documentos aceitos",
-            "input_country_not_found": "Sem resultados",
-            "input_placeholder_country": "Selecione o país emissor"
-        },
-        "subtitle": "Deve ser uma identificação oficial com fotografia",
-        "subtitle_country": "Selecione o país emissor para ver quais documentos aceitamos",
-        "subtitle_entire_page": "Página inteira",
-        "subtitle_front_back": "Frente e verso",
-        "subtitle_photo_page": "Página de fotos",
-        "subtitle_poa": "Estes são os documentos que deverão apresentar a sua morada atual",
-        "title": "Escolha o seu documento",
-        "title_poa": "Selecione um documento de %{country}"
-    },
-    "doc_submit": {
-        "button_link_upload": "ou carregar foto – digitalizações ou fotocópias não são permitidas",
-        "button_primary": "Continue no telefone",
-        "subtitle": "Tire uma foto com o seu telefone",
-        "title_bank_statement": "Enviar declaração",
-        "title_benefits_letter": "Enviar carta",
-        "title_bill": "Enviar fatura",
-        "title_government_letter": "Carta governamental",
-        "title_id_back": "Submeter cartão de identidade (verso)",
-        "title_id_front": "Submeter cartão de identidade (frente)",
-        "title_license_back": "Submeter carta (verso)",
-        "title_license_front": "Submeter carta (frente)",
-        "title_passport": "Submeta a página com fotografia do passaporte",
-        "title_permit_back": "Enviar autorização de residência (verso)",
-        "title_permit_front": "Enviar autorização de residência (frente)",
-        "title_tax_letter": "Enviar carta"
-    },
-    "doc_video_capture": {
-        "button_primary_fallback": "Próximo passo",
-        "button_primary_fallback_end": "Acabar gravação",
-        "detail_step2": "Mantenha o documento sempre totalmente visível",
-        "header": "Segurando no documento, mantenha o lado frontal dentro da moldura",
-        "header_paper_doc_step2": "Vire lentamente o seu documento para mostrar as páginas exteriores",
-        "header_passport": "Segurando no passaporte, mantenha a página da fotografia dentro da moldura",
-        "header_passport_progress": "Mantenha o documento imóvel",
-        "header_step1": "Agora, mantenha o documento imóvel",
-        "header_step2": "Vire lentamente o seu documento para mostrar o verso",
-        "prompt": {
-            "detail_timeout": "A gravação de vídeo está limitada a <timeout><\/timeout> segundos. <fallback>Comece novamente<\/fallback>"
-        },
-        "stepper": "Passo <step><\/step> de <total><\/total>",
-        "success_accessibility": "Sucesso"
-    },
-    "doc_video_confirmation": {
-        "button_secondary": "Pré-visualizar vídeo",
-        "title": "Verifique o seu vídeo"
-    },
-    "error_unsupported_browser": {
-        "subtitle_android": "Reiniciar o processo na versão mais recente do Google Chrome",
-        "subtitle_ios": "Reiniciar o processo na versão mais recente do Safari",
-        "title_android": "Navegador não suportado",
-        "title_ios": "Navegador não suportado"
-    },
-    "generic": {
-        "accessibility": {
-            "close_sdk_screen": "Escolher ecrã de verificação da identidade",
-            "dismiss_alert": "Ignorar alerta"
-        },
-        "back": "voltar",
-        "close": "fechar",
-        "errors": {
-            "expired_token": {
-                "instruction": "Tente novamente",
-                "message": "O seu token está caducado"
-            },
-            "geoblocked_error": {
-                "instruction": "Lamentamos, parece que não conseguimos avançar mais porque a sua localização atual não é suportada",
-                "message": "Serviço indisponível"
-            },
-            "interrupted_flow_error": {
-                "instruction": "Reiniciar o processo num dispositivo diferente",
-                "message": "Câmara não detetada"
-            },
-            "invalid_size": {
-                "instruction": "Deverá ter menos de 10MB.",
-                "message": "Tamanho de ficheiro excedido."
-            },
-            "invalid_type": {
-                "instruction": "Tente usar outro tipo de ficheiro.",
-                "message": "Ficheiro não carregado."
-            },
-            "lazy_loading": {
-                "message": "Ocorreu um erro ao carregar o componente"
-            },
-            "multiple_faces": {
-                "instruction": "Só a sua cara pode estar na fotografia de si",
-                "message": "Múltiplas faces encontradas"
-            },
-            "no_face": {
-                "instruction": "Certifique-se de que o seu rosto está visível",
-                "message": "Rosto não detetado"
-            },
-            "request_error": {
-                "instruction": "Tente novamente",
-                "message": "Ocorreu um erro"
-            },
-            "sms_failed": {
-                "instruction": "Copie a ligação para o seu telefone",
-                "message": "Ocorreu um erro"
-            },
-            "sms_overuse": {
-                "instruction": "Copie a ligação para o seu telefone",
-                "message": "Demasiadas tentativas falhadas"
-            },
-            "unsupported_file": {
-                "instruction": "Tente usar um ficheiro JPG ou PNG",
-                "message": "Tipo de ficheiro não suportado"
-            }
-        },
-        "lazy_load_placeholder": "A carregar...",
-        "loading": "A carregar"
-    },
-    "get_link": {
-        "alert_wrong_number": "Verifique se o seu número está correto",
-        "button_copied": "Copiado",
-        "button_copy": "Copiar",
-        "button_submit": "Enviar ligação",
-        "info_qr_how": "Como ler um código QR",
-        "info_qr_how_list_item_camera": "Aponte a câmara do telefone ao código QR",
-        "info_qr_how_list_item_download": "Se não funcionar, transfira um leitor de códigos QR a partir do Google Play ou da App Store",
-        "link_divider": "ou escolha um método alternativo",
-        "link_qr": "Ler código QR",
-        "link_sms": "Obtenha a ligação por SMS",
-        "link_url": "Copiar ligação",
-        "loader_sending": "A enviar",
-        "number_field_input_placeholder": "Introduza o número de telemóvel",
-        "number_field_label": "Introduza o seu número de telemóvel:",
-        "subtitle_qr": "Ler o código QR com o seu telefone",
-        "subtitle_sms": "Enviar esta ligação de utilização única para o seu telefone",
-        "subtitle_url": "Enviar esta ligação de utilização única para o seu telefone",
-        "title": "Obter a sua ligação segura",
-        "url_field_label": "Copie a ligação para o navegador do seu telemóvel"
-    },
-    "livenessV2": {
-        "error_reload_instructions": "Recarregar instruções",
-        "intro_note_no1": "Primeiro, posicione o seu rosto na moldura",
-        "intro_note_no2": "Depois, vire a cabeça lentamente para ambos os lados",
-        "intro_ready_button": "Por favor tenha em atenção que iremos gravar o seu rosto e o seu fundo",
-        "intro_subtitle": "Isto serve para verificar que é uma pessoa real",
-        "intro_warning": "Por favor tenha em atenção que iremos gravar o seu rosto e o seu fundo",
-        "success_main_button": "Enviar verificação",
-        "success_title": "É tudo o que precisamos para começar a verificar a sua identidade"
-    },
-    "mobilePhrases": {
-        "photo_upload": {
-            "body_id_back": "Tire uma foto do verso do seu cartão",
-            "body_id_front": "Tire uma foto da parte frontal do seu cartão",
-            "body_license_back": "Tire uma foto do verso da sua carta",
-            "body_license_front": "Tire uma foto da parte frontal da sua carta",
-            "body_passport": "Tire uma foto da página com fotografia do passaporte",
-            "body_selfie": "Tire uma selfie que mostre o rosto"
-        },
-        "selfie_capture": {
-            "alert": {
-                "camera_inactive": {
-                    "detail": "Tire uma foto usando antes o <fallback>modo de câmara básico<\/fallback>"
-                },
-                "camera_not_working": {
-                    "detail": "Tire uma foto usando antes o <fallback>modo de câmara básico<\/fallback>"
-                }
-            }
-        },
-        "upload_guide": {
-            "button_primary": "Tirar uma fotografia",
-            "title": "Página com fotografia do passaporte"
-        }
-    },
-    "outro": {
-        "body": "É tudo o que precisamos para começar a verificar a sua identidade",
-        "body_government_letter": "Forneça a página completa do documento para melhores resultados",
-        "title": "Obrigado"
-    },
-    "permission": {
-        "body_both": "Não podemos verificá-lo sem utilizar a sua câmara e microfone",
-        "body_cam": "Não o podemos verificar sem a sua câmara",
-        "button_primary_both": "Permitir ambos",
-        "button_primary_cam": "Ativar câmara",
-        "subtitle_both": "Quando solicitado, deve permitir o acesso de ambos para continuar",
-        "subtitle_cam": "Quando solicitado, deve permitir o acesso à câmara para continuar",
-        "title_both": "Permitir acesso ao microfone e câmara",
-        "title_cam": "Permitir o acesso à câmara"
-    },
-    "permission_recovery": {
-        "button_primary": "Atualizar",
-        "info": "Recuperação",
-        "list_header_both": "Siga estes passos para recuperar o acesso a ambos:",
-        "list_header_cam": "Siga estes passos para recuperar o acesso à câmara:",
-        "list_item_action_cam": "Atualize esta página para reiniciar o processo de verificação de identidade",
-        "list_item_how_to_both": "Conceda acesso à sua câmara e ao microfone a partir das definições do navegador",
-        "list_item_how_to_cam": "Conceda acesso à sua câmara a partir das definições do navegador",
-        "subtitle_both": "Recuperar o acesso à câmara e ao microfone para tirar um vídeo e completar o processo de verificação",
-        "subtitle_cam": "Recupere o acesso à câmara para continuar a sua verificação",
-        "subtitle_cam_old": "Recupere o acesso à câmara para continuar a verificação da face",
-        "title_both": "Acesso à câmara e ao microfone negado",
-        "title_cam": "O acesso à câmara é negado"
-    },
+    "lazy_load_placeholder": "A carregar...",
+    "loading": "A carregar"
+  },
+  "get_link": {
+    "alert_wrong_number": "Verifique se o seu número está correto",
+    "button_copied": "Copiado",
+    "button_copy": "Copiar",
+    "button_submit": "Enviar ligação",
+    "info_qr_how": "Como ler um código QR",
+    "info_qr_how_list_item_camera": "Aponte a câmara do telefone ao código QR",
+    "info_qr_how_list_item_download": "Se não funcionar, transfira um leitor de códigos QR a partir do Google Play ou da App Store",
+    "link_divider": "ou escolha um método alternativo",
+    "link_qr": "Ler código QR",
+    "link_sms": "Obtenha a ligação por SMS",
+    "link_url": "Copiar ligação",
+    "loader_sending": "A enviar",
+    "number_field_input_placeholder": "Introduza o número de telemóvel",
+    "number_field_label": "Introduza o seu número de telemóvel:",
+    "subtitle_qr": "Ler o código QR com o seu telefone",
+    "subtitle_sms": "Enviar esta ligação de utilização única para o seu telefone",
+    "subtitle_url": "Enviar esta ligação de utilização única para o seu telefone",
+    "title": "Obter a sua ligação segura",
+    "url_field_label": "Copie a ligação para o navegador do seu telemóvel"
+  },
+  "livenessV2": {
+    "error_reload_instructions": "Recarregar instruções",
+    "intro_note_no1": "Primeiro, posicione o seu rosto na moldura",
+    "intro_note_no2": "Depois, vire a cabeça lentamente para ambos os lados",
+    "intro_ready_button": "Por favor tenha em atenção que iremos gravar o seu rosto e o seu fundo",
+    "intro_subtitle": "Isto serve para verificar que é uma pessoa real",
+    "intro_warning": "Por favor tenha em atenção que iremos gravar o seu rosto e o seu fundo",
+    "success_main_button": "Enviar verificação",
+    "success_title": "É tudo o que precisamos para começar a verificar a sua identidade"
+  },
+  "mobilePhrases": {
     "photo_upload": {
-        "body_bank_statement": "Forneça a página completa do documento para melhores resultados",
-        "body_benefits_letter": "Forneça a página completa do documento para melhores resultados",
-        "body_bill": "Forneça a página completa do documento para melhores resultados",
-        "body_id_back": "Carregue o verso do cartão a partir do seu computador",
-        "body_id_front": "Carregue a frente do cartão a partir do seu computador",
-        "body_license_back": "Carregue o verso da carta a partir do seu computador",
-        "body_license_front": "Carregue a frente da carta a partir do seu computador",
-        "body_passport": "Carregue a página da foto do passaporte a partir do seu computador",
-        "body_selfie": "Carregue uma selfie a partir do seu computador",
-        "body_tax_letter": "Forneça a página completa do documento para melhores resultados",
-        "button_take_photo": "Tirar fotografia",
-        "button_upload": "Carregar",
-        "title_selfie": "Selfie"
-    },
-    "poa_cancel": "Cancelar",
-    "poa_err_invalid_file": {
-        "message": "Por favor escolha um ficheiro diferente.",
-        "ok": "OK",
-        "title": "Ficheiro inválido"
-    },
-    "poa_guidance": {
-        "button_primary": "Continuar",
-        "instructions": {
-            "address": "Morada atual",
-            "full_name": "Nome completo",
-            "issue_date": "Data de emissão ou período do resumo",
-            "label": "Capte o documento inteiro e garanta que este mostre claramente:",
-            "logo": "Logótipo"
-        },
-        "subtitle_bank_statement": "Deverá ter sido emitido nos <strong>últimos 3 meses<\/strong>",
-        "subtitle_benefits_letter": "Deverá ter sido emitido nos <strong>últimos 12 meses<\/strong>",
-        "subtitle_bill": "Deverá ter sido emitido nos <strong>últimos 3 meses<\/strong>",
-        "subtitle_tax_letter": "Deverá ter sido emitido nos <strong>últimos 12 meses<\/strong>"
-    },
-    "poa_intro": {
-        "button_primary": "Iniciar verificação",
-        "list_matches_signup": "<strong>Corresponde<\/strong> à morada que usou no seu registo",
-        "list_most_recent": "É o seu documento mais <strong>recente<\/strong>",
-        "list_shows_address": "Mostra a sua morada <strong>atual<\/strong>",
-        "subtitle": "Vai precisar de um documento que:",
-        "title": "Vamos verificar a sua morada"
-    },
-    "profile_data": {
-        "address_title": "Adicione a sua morada",
-        "button_continue": "Continuar",
-        "components": {
-            "country_select": {
-                "placeholder": "Selecione um país"
-            },
-            "nationality_select": {
-                "placeholder": "Selecione um país"
-            },
-            "pan": {
-                "placeholder": "ABCDE1234F"
-            },
-            "ssn": {
-                "placeholder": "123-45-6789"
-            },
-            "state_select": {
-                "placeholder": "Selecione um estado"
-            }
-        },
-        "country_of_residence_title": "Seu país de residência",
-        "field_labels": {
-            "country": "País",
-            "dob": "Data de nascimento",
-            "email": "Email",
-            "first_name": "Nome próprio",
-            "gbr_specific": {
-                "postcode": "Código postal",
-                "town": "Cidade"
-            },
-            "last_name": "Apelido",
-            "line1": "Linha da morada 1",
-            "line2": "Linha da morada 2",
-            "line3": "Linha da morada 3",
-            "mobile_number": "Número de telemóvel",
-            "nationality": "Nacionalidade",
-            "pan": "Número de conta permanente (PAN)",
-            "postcode": "Código postal",
-            "ssn": "Número de Segurança Social (NISS)",
-            "town": "Cidade",
-            "usa_specific": {
-                "line1_helper_text": "Morada, por exemplo: Rua Luís Silva 200",
-                "line2_helper_text": "Apartamento, suite, unidade, etc.",
-                "postcode": "Código postal",
-                "state": "Estado"
-            }
-        },
-        "field_optional": "(opcional)",
-        "field_validation": {
-            "gbr_specific": {
-                "required_postcode": "Introduza o seu código postal",
-                "too_long_postcode": "O código postal é demasiado longo",
-                "too_short_postcode": "O código postal é demasiado curto"
-            },
-            "invalid": "Verifique se existem caracteres ou símbolos inválidos",
-            "invalid_dob": "Introduza uma data de nascimento válida",
-            "required_country": "Selecione um país",
-            "required_dob": "Introduza a sua data de nascimento",
-            "required_email": "Introduza o seu e-mail",
-            "required_first_name": "",
-            "required_last_name": "Introduza o seu apelido",
-            "required_line1": "Introduza a sua morada",
-            "required_mobile_number": "Introduza o seu número de telemóvel",
-            "required_nationality": "Selecione um país",
-            "required_pan": "Introduza o seu PAN",
-            "required_postcode": "Introduza o seu código postal",
-            "required_ssn": "Introduza o seu NISS",
-            "too_long__line1": "A linha da morada é demasiado longa",
-            "too_long_first_name": "O nome próprio é demasiado longo",
-            "too_long_last_name": "O apelido é demasiado longo",
-            "too_long_postcode": "O código postal é demasiado longo",
-            "too_long_town": "",
-            "too_short_first_name": "O nome próprio é demasiado curto",
-            "too_short_last_name": "O apelido é demasiado curto",
-            "too_short_postcode": "O código postal é demasiado curto",
-            "usa_specific": {
-                "required_state": "Selecione um estado"
-            },
-            "valid_email": "Introduza um e-mail válido",
-            "valid_mobile_number": "Introduza um número de telemóvel válido",
-            "valid_pan": "Introduza um PAN válido",
-            "valid_ssn": "Introduza um NISS válido"
-        },
-        "personal_information_title": "Adicione as suas informações pessoais",
-        "prompt": {
-            "details_timeout": "Começar de novo",
-            "header_timeout": "Parece que demorou demasiado tempo"
-        }
-    },
-    "retry_feedback": {
-        "button_primary": "Tente novamente"
-    },
-    "retry_feedback_id_expired": {
-        "subtitle": "Tente de novo com uma identificação com foto válida e garanta que os seus dados estão claramente visíveis",
-        "title": "O seu documento está caducado"
-    },
-    "retry_feedback_id_generic": {
-        "subtitle": "Tente de novo com uma identificação com foto válida e garanta que os seus dados estão claramente visíveis",
-        "title": "Houve um problema com o seu documento"
-    },
-    "retry_feedback_id_unaccepted": {
-        "subtitle": "Tente de novo com uma identificação com foto válida e garanta que os seus dados estão claramente visíveis",
-        "title": "Documento não aceite"
-    },
-    "retry_feedback_selfie_generic": {
-        "subtitle": "Tente de novo e certifique-se de que o seu rosto está visível e bem iluminado",
-        "title": "Houve um problema com a sua selfie"
+      "body_id_back": "Tire uma foto do verso do seu cartão",
+      "body_id_front": "Tire uma foto da parte frontal do seu cartão",
+      "body_license_back": "Tire uma foto do verso da sua carta",
+      "body_license_front": "Tire uma foto da parte frontal da sua carta",
+      "body_passport": "Tire uma foto da página com fotografia do passaporte",
+      "body_selfie": "Tire uma selfie que mostre o rosto"
     },
     "selfie_capture": {
-        "alert": {
-            "camera_inactive": {
-                "detail": "Verifique se está ligada e operacional. Também pode <fallback>continuar a verificação no seu telefone<\/fallback>",
-                "detail_no_fallback": "Certifique-se de que o seu dispositivo tem uma câmara operacional",
-                "title": "A câmara não está a funcionar?"
-            },
-            "camera_not_working": {
-                "detail": "Pode estar desligada. <fallback>Tente usar o telefone<\/fallback>.",
-                "detail_no_fallback": "Certifique-se de que a câmara do seu dispositivo está operacional",
-                "title": "A câmara não está a funcionar"
-            },
-            "timeout": {
-                "detail": "Lembre-se de carregar no botão quando tiver terminado. <fallback>Refazer ações de vídeo<\/fallback>",
-                "title": "Parece que demorou demasiado tempo"
-            }
+      "alert": {
+        "camera_inactive": {
+          "detail": "Tire uma foto usando antes o <fallback>modo de câmara básico</fallback>"
         },
-        "body": "Mantenha o seu rosto dentro da forma oval",
-        "button_accessibility": "Tirar uma fotografia",
-        "button_primary": "Iniciar digitalizar da cara",
-        "frame_accessibility": "Vista da câmara",
-        "title": "Mantenha o seu rosto dentro da forma oval"
-    },
-    "selfie_confirmation": {
-        "image_accessibility": "Foto do seu rosto",
-        "subtitle": "Certifique-se de que todo o seu rosto está visível",
-        "title": "Verifique a sua selfie"
-    },
-    "selfie_intro": {
-        "button_primary": "Continuar",
-        "list_accessibility": "Dicas para tirar uma boa selfie",
-        "list_item_face_forward": "Fique virado para a frente e assegure-se de que os seus olhos são claramente visíveis",
-        "list_item_no_glasses": "Retire os seus óculos, se necessário",
-        "subtitle": "Iremos efetuar uma comparação comparação o seu documento",
-        "title": "Tirar uma fotografia"
-    },
-    "sms_sent": {
-        "info": "Dicas",
-        "info_link_expire": "A sua ligação irá expirar dentro de uma hora",
-        "info_link_window": "Mantenha esta janela aberta ao utilizar o telemóvel",
-        "link": "Reenviar a ligação",
-        "subtitle": "Enviámos uma ligação segura para %{number}",
-        "subtitle_minutes": "Poderá demorar alguns minutos a chegar",
-        "title": "Verifique o seu telemóvel"
-    },
-    "switch_phone": {
-        "info": "Dicas",
-        "info_link_expire": "A sua ligação móvel irá expirar dentro de uma hora",
-        "info_link_refresh": "Não atualize esta página",
-        "info_link_window": "Mantenha esta janela aberta ao utilizar o telemóvel",
-        "link": "Cancelar",
-        "subtitle": "Quando terminar, iremos encaminhá-lo para o próximo passo",
-        "title": "Ligado ao seu telemóvel"
+        "camera_not_working": {
+          "detail": "Tire uma foto usando antes o <fallback>modo de câmara básico</fallback>"
+        }
+      }
     },
     "upload_guide": {
-        "button_primary": "Carregar foto",
-        "image_detail_blur_alt": "Exemplo de um documento desfocado",
-        "image_detail_blur_label": "Todos os detalhes devem estar nítidos — nada desfocado",
-        "image_detail_cutoff_label": "Mostrar todos os detalhes — incluindo as 2 linhas de baixo",
-        "image_detail_glare_label": "Afaste-se da luz direta — sem encandeamento",
-        "image_detail_good_label": "A fotografia deverá mostrar claramente o seu documento",
-        "subtitle": "Digitalizações e fotocópias não são aceites",
-        "title": "Carregue a página com fotografia do passaporte"
-    },
-    "user_consent": {
-        "button_primary": "Accept",
-        "button_secondary": "Do not accept",
-        "prompt": {
-            "button_primary": "Review again",
-            "button_secondary": "Yes, don’t verify me",
-            "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
-            "no_consent_title": "Are you sure?"
-        }
-    },
-    "user_consent_load_fail": {
-        "button_primary": "Reload screen",
-        "detail": "Check that your connection is stable, then try again",
-        "title": "Content failed to load"
-    },
-    "video_capture": {
-        "body": "Mantenha o seu rosto dentro da forma oval",
-        "body_record": "Pressione o botão quando estiver pronto",
-        "body_stop": "Carregue em \"stop\" quando terminar",
-        "button_primary_finish": "Acabar gravação",
-        "button_primary_next": "Próximo passo",
-        "button_primary_start": "Começar a gravar",
-        "button_record_accessibility": "Começar a gravar",
-        "frame_accessibility": "Vista da câmara",
-        "header": {
-            "challenge_digit_instructions": "Diga cada dígito em voz alta",
-            "challenge_turn_forward": "depois vire-o para a frente",
-            "challenge_turn_left": "Vire a sua cabeça para a esquerda",
-            "challenge_turn_right": "Vire a sua cabeça para a direita"
-        },
-        "prompt": {
-            "header_timeout": "Parece que demorou demasiado tempo"
-        }
-    },
-    "video_confirmation": {
-        "body": "O seu vídeo foi gravado",
-        "button_primary": "Carregar vídeo",
-        "button_secondary": "Retomar vídeo",
-        "title": "Verifique o seu vídeo",
-        "video_accessibility": "Reproduzir o seu vídeo gravado"
-    },
-    "video_intro": {
-        "button_primary": "Gravar vídeo",
-        "list_accessibility": "Ações para gravar um vídeo selfie",
-        "list_item_actions": "Tem 20 segundos para terminar",
-        "list_item_speak": "Siga as instruções para se mover ou falar",
-        "title": "Gravar um vídeo"
-    },
-    "welcome": {
-        "doc_video_subtitle": "Pode demorar alguns minutos",
-        "list_header_doc_video": "Utilize o seu dispositivo para gravar:",
-        "list_header_webcam": "Utilize a sua câmara ou telefone para fotografar:",
-        "list_item_doc": "o seu documento de identidade",
-        "list_item_doc_video_timeout": "A gravação está limitada a <timeout><\/timeout> segundos",
-        "list_item_poa": "o seu comprovativo de morada",
-        "list_item_selfie": "o seu rosto",
-        "next_button": "Escolha o documento",
-        "start_workflow_button": "Iniciar a verificação",
-        "subtitle": "Pode demorar alguns minutos",
-        "title": "Verifique a sua identidade"
-    },
-    "workflow_complete": {
-        "pass": {
-            "description": "",
-            "title": ""
-        },
-        "reject": {
-            "description": "",
-            "title": ""
-        }
-    },
-    "workflow_erros": {
-        "generic_title": "",
-        "no_workflow_run_id": "",
-        "reload_app": "",
-        "task_not_completed": "",
-        "task_not_retrieved": "",
-        "task_not_supported": ""
+      "button_primary": "Tirar uma fotografia",
+      "title": "Página com fotografia do passaporte"
     }
+  },
+  "outro": {
+    "body": "É tudo o que precisamos para começar a verificar a sua identidade",
+    "body_government_letter": "Forneça a página completa do documento para melhores resultados",
+    "title": "Obrigado"
+  },
+  "permission": {
+    "body_both": "Não podemos verificá-lo sem utilizar a sua câmara e microfone",
+    "body_cam": "Não o podemos verificar sem a sua câmara",
+    "button_primary_both": "Permitir ambos",
+    "button_primary_cam": "Ativar câmara",
+    "subtitle_both": "Quando solicitado, deve permitir o acesso de ambos para continuar",
+    "subtitle_cam": "Quando solicitado, deve permitir o acesso à câmara para continuar",
+    "title_both": "Permitir acesso ao microfone e câmara",
+    "title_cam": "Permitir o acesso à câmara"
+  },
+  "permission_recovery": {
+    "button_primary": "Atualizar",
+    "info": "Recuperação",
+    "list_header_both": "Siga estes passos para recuperar o acesso a ambos:",
+    "list_header_cam": "Siga estes passos para recuperar o acesso à câmara:",
+    "list_item_action_cam": "Atualize esta página para reiniciar o processo de verificação de identidade",
+    "list_item_how_to_both": "Conceda acesso à sua câmara e ao microfone a partir das definições do navegador",
+    "list_item_how_to_cam": "Conceda acesso à sua câmara a partir das definições do navegador",
+    "subtitle_both": "Recuperar o acesso à câmara e ao microfone para tirar um vídeo e completar o processo de verificação",
+    "subtitle_cam": "Recupere o acesso à câmara para continuar a sua verificação",
+    "subtitle_cam_old": "Recupere o acesso à câmara para continuar a verificação da face",
+    "title_both": "Acesso à câmara e ao microfone negado",
+    "title_cam": "O acesso à câmara é negado"
+  },
+  "photo_upload": {
+    "body_bank_statement": "Forneça a página completa do documento para melhores resultados",
+    "body_benefits_letter": "Forneça a página completa do documento para melhores resultados",
+    "body_bill": "Forneça a página completa do documento para melhores resultados",
+    "body_id_back": "Carregue o verso do cartão a partir do seu computador",
+    "body_id_front": "Carregue a frente do cartão a partir do seu computador",
+    "body_license_back": "Carregue o verso da carta a partir do seu computador",
+    "body_license_front": "Carregue a frente da carta a partir do seu computador",
+    "body_passport": "Carregue a página da foto do passaporte a partir do seu computador",
+    "body_selfie": "Carregue uma selfie a partir do seu computador",
+    "body_tax_letter": "Forneça a página completa do documento para melhores resultados",
+    "button_take_photo": "Tirar fotografia",
+    "button_upload": "Carregar",
+    "title_selfie": "Selfie"
+  },
+  "poa_cancel": "Cancelar",
+  "poa_err_invalid_file": {
+    "message": "Por favor escolha um ficheiro diferente.",
+    "ok": "OK",
+    "title": "Ficheiro inválido"
+  },
+  "poa_guidance": {
+    "button_primary": "Continuar",
+    "instructions": {
+      "address": "Morada atual",
+      "full_name": "Nome completo",
+      "issue_date": "Data de emissão ou período do resumo",
+      "label": "Capte o documento inteiro e garanta que este mostre claramente:",
+      "logo": "Logótipo"
+    },
+    "subtitle_bank_statement": "Deverá ter sido emitido nos <strong>últimos 3 meses</strong>",
+    "subtitle_benefits_letter": "Deverá ter sido emitido nos <strong>últimos 12 meses</strong>",
+    "subtitle_bill": "Deverá ter sido emitido nos <strong>últimos 3 meses</strong>",
+    "subtitle_tax_letter": "Deverá ter sido emitido nos <strong>últimos 12 meses</strong>"
+  },
+  "poa_intro": {
+    "button_primary": "Iniciar verificação",
+    "list_matches_signup": "<strong>Corresponde</strong> à morada que usou no seu registo",
+    "list_most_recent": "É o seu documento mais <strong>recente</strong>",
+    "list_shows_address": "Mostra a sua morada <strong>atual</strong>",
+    "subtitle": "Vai precisar de um documento que:",
+    "title": "Vamos verificar a sua morada"
+  },
+  "profile_data": {
+    "address_title": "Adicione a sua morada",
+    "button_continue": "Continuar",
+    "components": {
+      "country_select": {
+        "placeholder": "Selecione um país"
+      },
+      "nationality_select": {
+        "placeholder": "Selecione um país"
+      },
+      "pan": {
+        "placeholder": "ABCDE1234F"
+      },
+      "ssn": {
+        "placeholder": "123-45-6789"
+      },
+      "state_select": {
+        "placeholder": "Selecione um estado"
+      }
+    },
+    "country_of_residence_title": "Seu país de residência",
+    "field_labels": {
+      "country": "País",
+      "dob": "Data de nascimento",
+      "email": "Email",
+      "first_name": "Nome próprio",
+      "gbr_specific": {
+        "postcode": "Código postal",
+        "town": "Cidade"
+      },
+      "last_name": "Apelido",
+      "line1": "Linha da morada 1",
+      "line2": "Linha da morada 2",
+      "line3": "Linha da morada 3",
+      "mobile_number": "Número de telemóvel",
+      "nationality": "Nacionalidade",
+      "pan": "Número de conta permanente (PAN)",
+      "postcode": "Código postal",
+      "ssn": "Número de Segurança Social (NISS)",
+      "town": "Cidade",
+      "usa_specific": {
+        "line1_helper_text": "Morada, por exemplo: Rua Luís Silva 200",
+        "line2_helper_text": "Apartamento, suite, unidade, etc.",
+        "postcode": "Código postal",
+        "state": "Estado"
+      }
+    },
+    "field_optional": "(opcional)",
+    "field_validation": {
+      "gbr_specific": {
+        "required_postcode": "Introduza o seu código postal",
+        "too_long_postcode": "O código postal é demasiado longo",
+        "too_short_postcode": "O código postal é demasiado curto"
+      },
+      "invalid": "Verifique se existem caracteres ou símbolos inválidos",
+      "invalid_dob": "Introduza uma data de nascimento válida",
+      "required_country": "Selecione um país",
+      "required_dob": "Introduza a sua data de nascimento",
+      "required_email": "Introduza o seu e-mail",
+      "required_first_name": "",
+      "required_last_name": "Introduza o seu apelido",
+      "required_line1": "Introduza a sua morada",
+      "required_mobile_number": "Introduza o seu número de telemóvel",
+      "required_nationality": "Selecione um país",
+      "required_pan": "Introduza o seu PAN",
+      "required_postcode": "Introduza o seu código postal",
+      "required_ssn": "Introduza o seu NISS",
+      "too_long__line1": "A linha da morada é demasiado longa",
+      "too_long_first_name": "O nome próprio é demasiado longo",
+      "too_long_last_name": "O apelido é demasiado longo",
+      "too_long_postcode": "O código postal é demasiado longo",
+      "too_long_town": "",
+      "too_short_first_name": "O nome próprio é demasiado curto",
+      "too_short_last_name": "O apelido é demasiado curto",
+      "too_short_postcode": "O código postal é demasiado curto",
+      "usa_specific": {
+        "required_state": "Selecione um estado"
+      },
+      "valid_email": "Introduza um e-mail válido",
+      "valid_mobile_number": "Introduza um número de telemóvel válido",
+      "valid_pan": "Introduza um PAN válido",
+      "valid_ssn": "Introduza um NISS válido"
+    },
+    "personal_information_title": "Adicione as suas informações pessoais",
+    "prompt": {
+      "details_timeout": "Começar de novo",
+      "header_timeout": "Parece que demorou demasiado tempo"
+    }
+  },
+  "retry_feedback": {
+    "button_primary": "Tente novamente"
+  },
+  "retry_feedback_id_expired": {
+    "subtitle": "Tente de novo com uma identificação com foto válida e garanta que os seus dados estão claramente visíveis",
+    "title": "O seu documento está caducado"
+  },
+  "retry_feedback_id_generic": {
+    "subtitle": "Tente de novo com uma identificação com foto válida e garanta que os seus dados estão claramente visíveis",
+    "title": "Houve um problema com o seu documento"
+  },
+  "retry_feedback_id_unaccepted": {
+    "subtitle": "Tente de novo com uma identificação com foto válida e garanta que os seus dados estão claramente visíveis",
+    "title": "Documento não aceite"
+  },
+  "retry_feedback_selfie_generic": {
+    "subtitle": "Tente de novo e certifique-se de que o seu rosto está visível e bem iluminado",
+    "title": "Houve um problema com a sua selfie"
+  },
+  "selfie_capture": {
+    "alert": {
+      "camera_inactive": {
+        "detail": "Verifique se está ligada e operacional. Também pode <fallback>continuar a verificação no seu telefone</fallback>",
+        "detail_no_fallback": "Certifique-se de que o seu dispositivo tem uma câmara operacional",
+        "title": "A câmara não está a funcionar?"
+      },
+      "camera_not_working": {
+        "detail": "Pode estar desligada. <fallback>Tente usar o telefone</fallback>.",
+        "detail_no_fallback": "Certifique-se de que a câmara do seu dispositivo está operacional",
+        "title": "A câmara não está a funcionar"
+      },
+      "timeout": {
+        "detail": "Lembre-se de carregar no botão quando tiver terminado. <fallback>Refazer ações de vídeo</fallback>",
+        "title": "Parece que demorou demasiado tempo"
+      }
+    },
+    "body": "Mantenha o seu rosto dentro da forma oval",
+    "button_accessibility": "Tirar uma fotografia",
+    "button_primary": "Iniciar digitalizar da cara",
+    "frame_accessibility": "Vista da câmara",
+    "title": "Mantenha o seu rosto dentro da forma oval"
+  },
+  "selfie_confirmation": {
+    "image_accessibility": "Foto do seu rosto",
+    "subtitle": "Certifique-se de que todo o seu rosto está visível",
+    "title": "Verifique a sua selfie"
+  },
+  "selfie_intro": {
+    "button_primary": "Continuar",
+    "list_accessibility": "Dicas para tirar uma boa selfie",
+    "list_item_face_forward": "Fique virado para a frente e assegure-se de que os seus olhos são claramente visíveis",
+    "list_item_no_glasses": "Retire os seus óculos, se necessário",
+    "subtitle": "Iremos efetuar uma comparação comparação o seu documento",
+    "title": "Tirar uma fotografia"
+  },
+  "sms_sent": {
+    "info": "Dicas",
+    "info_link_expire": "A sua ligação irá expirar dentro de uma hora",
+    "info_link_window": "Mantenha esta janela aberta ao utilizar o telemóvel",
+    "link": "Reenviar a ligação",
+    "subtitle": "Enviámos uma ligação segura para %{number}",
+    "subtitle_minutes": "Poderá demorar alguns minutos a chegar",
+    "title": "Verifique o seu telemóvel"
+  },
+  "switch_phone": {
+    "info": "Dicas",
+    "info_link_expire": "A sua ligação móvel irá expirar dentro de uma hora",
+    "info_link_refresh": "Não atualize esta página",
+    "info_link_window": "Mantenha esta janela aberta ao utilizar o telemóvel",
+    "link": "Cancelar",
+    "subtitle": "Quando terminar, iremos encaminhá-lo para o próximo passo",
+    "title": "Ligado ao seu telemóvel"
+  },
+  "upload_guide": {
+    "button_primary": "Carregar foto",
+    "image_detail_blur_alt": "Exemplo de um documento desfocado",
+    "image_detail_blur_label": "Todos os detalhes devem estar nítidos — nada desfocado",
+    "image_detail_cutoff_label": "Mostrar todos os detalhes — incluindo as 2 linhas de baixo",
+    "image_detail_glare_label": "Afaste-se da luz direta — sem encandeamento",
+    "image_detail_good_label": "A fotografia deverá mostrar claramente o seu documento",
+    "subtitle": "Digitalizações e fotocópias não são aceites",
+    "title": "Carregue a página com fotografia do passaporte"
+  },
+  "user_consent": {
+    "button_primary": "Accept",
+    "button_secondary": "Do not accept",
+    "prompt": {
+      "button_primary": "Review again",
+      "button_secondary": "Yes, don’t verify me",
+      "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
+      "no_consent_title": "Are you sure?"
+    }
+  },
+  "user_consent_load_fail": {
+    "button_primary": "Reload screen",
+    "detail": "Check that your connection is stable, then try again",
+    "title": "Content failed to load"
+  },
+  "video_capture": {
+    "body": "Mantenha o seu rosto dentro da forma oval",
+    "body_record": "Pressione o botão quando estiver pronto",
+    "body_stop": "Carregue em \"stop\" quando terminar",
+    "button_primary_finish": "Acabar gravação",
+    "button_primary_next": "Próximo passo",
+    "button_primary_start": "Começar a gravar",
+    "button_record_accessibility": "Começar a gravar",
+    "frame_accessibility": "Vista da câmara",
+    "header": {
+      "challenge_digit_instructions": "Diga cada dígito em voz alta",
+      "challenge_turn_forward": "depois vire-o para a frente",
+      "challenge_turn_left": "Vire a sua cabeça para a esquerda",
+      "challenge_turn_right": "Vire a sua cabeça para a direita"
+    },
+    "prompt": {
+      "header_timeout": "Parece que demorou demasiado tempo"
+    }
+  },
+  "video_confirmation": {
+    "body": "O seu vídeo foi gravado",
+    "button_primary": "Carregar vídeo",
+    "button_secondary": "Retomar vídeo",
+    "title": "Verifique o seu vídeo",
+    "video_accessibility": "Reproduzir o seu vídeo gravado"
+  },
+  "video_intro": {
+    "button_primary": "Gravar vídeo",
+    "list_accessibility": "Ações para gravar um vídeo selfie",
+    "list_item_actions": "Tem 20 segundos para terminar",
+    "list_item_speak": "Siga as instruções para se mover ou falar",
+    "title": "Gravar um vídeo"
+  },
+  "welcome": {
+    "doc_video_subtitle": "Pode demorar alguns minutos",
+    "list_header_doc_video": "Utilize o seu dispositivo para gravar:",
+    "list_header_webcam": "Utilize a sua câmara ou telefone para fotografar:",
+    "list_item_doc": "o seu documento de identidade",
+    "list_item_doc_video_timeout": "A gravação está limitada a <timeout></timeout> segundos",
+    "list_item_poa": "o seu comprovativo de morada",
+    "list_item_selfie": "o seu rosto",
+    "next_button": "Escolha o documento",
+    "start_workflow_button": "Iniciar a verificação",
+    "subtitle": "Pode demorar alguns minutos",
+    "title": "Verifique a sua identidade"
+  },
+  "workflow_complete": {
+    "pass": {
+      "description": "",
+      "title": ""
+    },
+    "reject": {
+      "description": "",
+      "title": ""
+    }
+  },
+  "workflow_erros": {
+    "generic_title": "",
+    "no_workflow_run_id": "",
+    "reload_app": "",
+    "task_not_completed": "",
+    "task_not_retrieved": "",
+    "task_not_supported": ""
+  }
 }

--- a/src/locales/ro_RO/ro_RO.json
+++ b/src/locales/ro_RO/ro_RO.json
@@ -1,678 +1,678 @@
 {
-    "avc_confirmation": {
-        "button_primary_upload": "Încărcați înregistrarea",
-        "subtitle": "Un clip video cu fața dvs. a fost înregistrat cu succes",
-        "title": "Înregistrare finalizată"
+  "avc_confirmation": {
+    "button_primary_upload": "Încărcați înregistrarea",
+    "subtitle": "Un clip video cu fața dvs. a fost înregistrat cu succes",
+    "title": "Înregistrare finalizată"
+  },
+  "avc_connection_error": {
+    "button_primary_reload": "Reîncărcați instrucțiunile",
+    "button_primary_retry_upload": "Încercați din nou să încărcați",
+    "button_secondary_restart_recording": "Începeți din nou înregistrarea",
+    "subtitle": "Verificați stabilitatea conexiunii dvs. și apoi încercați din nou",
+    "title": "Eroare de conectare"
+  },
+  "avc_face_alignment": {
+    "feedback_move_back": "Mișcați-vă înapoi",
+    "feedback_move_closer": "Veniți mai aproape",
+    "feedback_no_face_detected": "Fața nu este detectată",
+    "feedback_not_centered": "Fața nu este centrată",
+    "title": "Poziționați-vă fața în cadru"
+  },
+  "avc_face_capture": {
+    "alert": {
+      "timeout_body": "Aveți maximum 15 de secunde la dispoziție să finalizați înregistrarea",
+      "timeout_button_primary": "Încercați din nou",
+      "timeout_title": "Ne cerem scuze, trebuie să reîncepem înregistrarea",
+      "too_fast_body": "Vă rugăm să încercați din nou și întoarceți capul mai încet",
+      "too_fast_button_primary": "Încercați din nou",
+      "too_fast_title": "Ați întors capul prea repede"
     },
-    "avc_connection_error": {
-        "button_primary_reload": "Reîncărcați instrucțiunile",
-        "button_primary_retry_upload": "Încercați din nou să încărcați",
-        "button_secondary_restart_recording": "Începeți din nou înregistrarea",
-        "subtitle": "Verificați stabilitatea conexiunii dvs. și apoi încercați din nou",
-        "title": "Eroare de conectare"
+    "title": "Întoarceți capul încet în ambele părți",
+    "title_completed": "Înregistrare finalizată"
+  },
+  "avc_intro": {
+    "button_primary_ready": "Sunt pregătit",
+    "disclaimer": "Vă rugăm să aveți în vedere că vă vom înregistra fața și fundalul dvs.",
+    "list_item_one": "Întâi, poziționați-vă fața în cadru",
+    "list_item_two": "Apoi, întoarceți capul încet în ambele părți",
+    "subtitle": "Acest lucru este pentru a verifica faptul că sunteți o persoană reală",
+    "title": "Înregistrați un clip video"
+  },
+  "avc_no_face_detected": {
+    "button_primary_restart": "Începeți din nou înregistrarea",
+    "list_item_eyes": "Asigurați-vă ochii sunt clar vizibili",
+    "list_item_face": "Asigurați-vă că vă arătați doar fața, nu trebuie să vedem documentul dvs. de identitate",
+    "list_item_lighting": "Asigurați-vă că sunteți într-un loc bine luminat",
+    "list_item_mask": "Asigurați-vă că înlăturați măștile sau alte articole care vă acoperă fața. Ochelarii sunt acceptați",
+    "title": "Nu vă putem detecta fața"
+  },
+  "avc_uploading": {
+    "title": "Se încarcă"
+  },
+  "country_select": {
+    "alert": {
+      "another_doc": "Documente din aceea țară nu sunt în prezent acoperite — <fallback>încercați cu un alt tip de document</fallback>"
     },
-    "avc_face_alignment": {
-        "feedback_move_back": "Mișcați-vă înapoi",
-        "feedback_move_closer": "Veniți mai aproape",
-        "feedback_no_face_detected": "Fața nu este detectată",
-        "feedback_not_centered": "Fața nu este centrată",
-        "title": "Poziționați-vă fața în cadru"
+    "alert_dropdown": {
+      "country_not_found": "Țara nu a fost găsită"
     },
-    "avc_face_capture": {
-        "alert": {
-            "timeout_body": "Aveți maximum 15 de secunde la dispoziție să finalizați înregistrarea",
-            "timeout_button_primary": "Încercați din nou",
-            "timeout_title": "Ne cerem scuze, trebuie să reîncepem înregistrarea",
-            "too_fast_body": "Vă rugăm să încercați din nou și întoarceți capul mai încet",
-            "too_fast_button_primary": "Încercați din nou",
-            "too_fast_title": "Ați întors capul prea repede"
-        },
-        "title": "Întoarceți capul încet în ambele părți",
-        "title_completed": "Înregistrare finalizată"
+    "button_primary": "Trimiteți documentul",
+    "poa_alert": {
+      "country_not_found": "Ne cerem scuze. Depunem eforturi pentru a acoperi mai multe țări.",
+      "intro": "Nu vă găsiți țara?"
     },
-    "avc_intro": {
-        "button_primary_ready": "Sunt pregătit",
-        "disclaimer": "Vă rugăm să aveți în vedere că vă vom înregistra fața și fundalul dvs.",
-        "list_item_one": "Întâi, poziționați-vă fața în cadru",
-        "list_item_two": "Apoi, întoarceți capul încet în ambele părți",
-        "subtitle": "Acest lucru este pentru a verifica faptul că sunteți o persoană reală",
-        "title": "Înregistrați un clip video"
+    "search": {
+      "accessibility": "Selectați țara",
+      "input_placeholder": "de exemplu, Statele Unite ale Americii",
+      "label": "Căutați țara"
     },
-    "avc_no_face_detected": {
-        "button_primary_restart": "Începeți din nou înregistrarea",
-        "list_item_eyes": "Asigurați-vă ochii sunt clar vizibili",
-        "list_item_face": "Asigurați-vă că vă arătați doar fața, nu trebuie să vedem documentul dvs. de identitate",
-        "list_item_lighting": "Asigurați-vă că sunteți într-un loc bine luminat",
-        "list_item_mask": "Asigurați-vă că înlăturați măștile sau alte articole care vă acoperă fața. Ochelarii sunt acceptați",
-        "title": "Nu vă putem detecta fața"
+    "title": "Selectați țara emitentă"
+  },
+  "cross_device_checklist": {
+    "button_primary": "Trimiteți verificarea",
+    "info": "Sugestii",
+    "list_item_doc_multiple": "Documente",
+    "list_item_doc_one": "Document",
+    "list_item_poa": "Dovadă adresă",
+    "list_item_selfie": "Selfie",
+    "list_item_video": "Clip video",
+    "subtitle": "Aici găsiți tot ce ați încărcat:",
+    "title": "Un ultim pas"
+  },
+  "cross_device_error_desktop": {
+    "subtitle": "Linkul funcționează doar pe dispozitive mobile",
+    "title": "Ceva nu a mers bine"
+  },
+  "cross_device_error_restart": {
+    "subtitle": "Trebuie să începeți din nou verificarea dvs. pe computerul dvs.",
+    "title": "Ceva nu a mers bine"
+  },
+  "cross_device_intro": {
+    "button_primary": "Obțineți linkul sigur",
+    "list_accessibility": "Pași necesari pentru a continua verificarea pe telefonul dvs. mobil",
+    "list_item_finish": "Reveniți aici pentru a finaliza trimiterea",
+    "list_item_open_link": "Deschideți linkul și finalizați sarcinile",
+    "list_item_send_phone": "Trimiteți un link sigur spre telefonul dvs.",
+    "subtitle": "Vedeți cum trebuie să procedați:",
+    "title": "Continuați pe telefonul dvs."
+  },
+  "cross_device_return": {
+    "body": "Computerul dvs. poate avea nevoie de câteva secunde să se actualizeze",
+    "subtitle": "Acum puteți reveni la computerul dvs. pentru a continua",
+    "title": "Încărcări cu succes"
+  },
+  "cross_device_session_linked": {
+    "button_primary": "Continuați",
+    "info": "Dublă verificare",
+    "list_item_desktop_open": "Fereastra dvs. desktop rămâne deschisă",
+    "list_item_sent_by_you": "Acest link a fost trimis de dvs. — solicitați sfaturi dacă credeți că poate fi vorba de înșelăciune",
+    "subtitle": "Continuați cu verificarea",
+    "title": "Sesiune telefon mobil conectat la computerul dvs."
+  },
+  "doc_capture": {
+    "button_primary": "Începeți scanarea documentului",
+    "detail": {
+      "folded_doc_front": "Poziționați documentul dvs. pe o suprafață plană, includeți toate paginile interne (trebuie să conțină poza dvs.)"
     },
-    "avc_uploading": {
-        "title": "Se încarcă"
+    "header_folded_doc_front": "Latură poză de profil",
+    "prompt": {
+      "button_card": "Card de plastic",
+      "button_paper": "Document hârtie",
+      "title_id": "Ce tip de card de identitate aveți?",
+      "title_license": "Ce tip de permis de conducere aveți?"
+    }
+  },
+  "doc_confirmation": {
+    "alert": {
+      "blur_detail": "Asigurați-vă că totul este clar",
+      "blur_title": "Poză încețoșată detectată",
+      "crop_detail": "Asigurați-vă că întregul document este vizibil",
+      "crop_title": "Imagine tăiată detectată",
+      "glare_detail": "Nu stați în lumină directă",
+      "glare_title": "Luciu detectat",
+      "no_doc_detail": "Asigurați-vă că este integral în cadru",
+      "no_doc_title": "Documentul nu a fost detectat"
     },
-    "country_select": {
-        "alert": {
-            "another_doc": "Documente din aceea țară nu sunt în prezent acoperite — <fallback>încercați cu un alt tip de document<\/fallback>"
-        },
-        "alert_dropdown": {
-            "country_not_found": "Țara nu a fost găsită"
-        },
-        "button_primary": "Trimiteți documentul",
-        "poa_alert": {
-            "country_not_found": "Ne cerem scuze. Depunem eforturi pentru a acoperi mai multe țări.",
-            "intro": "Nu vă găsiți țara?"
-        },
-        "search": {
-            "accessibility": "Selectați țara",
-            "input_placeholder": "de exemplu, Statele Unite ale Americii",
-            "label": "Căutați țara"
-        },
-        "title": "Selectați țara emitentă"
+    "body": "Asigurați-vă că ați încărcat întreaga pagină a documentului și că detaliile sunt clare pentru a fi citite fără estompări sau luciri",
+    "body_bank_statement": "Asigurați-vă că ați încărcat întreaga pagină a documentului și că detaliile sunt clare pentru a fi citite fără estompări sau luciri",
+    "body_benefits_letter": "Asigurați-vă că ați încărcat întreaga pagină a documentului și că detaliile sunt clare pentru a fi citite fără estompări sau luciri",
+    "body_bill": "Asigurați-vă că ați încărcat întreaga pagină a documentului și că detaliile sunt clare pentru a fi citite fără estompări sau luciri",
+    "body_id": "Asigurați-vă că detaliile dvs. sunt clare și neobstrucționate",
+    "body_image_medium": "Va dura mai mult să vă verificăm dacă nu putem citi elementul",
+    "body_image_poor": "Pentru a vă verifica mai ușor, avem nevoie de o poză mai bună",
+    "body_license": "Asigurați-vă că detaliile dvs. sunt clare și neobstrucționate",
+    "body_passport": "Asigurați-vă că detaliile dvs. sunt clare și neobstrucționate",
+    "body_permit": "Asigurați-vă că detaliile dvs. sunt clare și neobstrucționate",
+    "body_tax_letter": "Asigurați-vă că ați încărcat întreaga pagină a documentului și că detaliile sunt clare pentru a fi citite fără estompări sau luciri",
+    "button_close": "Închideți",
+    "button_primary_redo": "Refaceți",
+    "button_primary_upload": "Încărcați",
+    "button_primary_upload_anyway": "Încărcați oricum",
+    "button_secondary_redo": "Refaceți",
+    "button_zoom": "Măriți imaginea",
+    "image_accessibility": "Poză a documentului dvs.",
+    "title": "Verificați imaginea dvs."
+  },
+  "doc_multi_frame_capture": {
+    "capture_progress_title": "Se scanează documentul",
+    "instructions_title_back": "Poziționați pagina verso a documentului dvs. în cadru",
+    "instructions_title_front": "Poziționați pagina față a documentului dvs. în cadru"
+  },
+  "doc_select": {
+    "button_bank_statement": "Extras de la bancă sau societatea mutuală de credit",
+    "button_bank_statement_non_uk": "Extras de cont",
+    "button_benefits_letter": "Scrisoare beneficii",
+    "button_benefits_letter_detail": "Beneficii pentru gospodărie autorizate de guvern, de exemplu, indemnizație de șomer, beneficii gospodărie, credite fiscale",
+    "button_bill": "Factură de utilități",
+    "button_bill_detail": "Gaz, electricitate, apă, telefon fix sau internet de bandă largă",
+    "button_government_letter": "Scrisoare de la guvern",
+    "button_government_letter_detail": "Orice scrisoare emisă de guvern, de exemplu, scrisori privind dreptul la beneficii, scrisori de votare, scrisori privind impozitele etc.",
+    "button_id": "Card de identitate",
+    "button_id_detail": "Față și verso",
+    "button_license": "Permis de conducere",
+    "button_license_detail": "Față și verso",
+    "button_passport": "Pașaport",
+    "button_passport_detail": "Pagină poză",
+    "button_permit": "Permis de ședere",
+    "button_permit_detail": "Față și verso",
+    "button_tax_letter": "Scrisoare de la Consiliul impozite",
+    "extra_estatements_ok": "extrase electronice acceptate",
+    "extra_no_mobile": "Ne pare rău, fără facturi de telefon mobil",
+    "list_accessibility": "Documente pe care le puteți utiliza pentru a vă verifica identitatea",
+    "pill": "cel mai rapid",
+    "section": {
+      "header_country": "Țară emitentă",
+      "header_doc_type": "Documente acceptate",
+      "input_country_not_found": "Niciun rezultat",
+      "input_placeholder_country": "Selectați țara emitentă"
     },
-    "cross_device_checklist": {
-        "button_primary": "Trimiteți verificarea",
-        "info": "Sugestii",
-        "list_item_doc_multiple": "Documente",
-        "list_item_doc_one": "Document",
-        "list_item_poa": "Dovadă adresă",
-        "list_item_selfie": "Selfie",
-        "list_item_video": "Clip video",
-        "subtitle": "Aici găsiți tot ce ați încărcat:",
-        "title": "Un ultim pas"
+    "subtitle": "Trebuie să fie un document de identitate cu poză oficial",
+    "subtitle_country": "Selectați țara emitentă pentru a vedea ce documente acceptăm",
+    "subtitle_entire_page": "Întreaga pagină",
+    "subtitle_front_back": "Față și verso",
+    "subtitle_photo_page": "Pagină poză",
+    "subtitle_poa": "Acestea sunt documente care cel mai probabil indică adresa dvs. de reședință actuală",
+    "title": "Alegeți documentul dvs.",
+    "title_poa": "Selectați un %{country} document"
+  },
+  "doc_submit": {
+    "button_link_upload": "sau încărcați poză – fără scanări sau fotocopii",
+    "button_primary": "Continuați pe telefonul dvs.",
+    "subtitle": "Faceți o poză cu telefonul dvs.",
+    "title_bank_statement": "Trimiteți extras",
+    "title_benefits_letter": "Trimiteți scrisoare",
+    "title_bill": "Trimiteți factură",
+    "title_government_letter": "Scrisoare de la guvern",
+    "title_id_back": "Trimiteți cardul de identitate (verso)",
+    "title_id_front": "Trimiteți cardul de identitate (față)",
+    "title_license_back": "Trimiteți permisul de conducere (verso)",
+    "title_license_front": "Trimiteți permisul de conducere (față)",
+    "title_passport": "Trimiteți pagina cu poză a pașaportului",
+    "title_permit_back": "Trimiteți permisul de ședere (verso)",
+    "title_permit_front": "Trimiteți permisul de ședere (față)",
+    "title_tax_letter": "Trimiteți scrisoare"
+  },
+  "doc_video_capture": {
+    "button_primary_fallback": "Următorul pas",
+    "button_primary_fallback_end": "Finalizați înregistrarea",
+    "detail_step2": "Țineți documentul la vedere permanent",
+    "header": "În timp ce poziționați documentul dvs, țineți pagina față în cadru",
+    "header_paper_doc_step2": "Întoarceți ușor documentul dvs. pentru a arăta paginile externe",
+    "header_passport": "În timp ce poziționați pașaportul dvs., țineți pagina cu poză în cadru",
+    "header_passport_progress": "Țineți nemișcat",
+    "header_step1": "Acum țineți nemișcat",
+    "header_step2": "Întoarceți ușor documentul dvs. pentru a arăta partea verso",
+    "prompt": {
+      "detail_timeout": "Înregistrarea video este limitată la <timeout></timeout> secunde. <fallback>Începeți din nou</fallback>"
     },
-    "cross_device_error_desktop": {
-        "subtitle": "Linkul funcționează doar pe dispozitive mobile",
-        "title": "Ceva nu a mers bine"
+    "stepper": "Pasul <step></step> din <total></total>",
+    "success_accessibility": "Succes"
+  },
+  "doc_video_confirmation": {
+    "button_secondary": "Previzualizare clip video",
+    "title": "Verificați clipul dvs. video"
+  },
+  "error_unsupported_browser": {
+    "subtitle_android": "Începeți din nou acest proces pe ultima versiune de Google Chrome",
+    "subtitle_ios": "Începeți din nou acest proces pe ultima versiune de Safari",
+    "title_android": "Browser incompatibil",
+    "title_ios": "Browser incompatibil"
+  },
+  "generic": {
+    "accessibility": {
+      "close_sdk_screen": "Închideți ecranul de verificare a identității",
+      "dismiss_alert": "Respingeți alerta"
     },
-    "cross_device_error_restart": {
-        "subtitle": "Trebuie să începeți din nou verificarea dvs. pe computerul dvs.",
-        "title": "Ceva nu a mers bine"
+    "back": "înapoi",
+    "close": "închideți",
+    "errors": {
+      "expired_token": {
+        "instruction": "Vă rugăm să încercați din nou",
+        "message": "Tokenul a expirat"
+      },
+      "geoblocked_error": {
+        "instruction": "Ne pare rău, se pare că nu putem continua pentru că locația dvs. actuală nu este acoperită",
+        "message": "Serviciu indisponibil"
+      },
+      "interrupted_flow_error": {
+        "instruction": "Începeți din nou procesul pe un dispozitiv diferit",
+        "message": "Camera video nu este detectată"
+      },
+      "invalid_size": {
+        "instruction": "Trebuie să fie sub 10MB.",
+        "message": "Dimensiunea fișierului depășită."
+      },
+      "invalid_type": {
+        "instruction": "Încercați să utilizați un alt tip de fișier.",
+        "message": "Fișierul nu a fost încărcat."
+      },
+      "lazy_loading": {
+        "message": "O eroare a survenit în timp ce componenta era încărcată"
+      },
+      "multiple_faces": {
+        "instruction": "Numai fața dvs. poate fi în poza selfie",
+        "message": "Fețe multiple găsite"
+      },
+      "no_face": {
+        "instruction": "Asigurați-vă că fața dvs. este vizibilă",
+        "message": "Fața nu este detectată"
+      },
+      "request_error": {
+        "instruction": "Vă rugăm să încercați din nou",
+        "message": "Ceva nu a mers bine"
+      },
+      "sms_failed": {
+        "instruction": "Copiați linkul pe telefonul dvs.",
+        "message": "Ceva nu a mers bine"
+      },
+      "sms_overuse": {
+        "instruction": "Copiați linkul pe telefonul dvs.",
+        "message": "Prea multe încercări eșuate"
+      },
+      "unsupported_file": {
+        "instruction": "Încercați să utilizați un fișier JPG sau PNG",
+        "message": "Tipul de fișier nu este compatibil"
+      }
     },
-    "cross_device_intro": {
-        "button_primary": "Obțineți linkul sigur",
-        "list_accessibility": "Pași necesari pentru a continua verificarea pe telefonul dvs. mobil",
-        "list_item_finish": "Reveniți aici pentru a finaliza trimiterea",
-        "list_item_open_link": "Deschideți linkul și finalizați sarcinile",
-        "list_item_send_phone": "Trimiteți un link sigur spre telefonul dvs.",
-        "subtitle": "Vedeți cum trebuie să procedați:",
-        "title": "Continuați pe telefonul dvs."
-    },
-    "cross_device_return": {
-        "body": "Computerul dvs. poate avea nevoie de câteva secunde să se actualizeze",
-        "subtitle": "Acum puteți reveni la computerul dvs. pentru a continua",
-        "title": "Încărcări cu succes"
-    },
-    "cross_device_session_linked": {
-        "button_primary": "Continuați",
-        "info": "Dublă verificare",
-        "list_item_desktop_open": "Fereastra dvs. desktop rămâne deschisă",
-        "list_item_sent_by_you": "Acest link a fost trimis de dvs. — solicitați sfaturi dacă credeți că poate fi vorba de înșelăciune",
-        "subtitle": "Continuați cu verificarea",
-        "title": "Sesiune telefon mobil conectat la computerul dvs."
-    },
-    "doc_capture": {
-        "button_primary": "Începeți scanarea documentului",
-        "detail": {
-            "folded_doc_front": "Poziționați documentul dvs. pe o suprafață plană, includeți toate paginile interne (trebuie să conțină poza dvs.)"
-        },
-        "header_folded_doc_front": "Latură poză de profil",
-        "prompt": {
-            "button_card": "Card de plastic",
-            "button_paper": "Document hârtie",
-            "title_id": "Ce tip de card de identitate aveți?",
-            "title_license": "Ce tip de permis de conducere aveți?"
-        }
-    },
-    "doc_confirmation": {
-        "alert": {
-            "blur_detail": "Asigurați-vă că totul este clar",
-            "blur_title": "Poză încețoșată detectată",
-            "crop_detail": "Asigurați-vă că întregul document este vizibil",
-            "crop_title": "Imagine tăiată detectată",
-            "glare_detail": "Nu stați în lumină directă",
-            "glare_title": "Luciu detectat",
-            "no_doc_detail": "Asigurați-vă că este integral în cadru",
-            "no_doc_title": "Documentul nu a fost detectat"
-        },
-        "body": "Asigurați-vă că ați încărcat întreaga pagină a documentului și că detaliile sunt clare pentru a fi citite fără estompări sau luciri",
-        "body_bank_statement": "Asigurați-vă că ați încărcat întreaga pagină a documentului și că detaliile sunt clare pentru a fi citite fără estompări sau luciri",
-        "body_benefits_letter": "Asigurați-vă că ați încărcat întreaga pagină a documentului și că detaliile sunt clare pentru a fi citite fără estompări sau luciri",
-        "body_bill": "Asigurați-vă că ați încărcat întreaga pagină a documentului și că detaliile sunt clare pentru a fi citite fără estompări sau luciri",
-        "body_id": "Asigurați-vă că detaliile dvs. sunt clare și neobstrucționate",
-        "body_image_medium": "Va dura mai mult să vă verificăm dacă nu putem citi elementul",
-        "body_image_poor": "Pentru a vă verifica mai ușor, avem nevoie de o poză mai bună",
-        "body_license": "Asigurați-vă că detaliile dvs. sunt clare și neobstrucționate",
-        "body_passport": "Asigurați-vă că detaliile dvs. sunt clare și neobstrucționate",
-        "body_permit": "Asigurați-vă că detaliile dvs. sunt clare și neobstrucționate",
-        "body_tax_letter": "Asigurați-vă că ați încărcat întreaga pagină a documentului și că detaliile sunt clare pentru a fi citite fără estompări sau luciri",
-        "button_close": "Închideți",
-        "button_primary_redo": "Refaceți",
-        "button_primary_upload": "Încărcați",
-        "button_primary_upload_anyway": "Încărcați oricum",
-        "button_secondary_redo": "Refaceți",
-        "button_zoom": "Măriți imaginea",
-        "image_accessibility": "Poză a documentului dvs.",
-        "title": "Verificați imaginea dvs."
-    },
-    "doc_multi_frame_capture": {
-        "capture_progress_title": "Se scanează documentul",
-        "instructions_title_back": "Poziționați pagina verso a documentului dvs. în cadru",
-        "instructions_title_front": "Poziționați pagina față a documentului dvs. în cadru"
-    },
-    "doc_select": {
-        "button_bank_statement": "Extras de la bancă sau societatea mutuală de credit",
-        "button_bank_statement_non_uk": "Extras de cont",
-        "button_benefits_letter": "Scrisoare beneficii",
-        "button_benefits_letter_detail": "Beneficii pentru gospodărie autorizate de guvern, de exemplu, indemnizație de șomer, beneficii gospodărie, credite fiscale",
-        "button_bill": "Factură de utilități",
-        "button_bill_detail": "Gaz, electricitate, apă, telefon fix sau internet de bandă largă",
-        "button_government_letter": "Scrisoare de la guvern",
-        "button_government_letter_detail": "Orice scrisoare emisă de guvern, de exemplu, scrisori privind dreptul la beneficii, scrisori de votare, scrisori privind impozitele etc.",
-        "button_id": "Card de identitate",
-        "button_id_detail": "Față și verso",
-        "button_license": "Permis de conducere",
-        "button_license_detail": "Față și verso",
-        "button_passport": "Pașaport",
-        "button_passport_detail": "Pagină poză",
-        "button_permit": "Permis de ședere",
-        "button_permit_detail": "Față și verso",
-        "button_tax_letter": "Scrisoare de la Consiliul impozite",
-        "extra_estatements_ok": "extrase electronice acceptate",
-        "extra_no_mobile": "Ne pare rău, fără facturi de telefon mobil",
-        "list_accessibility": "Documente pe care le puteți utiliza pentru a vă verifica identitatea",
-        "pill": "cel mai rapid",
-        "section": {
-            "header_country": "Țară emitentă",
-            "header_doc_type": "Documente acceptate",
-            "input_country_not_found": "Niciun rezultat",
-            "input_placeholder_country": "Selectați țara emitentă"
-        },
-        "subtitle": "Trebuie să fie un document de identitate cu poză oficial",
-        "subtitle_country": "Selectați țara emitentă pentru a vedea ce documente acceptăm",
-        "subtitle_entire_page": "Întreaga pagină",
-        "subtitle_front_back": "Față și verso",
-        "subtitle_photo_page": "Pagină poză",
-        "subtitle_poa": "Acestea sunt documente care cel mai probabil indică adresa dvs. de reședință actuală",
-        "title": "Alegeți documentul dvs.",
-        "title_poa": "Selectați un %{country} document"
-    },
-    "doc_submit": {
-        "button_link_upload": "sau încărcați poză – fără scanări sau fotocopii",
-        "button_primary": "Continuați pe telefonul dvs.",
-        "subtitle": "Faceți o poză cu telefonul dvs.",
-        "title_bank_statement": "Trimiteți extras",
-        "title_benefits_letter": "Trimiteți scrisoare",
-        "title_bill": "Trimiteți factură",
-        "title_government_letter": "Scrisoare de la guvern",
-        "title_id_back": "Trimiteți cardul de identitate (verso)",
-        "title_id_front": "Trimiteți cardul de identitate (față)",
-        "title_license_back": "Trimiteți permisul de conducere (verso)",
-        "title_license_front": "Trimiteți permisul de conducere (față)",
-        "title_passport": "Trimiteți pagina cu poză a pașaportului",
-        "title_permit_back": "Trimiteți permisul de ședere (verso)",
-        "title_permit_front": "Trimiteți permisul de ședere (față)",
-        "title_tax_letter": "Trimiteți scrisoare"
-    },
-    "doc_video_capture": {
-        "button_primary_fallback": "Următorul pas",
-        "button_primary_fallback_end": "Finalizați înregistrarea",
-        "detail_step2": "Țineți documentul la vedere permanent",
-        "header": "În timp ce poziționați documentul dvs, țineți pagina față în cadru",
-        "header_paper_doc_step2": "Întoarceți ușor documentul dvs. pentru a arăta paginile externe",
-        "header_passport": "În timp ce poziționați pașaportul dvs., țineți pagina cu poză în cadru",
-        "header_passport_progress": "Țineți nemișcat",
-        "header_step1": "Acum țineți nemișcat",
-        "header_step2": "Întoarceți ușor documentul dvs. pentru a arăta partea verso",
-        "prompt": {
-            "detail_timeout": "Înregistrarea video este limitată la <timeout><\/timeout> secunde. <fallback>Începeți din nou<\/fallback>"
-        },
-        "stepper": "Pasul <step><\/step> din <total><\/total>",
-        "success_accessibility": "Succes"
-    },
-    "doc_video_confirmation": {
-        "button_secondary": "Previzualizare clip video",
-        "title": "Verificați clipul dvs. video"
-    },
-    "error_unsupported_browser": {
-        "subtitle_android": "Începeți din nou acest proces pe ultima versiune de Google Chrome",
-        "subtitle_ios": "Începeți din nou acest proces pe ultima versiune de Safari",
-        "title_android": "Browser incompatibil",
-        "title_ios": "Browser incompatibil"
-    },
-    "generic": {
-        "accessibility": {
-            "close_sdk_screen": "Închideți ecranul de verificare a identității",
-            "dismiss_alert": "Respingeți alerta"
-        },
-        "back": "înapoi",
-        "close": "închideți",
-        "errors": {
-            "expired_token": {
-                "instruction": "Vă rugăm să încercați din nou",
-                "message": "Tokenul a expirat"
-            },
-            "geoblocked_error": {
-                "instruction": "Ne pare rău, se pare că nu putem continua pentru că locația dvs. actuală nu este acoperită",
-                "message": "Serviciu indisponibil"
-            },
-            "interrupted_flow_error": {
-                "instruction": "Începeți din nou procesul pe un dispozitiv diferit",
-                "message": "Camera video nu este detectată"
-            },
-            "invalid_size": {
-                "instruction": "Trebuie să fie sub 10MB.",
-                "message": "Dimensiunea fișierului depășită."
-            },
-            "invalid_type": {
-                "instruction": "Încercați să utilizați un alt tip de fișier.",
-                "message": "Fișierul nu a fost încărcat."
-            },
-            "lazy_loading": {
-                "message": "O eroare a survenit în timp ce componenta era încărcată"
-            },
-            "multiple_faces": {
-                "instruction": "Numai fața dvs. poate fi în poza selfie",
-                "message": "Fețe multiple găsite"
-            },
-            "no_face": {
-                "instruction": "Asigurați-vă că fața dvs. este vizibilă",
-                "message": "Fața nu este detectată"
-            },
-            "request_error": {
-                "instruction": "Vă rugăm să încercați din nou",
-                "message": "Ceva nu a mers bine"
-            },
-            "sms_failed": {
-                "instruction": "Copiați linkul pe telefonul dvs.",
-                "message": "Ceva nu a mers bine"
-            },
-            "sms_overuse": {
-                "instruction": "Copiați linkul pe telefonul dvs.",
-                "message": "Prea multe încercări eșuate"
-            },
-            "unsupported_file": {
-                "instruction": "Încercați să utilizați un fișier JPG sau PNG",
-                "message": "Tipul de fișier nu este compatibil"
-            }
-        },
-        "lazy_load_placeholder": "Se încarcă...",
-        "loading": "Se încarcă"
-    },
-    "get_link": {
-        "alert_wrong_number": "Verificați dacă numărul dvs. este corect",
-        "button_copied": "Copiat",
-        "button_copy": "Copiați",
-        "button_submit": "Trimiteți linkul",
-        "info_qr_how": "Cum să scanați un cod QR",
-        "info_qr_how_list_item_camera": "Poziționați camera video a telefonului dvs. spre codul QR",
-        "info_qr_how_list_item_download": "Dacă nu funcționează, descărcați un scaner de cod QR din Google Play sau App Store",
-        "link_divider": "sau alegeți o metodă alternativă",
-        "link_qr": "Scanați codul QR",
-        "link_sms": "Primiți linkul prin SMS",
-        "link_url": "Copiați linkul",
-        "loader_sending": "Se trimite",
-        "number_field_input_placeholder": "Introduceți numărul de telefon mobil",
-        "number_field_label": "Introduceți numărul dvs. de telefon mobil:",
-        "subtitle_qr": "Scanați codul QR cu telefonul dvs.",
-        "subtitle_sms": "Trimiteți acest link unic pe telefonul dvs.",
-        "subtitle_url": "Trimiteți acest link unic pe telefonul dvs.",
-        "title": "Primiți linkul sigur pentru dvs.",
-        "url_field_label": "Copiați linkul în browserul telefonului dvs."
-    },
-    "livenessV2": {
-        "error_reload_instructions": "Reîncărcați instrucțiunile",
-        "intro_note_no1": "Întâi, poziționați-vă fața în cadru",
-        "intro_note_no2": "Apoi, întoarceți capul încet în ambele părți",
-        "intro_ready_button": "Vă rugăm să aveți în vedere că vă vom înregistra fața și fundalul dvs.",
-        "intro_subtitle": "Acest lucru este pentru a verifica faptul că sunteți o persoană reală",
-        "intro_warning": "Vă rugăm să aveți în vedere că vă vom înregistra fața și fundalul dvs.",
-        "success_main_button": "Trimiteți verificarea",
-        "success_title": "Este tot ce avem nevoie pentru a începe verificarea identității dvs."
-    },
-    "mobilePhrases": {
-        "photo_upload": {
-            "body_id_back": "Faceți o poză cu partea verso a cardului dvs.",
-            "body_id_front": "Faceți o poză cu partea față a cardului dvs.",
-            "body_license_back": "Faceți o poză cu pagina verso a permisului dvs. de conducere",
-            "body_license_front": "Faceți o poză cu pagina față a permisului dvs. de conducere",
-            "body_passport": "Faceți o poză cu pagina cu poză a pașaportului dvs.",
-            "body_selfie": "Faceți o poză selfie cu fața dvs."
-        },
-        "selfie_capture": {
-            "alert": {
-                "camera_inactive": {
-                    "detail": "Faceți o poză folosind în schimb <fallback>modul de bază al camerei video<\/fallback>"
-                },
-                "camera_not_working": {
-                    "detail": "Faceți o poză folosind în schimb <fallback>modul de bază al camerei video<\/fallback>"
-                }
-            }
-        },
-        "upload_guide": {
-            "button_primary": "Faceți o poză",
-            "title": "Încărcați pagina cu poză a pașaportului"
-        }
-    },
-    "outro": {
-        "body": "Este tot ce avem nevoie pentru a începe verificarea identității dvs.",
-        "body_government_letter": "Furnizați întreaga pagină a documentului pentru rezultate mai bune",
-        "title": "Vă mulțumim"
-    },
-    "permission": {
-        "body_both": "Nu vă putem verifica fără a utiliza atât camera video, cât și microfonul dvs.",
-        "body_cam": "Nu vă putem verifica fără camera dvs. video",
-        "button_primary_both": "Activați ambele",
-        "button_primary_cam": "Activați camera video",
-        "subtitle_both": "Când vi se solicită, trebuie să activați accesul la ambele pentru a continua",
-        "subtitle_cam": "Când vi se solicită, trebuie să activați accesul la camera video pentru a continua",
-        "title_both": "Permiteți accesul la camera video și microfon",
-        "title_cam": "Permiteți accesul la camera video"
-    },
-    "permission_recovery": {
-        "button_primary": "Reîmprospătați",
-        "info": "Recuperare",
-        "list_header_both": "Urmați acești pași pentru a recupera acces pentru ambele:",
-        "list_header_cam": "Urmați acești pași pentru a recupera accesul la camera video:",
-        "list_item_action_cam": "Reîmprospătați această pagină pentru a începe din nou procesul de verificare a identității",
-        "list_item_how_to_both": "Permiteți accesul la camera video și microfonul dvs. din setările dvs. de browser",
-        "list_item_how_to_cam": "Permiteți accesul la camera dvs. video din setările dvs. de browser",
-        "subtitle_both": "Recuperați accesul la camera video și microfon pentru a face un clip video și a finaliza procesul de verificare",
-        "subtitle_cam": "Recuperați accesul la camera video pentru a continua verificarea dvs.",
-        "subtitle_cam_old": "Recuperați accesul la camera video pentru a continua verificarea feței",
-        "title_both": "Accesul la camera video și microfon este refuzat",
-        "title_cam": "Accesul la camera video este refuzat"
-    },
+    "lazy_load_placeholder": "Se încarcă...",
+    "loading": "Se încarcă"
+  },
+  "get_link": {
+    "alert_wrong_number": "Verificați dacă numărul dvs. este corect",
+    "button_copied": "Copiat",
+    "button_copy": "Copiați",
+    "button_submit": "Trimiteți linkul",
+    "info_qr_how": "Cum să scanați un cod QR",
+    "info_qr_how_list_item_camera": "Poziționați camera video a telefonului dvs. spre codul QR",
+    "info_qr_how_list_item_download": "Dacă nu funcționează, descărcați un scaner de cod QR din Google Play sau App Store",
+    "link_divider": "sau alegeți o metodă alternativă",
+    "link_qr": "Scanați codul QR",
+    "link_sms": "Primiți linkul prin SMS",
+    "link_url": "Copiați linkul",
+    "loader_sending": "Se trimite",
+    "number_field_input_placeholder": "Introduceți numărul de telefon mobil",
+    "number_field_label": "Introduceți numărul dvs. de telefon mobil:",
+    "subtitle_qr": "Scanați codul QR cu telefonul dvs.",
+    "subtitle_sms": "Trimiteți acest link unic pe telefonul dvs.",
+    "subtitle_url": "Trimiteți acest link unic pe telefonul dvs.",
+    "title": "Primiți linkul sigur pentru dvs.",
+    "url_field_label": "Copiați linkul în browserul telefonului dvs."
+  },
+  "livenessV2": {
+    "error_reload_instructions": "Reîncărcați instrucțiunile",
+    "intro_note_no1": "Întâi, poziționați-vă fața în cadru",
+    "intro_note_no2": "Apoi, întoarceți capul încet în ambele părți",
+    "intro_ready_button": "Vă rugăm să aveți în vedere că vă vom înregistra fața și fundalul dvs.",
+    "intro_subtitle": "Acest lucru este pentru a verifica faptul că sunteți o persoană reală",
+    "intro_warning": "Vă rugăm să aveți în vedere că vă vom înregistra fața și fundalul dvs.",
+    "success_main_button": "Trimiteți verificarea",
+    "success_title": "Este tot ce avem nevoie pentru a începe verificarea identității dvs."
+  },
+  "mobilePhrases": {
     "photo_upload": {
-        "body_bank_statement": "Furnizați întreaga pagină a documentului pentru mai bune rezultate",
-        "body_benefits_letter": "Furnizați întreaga pagină a documentului pentru mai bune rezultate",
-        "body_bill": "Furnizați întreaga pagină a documentului pentru mai bune rezultate",
-        "body_id_back": "Încărcați pagina verso a cardului din computerul dvs.",
-        "body_id_front": "Încărcați pagina față a cardului din computerul dvs.",
-        "body_license_back": "Încărcați pagina verso a permisului de conducere din computerul dvs.",
-        "body_license_front": "Încărcați pagina față a permisului de conducere din computerul dvs.",
-        "body_passport": "Încărcați pagina cu poză a pașaportului din computerul dvs.",
-        "body_selfie": "Încărcați o poză selfie din computerul dvs.",
-        "body_tax_letter": "Furnizați întreaga pagină a documentului pentru mai bune rezultate",
-        "button_take_photo": "Faceți poză",
-        "button_upload": "Încărcați",
-        "title_selfie": "Poză selfie"
-    },
-    "poa_cancel": "Anulați",
-    "poa_err_invalid_file": {
-        "message": "Vă rugăm să alegeți un fișier diferit.",
-        "ok": "OK",
-        "title": "Fișier nevalid"
-    },
-    "poa_guidance": {
-        "button_primary": "Continuați",
-        "instructions": {
-            "address": "Adresa actuală",
-            "full_name": "Numele complet",
-            "issue_date": "Data emiterii sau perioadă centralizatoare",
-            "label": "Capturați întregul document și asigurați-vă că arată în mod clar:",
-            "logo": "Logo"
-        },
-        "subtitle_bank_statement": "Trebuie să fie emis în <strong>ultimele 3 luni<\/strong>",
-        "subtitle_benefits_letter": "Trebuie să fie emis în <strong>ultimele 12 luni<\/strong>",
-        "subtitle_bill": "Trebuie să fi fost emis în <strong>ultimele 3 luni<\/strong>",
-        "subtitle_tax_letter": "Trebuie să fie emis în <strong>ultimele 12 luni<\/strong>"
-    },
-    "poa_intro": {
-        "button_primary": "Începeți verificarea",
-        "list_matches_signup": "<strong>Se potrivește<\/strong> cu adresa pe care ați utilizat-o pentru a vă înregistra",
-        "list_most_recent": "Este documentul dvs. <strong>recent<\/strong>",
-        "list_shows_address": "Arată adresa dvs. <strong>actuală<\/strong>",
-        "subtitle": "Aveți nevoie de un document care:",
-        "title": "Haideți să vă verificăm adresa"
-    },
-    "profile_data": {
-        "address_title": "Adăugați adresa dvs.",
-        "button_continue": "Continuați",
-        "components": {
-            "country_select": {
-                "placeholder": "Selectați o țară"
-            },
-            "nationality_select": {
-                "placeholder": "Selectați o țară"
-            },
-            "pan": {
-                "placeholder": "ABCDE1234F"
-            },
-            "ssn": {
-                "placeholder": "123-45-6789"
-            },
-            "state_select": {
-                "placeholder": "Selectați un stat"
-            }
-        },
-        "country_of_residence_title": "Țara dvs. de reședință",
-        "field_labels": {
-            "country": "Țară",
-            "dob": "Data nașterii",
-            "email": "E-mail",
-            "first_name": "Prenume",
-            "gbr_specific": {
-                "postcode": "Cod poștal",
-                "town": "Oraș\/Localitate"
-            },
-            "last_name": "Nume de familie",
-            "line1": "Linie adresă 1",
-            "line2": "Linie adresă 2",
-            "line3": "Linie adresă 3",
-            "mobile_number": "Telefonul mobil",
-            "nationality": "Naționalitatea",
-            "pan": "Număr de cont permanent (PAN)",
-            "postcode": "Cod poștal",
-            "ssn": "Numărul de asigurare socială (SSN)",
-            "town": "Localitate",
-            "usa_specific": {
-                "line1_helper_text": "Adresă stradă, de exemplu: 200 Albert Street",
-                "line2_helper_text": "Apartament, birou, bloc etc.",
-                "postcode": "Cod poștal",
-                "state": "Stat"
-            }
-        },
-        "field_optional": "(opțional)",
-        "field_validation": {
-            "gbr_specific": {
-                "required_postcode": "Vă rugăm să introduceți codul dvs. poștal",
-                "too_long_postcode": "Codul poștal este prea lung",
-                "too_short_postcode": "Codul poștal este prea scurt"
-            },
-            "invalid": "Vă rugăm să verificați să nu fie caractere sau simboluri nevalide",
-            "invalid_dob": "Vă rugăm să introduceți o dată de naștere validă",
-            "required_country": "Vă rugăm să selectați o țară",
-            "required_dob": "Vă rugăm să introduceți data dvs. de naștere",
-            "required_email": "Vă rugăm să introduceți e-mailul dvs.",
-            "required_first_name": "Vă rugăm să introduceți prenumele dvs.",
-            "required_last_name": "Vă rugăm să introduceți numele dvs. de familie",
-            "required_line1": "Vă rugăm să introduceți adresa dvs.",
-            "required_mobile_number": "Vă rugăm să verificați dacă numărul dvs. este corect",
-            "required_nationality": "Vă rugăm să selectați o țară",
-            "required_pan": "Vă rugăm să introduceți numărul PAN",
-            "required_postcode": "Vă rugăm să introduceți codul dvs. poștal",
-            "required_ssn": "Vă rugăm să introduceți numărul SSN",
-            "too_long__line1": "Linia adresă este prea lungă",
-            "too_long_first_name": "Prenumele este prea lung",
-            "too_long_last_name": "Numele de familie este prea lung",
-            "too_long_postcode": "Codul poștal este prea lung",
-            "too_long_town": "Numele orașului este prea lung",
-            "too_short_first_name": "Prenumele este prea scurt",
-            "too_short_last_name": "Numele de familie este prea scurt",
-            "too_short_postcode": "Codul poștal este prea scurt",
-            "usa_specific": {
-                "required_state": "Vă rugăm să selectați un stat"
-            },
-            "valid_email": "Vă rugăm să introduceți un e-mail valabil",
-            "valid_mobile_number": "Vă rugăm să introduceți un număr de telefon valid",
-            "valid_pan": "Vă rugăm să introduceți un PAN valabil",
-            "valid_ssn": "Vă rugăm să introduceți un SSN valabil"
-        },
-        "personal_information_title": "Adăugați informațiile dvs. personale",
-        "prompt": {
-            "details_timeout": "Începeți din nou",
-            "header_timeout": "Se pare că acțiunea dvs. a durat prea mult"
-        }
-    },
-    "retry_feedback": {
-        "button_primary": "Încercați din nou"
-    },
-    "retry_feedback_id_expired": {
-        "subtitle": "Vă rugăm să încercați din nou cu un document de identitate cu poză valabil și asigurați-vă că informațiile dvs. sunt clar vizibile",
-        "title": "Documentul dvs. a expirat"
-    },
-    "retry_feedback_id_generic": {
-        "subtitle": "Vă rugăm să încercați din nou cu un document de identitate cu poză valabil și asigurați-vă că informațiile dvs. sunt clar vizibile",
-        "title": "A survenit o problemă cu documentul dvs."
-    },
-    "retry_feedback_id_unaccepted": {
-        "subtitle": "Vă rugăm să încercați din nou cu un document de identitate cu poză valabil și asigurați-vă că informațiile dvs. sunt clar vizibile",
-        "title": "Document neacceptat"
-    },
-    "retry_feedback_selfie_generic": {
-        "subtitle": "Vă rugăm să încercați din nou și asigurați-vă că fața dvs. este vizibilă și bine luminată",
-        "title": "A survenit o problemă cu poza dvs. selfie"
+      "body_id_back": "Faceți o poză cu partea verso a cardului dvs.",
+      "body_id_front": "Faceți o poză cu partea față a cardului dvs.",
+      "body_license_back": "Faceți o poză cu pagina verso a permisului dvs. de conducere",
+      "body_license_front": "Faceți o poză cu pagina față a permisului dvs. de conducere",
+      "body_passport": "Faceți o poză cu pagina cu poză a pașaportului dvs.",
+      "body_selfie": "Faceți o poză selfie cu fața dvs."
     },
     "selfie_capture": {
-        "alert": {
-            "camera_inactive": {
-                "detail": "Verificați dacă este conectată și funcțională. Puteți, de asemenea, <fallback>continua verificarea pe telefonul dvs.<\/fallback>",
-                "detail_no_fallback": "Asigurați-vă că dispozitivul dvs. are o cameră video funcțională",
-                "title": "Camera video nu funcționează?"
-            },
-            "camera_not_working": {
-                "detail": "Poate fi deconectată. <fallback>Încercați să vă folosiți telefonul în schimb<\/fallback>.",
-                "detail_no_fallback": "Asigurați-vă că funcția cameră video a dispozitivului dvs. funcționează",
-                "title": "Camera video nu funcționează"
-            },
-            "timeout": {
-                "detail": "Nu uitați să apăsați butonul când terminați. <fallback>Refaceți acțiunile video<\/fallback>",
-                "title": "Se pare că acțiunea dvs. a durat prea mult"
-            }
+      "alert": {
+        "camera_inactive": {
+          "detail": "Faceți o poză folosind în schimb <fallback>modul de bază al camerei video</fallback>"
         },
-        "body": "Mențineți fața în oval",
-        "button_accessibility": "",
-        "button_primary": "Începeți scanarea feței",
-        "frame_accessibility": "Vizualizați din camera video",
-        "title": "Mențineți fața în oval"
-    },
-    "selfie_confirmation": {
-        "image_accessibility": "Poza feței dvs.",
-        "subtitle": "Asigurați-vă că întreaga față este vizibilă",
-        "title": "Verificați poza dvs. selfie"
-    },
-    "selfie_intro": {
-        "button_primary": "Continuați",
-        "list_accessibility": "Sugestii pentru a face o poză selfie bună",
-        "list_item_face_forward": "Uitați-vă înainte și asigurați-vă că ochii dvs. sunt clar vizibili",
-        "list_item_no_glasses": "Dați-vă jos ochelarii dacă este necesar",
-        "subtitle": "Vom compara această imagine cu documentul dvs.",
-        "title": "Faceți o poză selfie"
-    },
-    "sms_sent": {
-        "info": "Sugestii",
-        "info_link_expire": "Linkul dvs. va expira într-o oră",
-        "info_link_window": "Mențineți această fereastră deschisă în timp ce vă utilizați telefonul mobil",
-        "link": "Trimiteți din nou linkul",
-        "subtitle": "Am trimis un link sigur la %{number}",
-        "subtitle_minutes": "Ar putea să dureze câteva minute să îl primiți",
-        "title": "Verificați telefonul dvs. mobil"
-    },
-    "switch_phone": {
-        "info": "Sugestii",
-        "info_link_expire": "Linkul dvs. pentru telefonul mobil va expira într-o oră",
-        "info_link_refresh": "Nu reîmprospătați această pagină",
-        "info_link_window": "Mențineți această fereastră deschisă în timp ce vă utilizați telefonul mobil",
-        "link": "Anulați",
-        "subtitle": "Odată ce ați terminat, vom trece la următorul pas",
-        "title": "Conectat la telefonul dvs. mobil"
+        "camera_not_working": {
+          "detail": "Faceți o poză folosind în schimb <fallback>modul de bază al camerei video</fallback>"
+        }
+      }
     },
     "upload_guide": {
-        "button_primary": "Încărcați poza",
-        "image_detail_blur_alt": "Exemplu de document încețoșat",
-        "image_detail_blur_label": "Toate detaliile trebuie să fie clare — nimic cețos",
-        "image_detail_cutoff_label": "Arătați toate detaliile — includeți cele 2 linii de jos",
-        "image_detail_glare_label": "Nu stați în lumină directă — fără luciri",
-        "image_detail_good_label": "Poza trebuie să arate clar documentul dvs.",
-        "subtitle": "Scanările și fotocopiile nu sunt acceptate",
-        "title": "Încărcați pagina cu poză a pașaportului"
-    },
-    "user_consent": {
-        "button_primary": "Accept",
-        "button_secondary": "Do not accept",
-        "prompt": {
-            "button_primary": "Review again",
-            "button_secondary": "Yes, don’t verify me",
-            "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
-            "no_consent_title": "Are you sure?"
-        }
-    },
-    "user_consent_load_fail": {
-        "button_primary": "Reload screen",
-        "detail": "Check that your connection is stable, then try again",
-        "title": "Content failed to load"
-    },
-    "video_capture": {
-        "body": "Mențineți fața în oval",
-        "body_record": "Apăsați butonul când sunteți gata",
-        "body_stop": "Apăsați stop când ați terminat",
-        "button_primary_finish": "Finalizați înregistrarea",
-        "button_primary_next": "Următorul pas",
-        "button_primary_start": "Începeți înregistrarea",
-        "button_record_accessibility": "Începeți înregistrarea",
-        "frame_accessibility": "Vizualizați din camera video",
-        "header": {
-            "challenge_digit_instructions": "Spuneți fiecare cifră cu voce tare",
-            "challenge_turn_forward": "apoi să vă uitați înainte",
-            "challenge_turn_left": "Întoarceți capul spre stânga",
-            "challenge_turn_right": "Întoarceți capul spre dreapta"
-        },
-        "prompt": {
-            "header_timeout": "Se pare că acțiunea dvs. a durat prea mult"
-        }
-    },
-    "video_confirmation": {
-        "body": "Clipul dvs. video a fost înregistrat",
-        "button_primary": "Înregistrați un clip video",
-        "button_secondary": "Faceți clipul video din nou",
-        "title": "Verificați clipul dvs. video",
-        "video_accessibility": "Redați din nou clipul dvs. înregistrat"
-    },
-    "video_intro": {
-        "button_primary": "Înregistrați un clip video",
-        "list_accessibility": "Acțiuni pentru a verifica un clip video selfie",
-        "list_item_actions": "Aveți 20 de secunde să finalizați",
-        "list_item_speak": "Urmați instrucțiunile pentru a vă mișca sau a vorbi",
-        "title": "Înregistrați un clip video"
-    },
-    "welcome": {
-        "doc_video_subtitle": "",
-        "list_header_doc_video": "Utilizați dispozitivul dvs. pentru înregistra:",
-        "list_header_webcam": "Utilizați camera dvs. web sau telefonul dvs. pentru a face o poză:",
-        "list_item_doc": "documentul dvs. de identitate",
-        "list_item_doc_video_timeout": "Înregistrarea este limitată la <timeout><\/timeout> secunde",
-        "list_item_poa": "dovada dvs. de adresă",
-        "list_item_selfie": "fața dvs.",
-        "next_button": "Alegeți documentul",
-        "start_workflow_button": "Începeți verificarea",
-        "subtitle": "Ar trebui să dureze câteva minute",
-        "title": "Verificați identitatea dvs."
-    },
-    "workflow_complete": {
-        "pass": {
-            "description": "Am reușit să vă verificăm identitatea",
-            "title": "Reușit"
-        },
-        "reject": {
-            "description": "Nu am reușit să vă verificăm identitatea",
-            "title": "Respins"
-        }
-    },
-    "workflow_erros": {
-        "generic_title": "A survenit o eroare de server!",
-        "no_workflow_run_id": "ID-ul de executare flux de lucru nu este setat.",
-        "reload_app": "Vă rugăm să încercați să reîncărcați aplicația și încercați din nou.",
-        "task_not_completed": "Imposibilitate de a finaliza sarcina de flux de lucru.",
-        "task_not_retrieved": "Imposibilitate de a relua sarcina de flux de lucru.",
-        "task_not_supported": "Sarcina nu este în mod prezent acoperită"
+      "button_primary": "Faceți o poză",
+      "title": "Încărcați pagina cu poză a pașaportului"
     }
+  },
+  "outro": {
+    "body": "Este tot ce avem nevoie pentru a începe verificarea identității dvs.",
+    "body_government_letter": "Furnizați întreaga pagină a documentului pentru rezultate mai bune",
+    "title": "Vă mulțumim"
+  },
+  "permission": {
+    "body_both": "Nu vă putem verifica fără a utiliza atât camera video, cât și microfonul dvs.",
+    "body_cam": "Nu vă putem verifica fără camera dvs. video",
+    "button_primary_both": "Activați ambele",
+    "button_primary_cam": "Activați camera video",
+    "subtitle_both": "Când vi se solicită, trebuie să activați accesul la ambele pentru a continua",
+    "subtitle_cam": "Când vi se solicită, trebuie să activați accesul la camera video pentru a continua",
+    "title_both": "Permiteți accesul la camera video și microfon",
+    "title_cam": "Permiteți accesul la camera video"
+  },
+  "permission_recovery": {
+    "button_primary": "Reîmprospătați",
+    "info": "Recuperare",
+    "list_header_both": "Urmați acești pași pentru a recupera acces pentru ambele:",
+    "list_header_cam": "Urmați acești pași pentru a recupera accesul la camera video:",
+    "list_item_action_cam": "Reîmprospătați această pagină pentru a începe din nou procesul de verificare a identității",
+    "list_item_how_to_both": "Permiteți accesul la camera video și microfonul dvs. din setările dvs. de browser",
+    "list_item_how_to_cam": "Permiteți accesul la camera dvs. video din setările dvs. de browser",
+    "subtitle_both": "Recuperați accesul la camera video și microfon pentru a face un clip video și a finaliza procesul de verificare",
+    "subtitle_cam": "Recuperați accesul la camera video pentru a continua verificarea dvs.",
+    "subtitle_cam_old": "Recuperați accesul la camera video pentru a continua verificarea feței",
+    "title_both": "Accesul la camera video și microfon este refuzat",
+    "title_cam": "Accesul la camera video este refuzat"
+  },
+  "photo_upload": {
+    "body_bank_statement": "Furnizați întreaga pagină a documentului pentru mai bune rezultate",
+    "body_benefits_letter": "Furnizați întreaga pagină a documentului pentru mai bune rezultate",
+    "body_bill": "Furnizați întreaga pagină a documentului pentru mai bune rezultate",
+    "body_id_back": "Încărcați pagina verso a cardului din computerul dvs.",
+    "body_id_front": "Încărcați pagina față a cardului din computerul dvs.",
+    "body_license_back": "Încărcați pagina verso a permisului de conducere din computerul dvs.",
+    "body_license_front": "Încărcați pagina față a permisului de conducere din computerul dvs.",
+    "body_passport": "Încărcați pagina cu poză a pașaportului din computerul dvs.",
+    "body_selfie": "Încărcați o poză selfie din computerul dvs.",
+    "body_tax_letter": "Furnizați întreaga pagină a documentului pentru mai bune rezultate",
+    "button_take_photo": "Faceți poză",
+    "button_upload": "Încărcați",
+    "title_selfie": "Poză selfie"
+  },
+  "poa_cancel": "Anulați",
+  "poa_err_invalid_file": {
+    "message": "Vă rugăm să alegeți un fișier diferit.",
+    "ok": "OK",
+    "title": "Fișier nevalid"
+  },
+  "poa_guidance": {
+    "button_primary": "Continuați",
+    "instructions": {
+      "address": "Adresa actuală",
+      "full_name": "Numele complet",
+      "issue_date": "Data emiterii sau perioadă centralizatoare",
+      "label": "Capturați întregul document și asigurați-vă că arată în mod clar:",
+      "logo": "Logo"
+    },
+    "subtitle_bank_statement": "Trebuie să fie emis în <strong>ultimele 3 luni</strong>",
+    "subtitle_benefits_letter": "Trebuie să fie emis în <strong>ultimele 12 luni</strong>",
+    "subtitle_bill": "Trebuie să fi fost emis în <strong>ultimele 3 luni</strong>",
+    "subtitle_tax_letter": "Trebuie să fie emis în <strong>ultimele 12 luni</strong>"
+  },
+  "poa_intro": {
+    "button_primary": "Începeți verificarea",
+    "list_matches_signup": "<strong>Se potrivește</strong> cu adresa pe care ați utilizat-o pentru a vă înregistra",
+    "list_most_recent": "Este documentul dvs. <strong>recent</strong>",
+    "list_shows_address": "Arată adresa dvs. <strong>actuală</strong>",
+    "subtitle": "Aveți nevoie de un document care:",
+    "title": "Haideți să vă verificăm adresa"
+  },
+  "profile_data": {
+    "address_title": "Adăugați adresa dvs.",
+    "button_continue": "Continuați",
+    "components": {
+      "country_select": {
+        "placeholder": "Selectați o țară"
+      },
+      "nationality_select": {
+        "placeholder": "Selectați o țară"
+      },
+      "pan": {
+        "placeholder": "ABCDE1234F"
+      },
+      "ssn": {
+        "placeholder": "123-45-6789"
+      },
+      "state_select": {
+        "placeholder": "Selectați un stat"
+      }
+    },
+    "country_of_residence_title": "Țara dvs. de reședință",
+    "field_labels": {
+      "country": "Țară",
+      "dob": "Data nașterii",
+      "email": "E-mail",
+      "first_name": "Prenume",
+      "gbr_specific": {
+        "postcode": "Cod poștal",
+        "town": "Oraș/Localitate"
+      },
+      "last_name": "Nume de familie",
+      "line1": "Linie adresă 1",
+      "line2": "Linie adresă 2",
+      "line3": "Linie adresă 3",
+      "mobile_number": "Telefonul mobil",
+      "nationality": "Naționalitatea",
+      "pan": "Număr de cont permanent (PAN)",
+      "postcode": "Cod poștal",
+      "ssn": "Numărul de asigurare socială (SSN)",
+      "town": "Localitate",
+      "usa_specific": {
+        "line1_helper_text": "Adresă stradă, de exemplu: 200 Albert Street",
+        "line2_helper_text": "Apartament, birou, bloc etc.",
+        "postcode": "Cod poștal",
+        "state": "Stat"
+      }
+    },
+    "field_optional": "(opțional)",
+    "field_validation": {
+      "gbr_specific": {
+        "required_postcode": "Vă rugăm să introduceți codul dvs. poștal",
+        "too_long_postcode": "Codul poștal este prea lung",
+        "too_short_postcode": "Codul poștal este prea scurt"
+      },
+      "invalid": "Vă rugăm să verificați să nu fie caractere sau simboluri nevalide",
+      "invalid_dob": "Vă rugăm să introduceți o dată de naștere validă",
+      "required_country": "Vă rugăm să selectați o țară",
+      "required_dob": "Vă rugăm să introduceți data dvs. de naștere",
+      "required_email": "Vă rugăm să introduceți e-mailul dvs.",
+      "required_first_name": "Vă rugăm să introduceți prenumele dvs.",
+      "required_last_name": "Vă rugăm să introduceți numele dvs. de familie",
+      "required_line1": "Vă rugăm să introduceți adresa dvs.",
+      "required_mobile_number": "Vă rugăm să verificați dacă numărul dvs. este corect",
+      "required_nationality": "Vă rugăm să selectați o țară",
+      "required_pan": "Vă rugăm să introduceți numărul PAN",
+      "required_postcode": "Vă rugăm să introduceți codul dvs. poștal",
+      "required_ssn": "Vă rugăm să introduceți numărul SSN",
+      "too_long__line1": "Linia adresă este prea lungă",
+      "too_long_first_name": "Prenumele este prea lung",
+      "too_long_last_name": "Numele de familie este prea lung",
+      "too_long_postcode": "Codul poștal este prea lung",
+      "too_long_town": "Numele orașului este prea lung",
+      "too_short_first_name": "Prenumele este prea scurt",
+      "too_short_last_name": "Numele de familie este prea scurt",
+      "too_short_postcode": "Codul poștal este prea scurt",
+      "usa_specific": {
+        "required_state": "Vă rugăm să selectați un stat"
+      },
+      "valid_email": "Vă rugăm să introduceți un e-mail valabil",
+      "valid_mobile_number": "Vă rugăm să introduceți un număr de telefon valid",
+      "valid_pan": "Vă rugăm să introduceți un PAN valabil",
+      "valid_ssn": "Vă rugăm să introduceți un SSN valabil"
+    },
+    "personal_information_title": "Adăugați informațiile dvs. personale",
+    "prompt": {
+      "details_timeout": "Începeți din nou",
+      "header_timeout": "Se pare că acțiunea dvs. a durat prea mult"
+    }
+  },
+  "retry_feedback": {
+    "button_primary": "Încercați din nou"
+  },
+  "retry_feedback_id_expired": {
+    "subtitle": "Vă rugăm să încercați din nou cu un document de identitate cu poză valabil și asigurați-vă că informațiile dvs. sunt clar vizibile",
+    "title": "Documentul dvs. a expirat"
+  },
+  "retry_feedback_id_generic": {
+    "subtitle": "Vă rugăm să încercați din nou cu un document de identitate cu poză valabil și asigurați-vă că informațiile dvs. sunt clar vizibile",
+    "title": "A survenit o problemă cu documentul dvs."
+  },
+  "retry_feedback_id_unaccepted": {
+    "subtitle": "Vă rugăm să încercați din nou cu un document de identitate cu poză valabil și asigurați-vă că informațiile dvs. sunt clar vizibile",
+    "title": "Document neacceptat"
+  },
+  "retry_feedback_selfie_generic": {
+    "subtitle": "Vă rugăm să încercați din nou și asigurați-vă că fața dvs. este vizibilă și bine luminată",
+    "title": "A survenit o problemă cu poza dvs. selfie"
+  },
+  "selfie_capture": {
+    "alert": {
+      "camera_inactive": {
+        "detail": "Verificați dacă este conectată și funcțională. Puteți, de asemenea, <fallback>continua verificarea pe telefonul dvs.</fallback>",
+        "detail_no_fallback": "Asigurați-vă că dispozitivul dvs. are o cameră video funcțională",
+        "title": "Camera video nu funcționează?"
+      },
+      "camera_not_working": {
+        "detail": "Poate fi deconectată. <fallback>Încercați să vă folosiți telefonul în schimb</fallback>.",
+        "detail_no_fallback": "Asigurați-vă că funcția cameră video a dispozitivului dvs. funcționează",
+        "title": "Camera video nu funcționează"
+      },
+      "timeout": {
+        "detail": "Nu uitați să apăsați butonul când terminați. <fallback>Refaceți acțiunile video</fallback>",
+        "title": "Se pare că acțiunea dvs. a durat prea mult"
+      }
+    },
+    "body": "Mențineți fața în oval",
+    "button_accessibility": "",
+    "button_primary": "Începeți scanarea feței",
+    "frame_accessibility": "Vizualizați din camera video",
+    "title": "Mențineți fața în oval"
+  },
+  "selfie_confirmation": {
+    "image_accessibility": "Poza feței dvs.",
+    "subtitle": "Asigurați-vă că întreaga față este vizibilă",
+    "title": "Verificați poza dvs. selfie"
+  },
+  "selfie_intro": {
+    "button_primary": "Continuați",
+    "list_accessibility": "Sugestii pentru a face o poză selfie bună",
+    "list_item_face_forward": "Uitați-vă înainte și asigurați-vă că ochii dvs. sunt clar vizibili",
+    "list_item_no_glasses": "Dați-vă jos ochelarii dacă este necesar",
+    "subtitle": "Vom compara această imagine cu documentul dvs.",
+    "title": "Faceți o poză selfie"
+  },
+  "sms_sent": {
+    "info": "Sugestii",
+    "info_link_expire": "Linkul dvs. va expira într-o oră",
+    "info_link_window": "Mențineți această fereastră deschisă în timp ce vă utilizați telefonul mobil",
+    "link": "Trimiteți din nou linkul",
+    "subtitle": "Am trimis un link sigur la %{number}",
+    "subtitle_minutes": "Ar putea să dureze câteva minute să îl primiți",
+    "title": "Verificați telefonul dvs. mobil"
+  },
+  "switch_phone": {
+    "info": "Sugestii",
+    "info_link_expire": "Linkul dvs. pentru telefonul mobil va expira într-o oră",
+    "info_link_refresh": "Nu reîmprospătați această pagină",
+    "info_link_window": "Mențineți această fereastră deschisă în timp ce vă utilizați telefonul mobil",
+    "link": "Anulați",
+    "subtitle": "Odată ce ați terminat, vom trece la următorul pas",
+    "title": "Conectat la telefonul dvs. mobil"
+  },
+  "upload_guide": {
+    "button_primary": "Încărcați poza",
+    "image_detail_blur_alt": "Exemplu de document încețoșat",
+    "image_detail_blur_label": "Toate detaliile trebuie să fie clare — nimic cețos",
+    "image_detail_cutoff_label": "Arătați toate detaliile — includeți cele 2 linii de jos",
+    "image_detail_glare_label": "Nu stați în lumină directă — fără luciri",
+    "image_detail_good_label": "Poza trebuie să arate clar documentul dvs.",
+    "subtitle": "Scanările și fotocopiile nu sunt acceptate",
+    "title": "Încărcați pagina cu poză a pașaportului"
+  },
+  "user_consent": {
+    "button_primary": "Accept",
+    "button_secondary": "Do not accept",
+    "prompt": {
+      "button_primary": "Review again",
+      "button_secondary": "Yes, don’t verify me",
+      "no_consent_detail": "If you do not accept Onfido’s privacy statements and terms of service, we will not be able to verify your identity and you will exit this step.",
+      "no_consent_title": "Are you sure?"
+    }
+  },
+  "user_consent_load_fail": {
+    "button_primary": "Reload screen",
+    "detail": "Check that your connection is stable, then try again",
+    "title": "Content failed to load"
+  },
+  "video_capture": {
+    "body": "Mențineți fața în oval",
+    "body_record": "Apăsați butonul când sunteți gata",
+    "body_stop": "Apăsați stop când ați terminat",
+    "button_primary_finish": "Finalizați înregistrarea",
+    "button_primary_next": "Următorul pas",
+    "button_primary_start": "Începeți înregistrarea",
+    "button_record_accessibility": "Începeți înregistrarea",
+    "frame_accessibility": "Vizualizați din camera video",
+    "header": {
+      "challenge_digit_instructions": "Spuneți fiecare cifră cu voce tare",
+      "challenge_turn_forward": "apoi să vă uitați înainte",
+      "challenge_turn_left": "Întoarceți capul spre stânga",
+      "challenge_turn_right": "Întoarceți capul spre dreapta"
+    },
+    "prompt": {
+      "header_timeout": "Se pare că acțiunea dvs. a durat prea mult"
+    }
+  },
+  "video_confirmation": {
+    "body": "Clipul dvs. video a fost înregistrat",
+    "button_primary": "Înregistrați un clip video",
+    "button_secondary": "Faceți clipul video din nou",
+    "title": "Verificați clipul dvs. video",
+    "video_accessibility": "Redați din nou clipul dvs. înregistrat"
+  },
+  "video_intro": {
+    "button_primary": "Înregistrați un clip video",
+    "list_accessibility": "Acțiuni pentru a verifica un clip video selfie",
+    "list_item_actions": "Aveți 20 de secunde să finalizați",
+    "list_item_speak": "Urmați instrucțiunile pentru a vă mișca sau a vorbi",
+    "title": "Înregistrați un clip video"
+  },
+  "welcome": {
+    "doc_video_subtitle": "",
+    "list_header_doc_video": "Utilizați dispozitivul dvs. pentru înregistra:",
+    "list_header_webcam": "Utilizați camera dvs. web sau telefonul dvs. pentru a face o poză:",
+    "list_item_doc": "documentul dvs. de identitate",
+    "list_item_doc_video_timeout": "Înregistrarea este limitată la <timeout></timeout> secunde",
+    "list_item_poa": "dovada dvs. de adresă",
+    "list_item_selfie": "fața dvs.",
+    "next_button": "Alegeți documentul",
+    "start_workflow_button": "Începeți verificarea",
+    "subtitle": "Ar trebui să dureze câteva minute",
+    "title": "Verificați identitatea dvs."
+  },
+  "workflow_complete": {
+    "pass": {
+      "description": "Am reușit să vă verificăm identitatea",
+      "title": "Reușit"
+    },
+    "reject": {
+      "description": "Nu am reușit să vă verificăm identitatea",
+      "title": "Respins"
+    }
+  },
+  "workflow_erros": {
+    "generic_title": "A survenit o eroare de server!",
+    "no_workflow_run_id": "ID-ul de executare flux de lucru nu este setat.",
+    "reload_app": "Vă rugăm să încercați să reîncărcați aplicația și încercați din nou.",
+    "task_not_completed": "Imposibilitate de a finaliza sarcina de flux de lucru.",
+    "task_not_retrieved": "Imposibilitate de a relua sarcina de flux de lucru.",
+    "task_not_supported": "Sarcina nu este în mod prezent acoperită"
+  }
 }


### PR DESCRIPTION
# Problem
- When we check in new translations we have those diffs making translation reviews difficult
# Solution
- Remove them from prettierignore
## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
