### PR TITLE
Update Polish translations for ID card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Fixed
 
-- Polish translations for ID card
+- Polish translations for ID card (https://github.com/onfido/onfido-sdk-ui/pull/2179)
 
 ## [13.0.0] - 2023-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to the Node [default version scheme](https://docs.npmjs.com
 
 ### Changed
 
+### Fixed
+
+- Polish translations for ID card
+
 ## [13.0.0] - 2023-07-11
 
 ### Changed

--- a/locales/pl_PL/pl_PL.json
+++ b/locales/pl_PL/pl_PL.json
@@ -380,7 +380,7 @@
   "mobilePhrases": {
     "photo_upload": {
       "body_id_back": "Zrób zdjęcie tylnej strony dowodu osobistego",
-      "body_id_front": "Zrób zdjęcie przedniej strony karty",
+      "body_id_front": "Zrób zdjęcie przedniej strony dowodu osobistego",
       "body_license_back": "Zrób zdjęcie odwrotnej strony prawa jazdy",
       "body_license_front": "Zrób zdjęcie przedniej strony prawa jazdy",
       "body_passport": "Zrób zdjęcie strony ze zdjęciem paszportowym",
@@ -442,8 +442,8 @@
     "body_bill": "Podaj całą stronę dokumentu, aby uzyskać najlepsze wyniki",
     "body_generic_document_back": "Prześlij zdjęcie rewersu dokumentu ze swojego komputera",
     "body_generic_document_front": "Prześlij zdjęcie przedniej strony dokumentu ze swojego komputera",
-    "body_id_back": "Prześlij zdjęcie tylnej strony karty ze swojego komputera",
-    "body_id_front": "Prześlij zdjęcie przodu karty ze swojego komputera",
+    "body_id_back": "Prześlij zdjęcie tylnej strony dowodu osobistego ze swojego komputera",
+    "body_id_front": "Prześlij zdjęcie przedniej strony dowodu osobistego ze swojego komputera",
     "body_license_back": "Prześlij tylną stronę dokumentu ze swojego komputera",
     "body_license_front": "Prześlij przednią stronę dokumentu ze swojego komputera",
     "body_passport": "Prześlij stronę paszportu ze zdjęciem ze swojego komputera",


### PR DESCRIPTION
# Problem
Polish translations for ID card are incorrect in some places, ie. `ID card` is translated into `karta` which is a `card` indeed but in Polish, in this context, it is mostly understood as, eg. a credit card and not an ID card. In this context, `dowodu osobistego` suits better than `karty`.

# Solution
Update Polish translations and use `dowodu osobistego` instead of `karty`.

## Checklist

_put `n/a` if item is not relevant to PR changes_

- [X] Has the CHANGELOG been updated? yes
- [x] Has the README been updated? n/a
- [x] Has the CONTRIBUTING doc been updated? n/a
- [x] Has the RELEASE_GUIDELINES been updated? n/a
- [x] Has the TESTING_GUIDELINES been updated? n/a
- [x] Has the MIGRATION doc been updated for any MAJOR breaking changes? n/a
- [x] Has the MIGRATION doc been updated for any MINOR breaking changes, including any translation strings or keys changes? n/a
- [x] Have any new automated tests been implemented or the existing ones changed? n/a
- [x] Have any new manual tests been written down or the existing ones changed? n/a
- [x] Have any new strings been translated or the existing ones changed? yes
