### PR TITLE
Update UI_CUSTOMIZATION.md

### DIFF
--- a/UI_CUSTOMIZATION.md
+++ b/UI_CUSTOMIZATION.md
@@ -132,7 +132,7 @@ The Web SDK supports customization options across the SDK screen including text,
 
   | Links                       | Description                               |
   | --------------------------- | ----------------------------------------- |
-  | `colorContentLinkTextHover` | Change Link text color                    |
+  | `colorContentLinkTextHover` | Change Link text color on hover           |
   | `colorBorderLinkUnderline`  | Change Link underline color               |
   | `colorBackgroundLinkHover`  | Change Link background color on hover     |
   | `colorBackgroundLinkActive` | Change Link background color on click/tap |


### PR DESCRIPTION
`colorContentLinkTextHover` changes the link text color on hover

# Problem

Currently states that `colorContentLinkTextHover` changes the link text color. It changes the link text color on hover.

# Solution

Tiny change to state that `colorContentLinkTextHover` changes link text color on hover.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [ ] Has the CHANGELOG been updated?
- [ ] Has the README been updated?
- [ ] Has the CONTRIBUTING doc been updated?
- [ ] Has the RELEASE_GUIDELINES been updated?
- [ ] Has the TESTING_GUIDELINES been updated?
- [ ] Has the MIGRATION doc been updated for any MAJOR breaking changes?
- [ ] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes?
- [ ] Have any new automated tests been implemented or the existing ones changed?
- [ ] Have any new manual tests been written down or the existing ones changed?
- [ ] Have any new strings been translated or the existing ones changed?
