### PR TITLE
Upload latest release to AWS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,10 @@ jobs:
         run: |
           aws s3 cp ./dist s3://${{ env.AWS_S3_BUCKET }}/web-sdk-releases/$RELEASE_VERSION/ --exclude "*.html" --recursive --acl public-read
 
+      - name: Upload Release as latest to S3
+        run: |
+          aws s3 cp ./dist s3://${{ env.AWS_S3_BUCKET }}/web-sdk-releases/latest/ --exclude "*.html" --recursive --acl public-read
+
       - name: Publish to NPM
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
# Problem
- The CDN url (https://assets.onfido.com/web-sdk-releases/latest/onfido.min.js) doesn't have the latest release. 
- It's not updated in our Release CI automatically

# Solution
- [x] Let the release CI update it automatically for full releases (skipping RC, beta, alpa, test releases)
- [x] (manually) Update AWS with the latest release

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [x] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
